### PR TITLE
[359] Add border node elements to the sample Robot model

### DIFF
--- a/backend/sirius-web-sample-application/src/main/resources/robot.flow
+++ b/backend/sirius-web-sample-application/src/main/resources/robot.flow
@@ -6,6 +6,8 @@
     </elements>
     <elements xsi:type="flow:Processor" xmi:id="_74kR0LTZEeeolunnT_MYFg" usage="high" incomingFlows="_74jDsLTZEeeolunnT_MYFg _74lf87TZEeeolunnT_MYFg _74muErTZEeeolunnT_MYFg" capacity="15" load="18" consumption="150" name="Motion_Engine" volume="18"/>
     <elements xsi:type="flow:Fan" xmi:id="_74k44LTZEeeolunnT_MYFg" consumption="10"/>
+    <powerOutputs xmi:id="_VtwQEHwHEeu51MfXx1etfQ"/>
+    <powerInputs xmi:id="_VtwQEXwHEeu51MfXx1etfQ"/>
   </elements>
   <elements xsi:type="flow:CompositeProcessor" xmi:id="_74lf8bTZEeeolunnT_MYFg" consumption="300" usage="standard" name="CaptureSubSystem" temperature="28" weight="33" routingRules=" Case  CaptureSubSystem.temperature > 70 °C:&#xA; /!\ critical  /!\;&#xA; &#xA;">
     <elements xsi:type="flow:Processor" xmi:id="_74lf8rTZEeeolunnT_MYFg" usage="standard" incomingFlows="_74mHA7TZEeeolunnT_MYFg" load="8" consumption="100" name="Radar_Capture" volume="8">
@@ -23,8 +25,12 @@
       <outgoingFlows xmi:id="_74muErTZEeeolunnT_MYFg" usage="standard" load="6" target="_74kR0LTZEeeolunnT_MYFg"/>
     </elements>
     <elements xsi:type="flow:Fan" xmi:id="_74muE7TZEeeolunnT_MYFg" speed="20"/>
+    <powerOutputs xmi:id="_cdQ1AHwHEeu51MfXx1etfQ">
+      <links xmi:id="_czHJMHwHEeu51MfXx1etfQ" target="_VtwQEXwHEeu51MfXx1etfQ"/>
+    </powerOutputs>
   </elements>
   <elements xsi:type="flow:DataSource" xmi:id="_74muFbTZEeeolunnT_MYFg" usage="standard" name="Wifi" volume="4">
     <outgoingFlows xmi:id="_74muFrTZEeeolunnT_MYFg" usage="standard" capacity="4" load="4" target="_74icoLTZEeeolunnT_MYFg"/>
   </elements>
 </flow:System>
+


### PR DESCRIPTION
Border node support has been broken/forgotten in the work on manual
layout in large part because our main sample model does not display
any.

Bug: eclipse-sirius/sirius-components#359
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>