### PR TITLE
[16] Fix invalid path to Liquibase configuration file

### DIFF
--- a/backend/sirius-web-sample-application/src/main/resources/application.properties
+++ b/backend/sirius-web-sample-application/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialec
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
-spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
+spring.liquibase.change-log=classpath:db/changelog/sirius-web.db.changelog.xml
 
 spring.servlet.multipart.max-file-size=256MB
 spring.servlet.multipart.max-request-size=256MB


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/16
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>