### PR TITLE
Remove uses of "useBranding"

### DIFF
--- a/backend/sirius-web-frontend/pom.xml
+++ b/backend/sirius-web-frontend/pom.xml
@@ -28,7 +28,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.2.21</sirius.components.version>
+		<sirius.components.version>0.2.22</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-sample-application/pom.xml
+++ b/backend/sirius-web-sample-application/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.2.21</sirius.components.version>
+		<sirius.components.version>0.2.22</sirius.components.version>
 		<flow.version>1.0.5-SNAPSHOT</flow.version>
 		<bpmn.version>4.0.3-SNAPSHOT</bpmn.version>
 	</properties>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1903,9 +1903,9 @@
       "dev": true
     },
     "@eclipse-sirius/sirius-components": {
-      "version": "0.2.21",
-      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.2.21/32f54794b81c53a95a488b322310948cba495a2283975fd4043a9f6295230c6e",
-      "integrity": "sha512-K1k9n+yxy64qZ1bSQ7eVpBFoIl83r3UQArS5tTfMwv9GcxIUmDPKmMFZKIRh/hEi6PBP7xRFQlPiUrTOVymhBw==",
+      "version": "0.2.22",
+      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.2.22/acf91e041ac1c23da42f7967410f3e7546d97e1cb42dc2ba6b7c462c65483b6e",
+      "integrity": "sha512-39FrTF/YdMamQlBs8+Vx9yps9zswsqu2KT2YOWwFRQZGTyu3VbxAo4Esa2BtoTQv/K0Q+BoI83Tb2yB5kqE/cQ==",
       "requires": {
         "uuid": "8.3.2"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "3.2.7",
-    "@eclipse-sirius/sirius-components": "0.2.21",
+    "@eclipse-sirius/sirius-components": "0.2.22",
     "@material-ui/core": "4.11.2",
     "@material-ui/icons": "4.11.2",
     "@xstate/react": "1.1.0",

--- a/frontend/src/footer/Footer.tsx
+++ b/frontend/src/footer/Footer.tsx
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { Link, makeStyles, Typography } from '@material-ui/core';
+import React from 'react';
+
+const useFooterStyles = makeStyles(theme => ({
+  footer: {
+    display: 'flex',
+    justifyContent: 'center',
+    margin: theme.spacing(2),
+    '& > *': {
+      marginLeft: theme.spacing(0.5),
+      marginRight: theme.spacing(0.5)
+    }
+  }
+}));
+
+export const Footer = () => {
+  const classes = useFooterStyles();
+  return (
+    <footer className={classes.footer}>
+      <Typography variant="caption">&copy; {new Date().getFullYear()} Obeo. Powered by </Typography>
+      <Link variant="caption" href="https://www.eclipse.org/sirius" rel="noopener noreferrer" target="_blank">
+        Sirius Web
+      </Link>
+    </footer>
+  );
+};

--- a/frontend/src/help/help.tsx
+++ b/frontend/src/help/help.tsx
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { Link } from '@material-ui/core';
+import HelpIcon from '@material-ui/icons/Help';
+import React from 'react';
+
+export const Help = () => {
+  return (
+    <Link href="https://www.eclipse.org/sirius" rel="noopener noreferrer" target="_blank" color="inherit">
+      <HelpIcon />
+    </Link>
+  );
+};

--- a/frontend/src/navigationBar/NavigationBar.tsx
+++ b/frontend/src/navigationBar/NavigationBar.tsx
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { Link } from '@material-ui/core';
+import AppBar from '@material-ui/core/AppBar';
+import { makeStyles } from '@material-ui/core/styles';
+import Toolbar from '@material-ui/core/Toolbar';
+import Tooltip from '@material-ui/core/Tooltip';
+import { SiriusIcon } from '@eclipse-sirius/sirius-components';
+import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import { Help } from 'help/help';
+
+const useNavigationbarStyles = makeStyles(theme => ({
+  toolbar: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  left: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  link: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  right: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end'
+  }
+}));
+
+export const NavigationBar = () => {
+  const classes = useNavigationbarStyles();
+  return (
+    <AppBar position="static">
+      <Toolbar className={classes.toolbar}>
+        <div className={classes.left}>
+          <Tooltip title="Back to the homepage">
+            <Link component={RouterLink} to="/" className={classes.link} color="inherit">
+              <SiriusIcon fontSize="large" />
+            </Link>
+          </Tooltip>
+        </div>
+        <div className={classes.right}>
+          <Help />
+        </div>
+      </Toolbar>
+    </AppBar>
+  );
+};

--- a/frontend/src/views/edit-project/EditProjectNavbar/EditProjectNavbar.tsx
+++ b/frontend/src/views/edit-project/EditProjectNavbar/EditProjectNavbar.tsx
@@ -11,20 +11,17 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import {
-  IconButton,
-  More,
   DeleteProjectModal,
   NewDocumentModal,
   RenameProjectModal,
   UploadDocumentModal,
-  Logo,
-  Title
+  SiriusIcon,
+  ServerContext
 } from '@eclipse-sirius/sirius-components';
-import React, { useReducer } from 'react';
+import React, { useContext, useReducer } from 'react';
+import { Link } from '@material-ui/core';
 import { Redirect } from 'react-router-dom';
-import { EditProjectNavbarContextMenu } from 'views/edit-project/EditProjectNavbar/EditProjectNavbarContextMenu';
 import { EditProjectNavbarProps } from 'views/edit-project/EditProjectNavbar/EditProjectNavbar.types';
-import styles from './EditProjectNavbar.module.css';
 import {
   CONTEXTUAL_MENU_DISPLAYED__STATE,
   EMPTY__STATE,
@@ -37,51 +34,74 @@ import {
 } from './machine';
 import { initialState, reducer } from './reducer';
 import { Help } from 'help/help';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  AppBar,
+  makeStyles,
+  Toolbar,
+  Tooltip,
+  Typography,
+  IconButton,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText
+} from '@material-ui/core';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import AddIcon from '@material-ui/icons/Add';
+import DeleteIcon from '@material-ui/icons/Delete';
+import EditIcon from '@material-ui/icons/Edit';
+import GetAppIcon from '@material-ui/icons/GetApp';
+import PublishIcon from '@material-ui/icons/Publish';
 
-/**
- * Determines where the context menu should open relative to the actual mouse position.
- */
-const menuPositionDelta = {
-  dx: -4,
-  dy: 44
-};
+const useEditProjectViewNavbarStyles = makeStyles(theme => ({
+  toolbar: {
+    display: 'grid',
+    gridTemplateRows: '1fr',
+    gridTemplateColumns: '1fr max-content 1fr'
+  },
+  left: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  link: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  center: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  title: {
+    marginRight: theme.spacing(2)
+  },
+  right: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end'
+  }
+}));
 
-export const EditProjectNavbar = ({ projectId, name }: EditProjectNavbarProps) => {
+export const EditProjectNavbar = ({ project }: EditProjectNavbarProps) => {
+  const classes = useEditProjectViewNavbarStyles();
+  const { httpOrigin } = useContext(ServerContext);
   const [state, dispatch] = useReducer(reducer, initialState);
-  const onMore = (event: React.SyntheticEvent<HTMLButtonElement>) => {
+
+  const onMoreClick = (event: React.MouseEvent<HTMLElement>) => {
     if (state.viewState === EMPTY__STATE) {
-      const { x, y } = event.currentTarget.getBoundingClientRect();
       const action = {
         type: HANDLE_SHOW_CONTEXT_MENU__ACTION,
-        x: x + menuPositionDelta.dx,
-        y: y + menuPositionDelta.dy
+        projectMenuAnchor: event.currentTarget
       };
       dispatch(action);
     }
   };
 
-  const { viewState, to, modalDisplayed, x, y } = state;
-
-  let contextMenu = null;
-  if (viewState === CONTEXTUAL_MENU_DISPLAYED__STATE) {
-    const onCreateDocument = () => dispatch({ modalDisplayed: 'CreateDocument', type: HANDLE_SHOW_MODAL__ACTION });
-    const onUploadDocument = () => dispatch({ modalDisplayed: 'UploadDocument', type: HANDLE_SHOW_MODAL__ACTION });
-    const onRename = () => dispatch({ modalDisplayed: 'RenameProject', type: HANDLE_SHOW_MODAL__ACTION });
-    const onDelete = () => dispatch({ modalDisplayed: 'DeleteProject', type: HANDLE_SHOW_MODAL__ACTION });
-    const onCloseContextMenu = () => dispatch({ type: HANDLE_CLOSE_CONTEXT_MENU__ACTION });
-    contextMenu = (
-      <EditProjectNavbarContextMenu
-        x={x}
-        y={y}
-        projectId={projectId}
-        onCreateDocument={onCreateDocument}
-        onUploadDocument={onUploadDocument}
-        onRename={onRename}
-        onDelete={onDelete}
-        onClose={onCloseContextMenu}
-      />
-    );
-  }
+  const { viewState, to, modalDisplayed, projectMenuAnchor } = state;
 
   const onCloseModal = () => dispatch({ type: HANDLE_CLOSE_MODAL__ACTION });
 
@@ -90,8 +110,7 @@ export const EditProjectNavbar = ({ projectId, name }: EditProjectNavbarProps) =
       type: HANDLE_REDIRECTING__ACTION,
       to: '/projects',
       modalDisplayed: null,
-      x: 0,
-      y: 0
+      proprojectMenuAnchor: null
     });
   };
 
@@ -100,45 +119,107 @@ export const EditProjectNavbar = ({ projectId, name }: EditProjectNavbarProps) =
   }
 
   let modal = null;
-  if (modalDisplayed === 'CreateDocument') {
-    modal = <NewDocumentModal editingContextId={projectId} onDocumentCreated={onCloseModal} onClose={onCloseModal} />;
-  } else if (modalDisplayed === 'UploadDocument') {
-    modal = <UploadDocumentModal projectId={projectId} onDocumentUploaded={onCloseModal} onClose={onCloseModal} />;
-  } else if (modalDisplayed === 'RenameProject') {
-    modal = (
-      <RenameProjectModal
-        projectId={projectId}
-        initialProjectName={name}
-        onRename={onCloseModal}
-        onClose={onCloseModal}
-      />
-    );
-  } else if (modalDisplayed === 'DeleteProject') {
-    modal = <DeleteProjectModal projectId={projectId} onDelete={onProjectDeleted} onClose={onCloseModal} />;
+  if (project) {
+    if (modalDisplayed === 'CreateDocument') {
+      modal = (
+        <NewDocumentModal
+          editingContextId={project.currentEditingContext.id}
+          onDocumentCreated={onCloseModal}
+          onClose={onCloseModal}
+        />
+      );
+    } else if (modalDisplayed === 'UploadDocument') {
+      modal = <UploadDocumentModal projectId={project.id} onDocumentUploaded={onCloseModal} onClose={onCloseModal} />;
+    } else if (modalDisplayed === 'RenameProject') {
+      modal = (
+        <RenameProjectModal
+          projectId={project.id}
+          initialProjectName={project.name}
+          onRename={onCloseModal}
+          onClose={onCloseModal}
+        />
+      );
+    } else if (modalDisplayed === 'DeleteProject') {
+      modal = <DeleteProjectModal projectId={project.id} onDelete={onProjectDeleted} onClose={onCloseModal} />;
+    }
   }
   return (
     <>
-      <div className={styles.editProjectNavbar}>
-        <div className={styles.container}>
-          <div className={styles.leftArea}>
-            <Logo title="Back to all projects" />
+      <AppBar position="static">
+        <Toolbar className={classes.toolbar}>
+          <div className={classes.left}>
+            <Tooltip title="Back to the homepage">
+              <Link component={RouterLink} to="/" className={classes.link} color="inherit">
+                <SiriusIcon fontSize="large" />
+              </Link>
+            </Tooltip>
           </div>
-          <div className={styles.centerArea}>
-            <div>
-              <Title label={name} />
-              <div className={styles.smallIconContainer}>
-                <IconButton className={styles.moreIcon} onClick={onMore} data-testid="more">
-                  <More title="More" />
-                </IconButton>
-              </div>
-            </div>
+
+          <div className={classes.center}>
+            <Typography variant="h6" noWrap className={classes.title}>
+              {project?.name}
+            </Typography>
+            <IconButton
+              edge="start"
+              aria-label="more"
+              aria-controls="more-menu"
+              aria-haspopup="true"
+              onClick={onMoreClick}
+              color="inherit">
+              <MoreHorizIcon />
+            </IconButton>
           </div>
-          <div className={styles.rightArea}>
+
+          <div className={classes.right}>
             <Help />
           </div>
-        </div>
-      </div>
-      {contextMenu}
+        </Toolbar>
+      </AppBar>
+
+      <Menu
+        open={viewState === CONTEXTUAL_MENU_DISPLAYED__STATE}
+        anchorEl={projectMenuAnchor}
+        onClose={() => dispatch({ type: HANDLE_CLOSE_CONTEXT_MENU__ACTION })}>
+        <MenuItem onClick={() => dispatch({ modalDisplayed: 'CreateDocument', type: HANDLE_SHOW_MODAL__ACTION })}>
+          <ListItemIcon>
+            <AddIcon />
+          </ListItemIcon>
+          <ListItemText primary="New model" />
+        </MenuItem>
+        <MenuItem
+          divider
+          onClick={() => dispatch({ modalDisplayed: 'UploadDocument', type: HANDLE_SHOW_MODAL__ACTION })}>
+          <ListItemIcon>
+            <PublishIcon />
+          </ListItemIcon>
+          <ListItemText primary="Upload model" />
+        </MenuItem>
+        <MenuItem onClick={() => dispatch({ modalDisplayed: 'RenameProject', type: HANDLE_SHOW_MODAL__ACTION })}>
+          <ListItemIcon>
+            <EditIcon />
+          </ListItemIcon>
+          <ListItemText primary="Rename" />
+        </MenuItem>
+        <MenuItem
+          divider
+          component="a"
+          href={`${httpOrigin}/api/projects/${project?.id}`}
+          type="application/octet-stream"
+          onClick={() => dispatch({ type: HANDLE_CLOSE_CONTEXT_MENU__ACTION })}
+          data-testid="download-link">
+          <ListItemIcon>
+            <GetAppIcon />
+          </ListItemIcon>
+          <ListItemText primary="Download" />
+        </MenuItem>
+        <MenuItem onClick={() => dispatch({ modalDisplayed: 'DeleteProject', type: HANDLE_SHOW_MODAL__ACTION })}>
+          <ListItemIcon>
+            <DeleteIcon />
+          </ListItemIcon>
+          <ListItemText primary="Delete" />
+        </MenuItem>
+      </Menu>
+
       {modal}
     </>
   );

--- a/frontend/src/views/edit-project/EditProjectNavbar/EditProjectNavbar.tsx
+++ b/frontend/src/views/edit-project/EditProjectNavbar/EditProjectNavbar.tsx
@@ -11,7 +11,6 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import {
-  useBranding,
   IconButton,
   More,
   DeleteProjectModal,
@@ -37,6 +36,7 @@ import {
   REDIRECT__STATE
 } from './machine';
 import { initialState, reducer } from './reducer';
+import { Help } from 'help/help';
 
 /**
  * Determines where the context menu should open relative to the actual mouse position.
@@ -48,7 +48,6 @@ const menuPositionDelta = {
 
 export const EditProjectNavbar = ({ projectId, name }: EditProjectNavbarProps) => {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const { userStatus } = useBranding();
   const onMore = (event: React.SyntheticEvent<HTMLButtonElement>) => {
     if (state.viewState === EMPTY__STATE) {
       const { x, y } = event.currentTarget.getBoundingClientRect();
@@ -134,7 +133,9 @@ export const EditProjectNavbar = ({ projectId, name }: EditProjectNavbarProps) =
               </div>
             </div>
           </div>
-          <div className={styles.rightArea}>{userStatus}</div>
+          <div className={styles.rightArea}>
+            <Help />
+          </div>
         </div>
       </div>
       {contextMenu}

--- a/frontend/src/views/edit-project/EditProjectNavbar/EditProjectNavbar.types.ts
+++ b/frontend/src/views/edit-project/EditProjectNavbar/EditProjectNavbar.types.ts
@@ -11,7 +11,8 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
+import { Project } from 'views/edit-project/EditProjectView.types';
+
 export interface EditProjectNavbarProps {
-  projectId: string;
-  name: string;
+  project: Project;
 }

--- a/frontend/src/views/edit-project/EditProjectNavbar/reducer.ts
+++ b/frontend/src/views/edit-project/EditProjectNavbar/reducer.ts
@@ -27,8 +27,7 @@ export const initialState = {
   viewState: EMPTY__STATE,
   to: null,
   modalDisplayed: null,
-  x: 0,
-  y: 0
+  projectMenuAnchor: null
 };
 
 export const reducer = (prevState, action) => {
@@ -65,12 +64,12 @@ export const reducer = (prevState, action) => {
 };
 
 const handleShowContextMenuAction = (prevState, action) => {
-  const { x, y } = action;
-  return { ...prevState, viewState: CONTEXTUAL_MENU_DISPLAYED__STATE, x, y };
+  const { projectMenuAnchor } = action;
+  return { ...prevState, viewState: CONTEXTUAL_MENU_DISPLAYED__STATE, projectMenuAnchor };
 };
 
 const handleCloseContextMenuAction = prevState => {
-  return { ...prevState, viewState: EMPTY__STATE, x: 0, y: 0 };
+  return { ...prevState, viewState: EMPTY__STATE, projectMenuAnchor: null };
 };
 
 const handleShowModalAction = (prevState, action) => {
@@ -78,8 +77,7 @@ const handleShowModalAction = (prevState, action) => {
   return {
     ...prevState,
     viewState: MODAL_DISPLAYED__STATE,
-    x: 0,
-    y: 0,
+    projectMenuAnchor: null,
     modalDisplayed
   };
 };
@@ -94,6 +92,6 @@ const handleCloseModalAction = prevState => {
 
 const handleRedirectingAction = (prevState, action) => {
   const { to } = action;
-  const state = { ...prevState, modalDisplayed: null, viewState: REDIRECT__STATE, to };
+  const state = { ...prevState, modalDisplayed: null, viewState: REDIRECT__STATE, to, projectMenuAnchor: null };
   return state;
 };

--- a/frontend/src/views/edit-project/EditProjectView.tsx
+++ b/frontend/src/views/edit-project/EditProjectView.tsx
@@ -145,7 +145,7 @@ export const EditProjectView = () => {
   return (
     <>
       <div className={classes.editProjectView}>
-        <EditProjectNavbar projectId={projectId} name={project?.name ?? ''} />
+        <EditProjectNavbar project={project} />
         {main}
       </div>
       <Snackbar

--- a/frontend/src/views/new-project/NewProjectView.tsx
+++ b/frontend/src/views/new-project/NewProjectView.tsx
@@ -17,10 +17,10 @@ import IconButton from '@material-ui/core/IconButton';
 import Snackbar from '@material-ui/core/Snackbar';
 import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
+import { NavigationBar } from 'navigationBar/NavigationBar';
 import CloseIcon from '@material-ui/icons/Close';
 import { useMachine } from '@xstate/react';
-import { useBranding } from '@eclipse-sirius/sirius-components';
-import { Form, FormContainer, NavigationBar } from '@eclipse-sirius/sirius-components';
+import { Form, FormContainer } from '@eclipse-sirius/sirius-components';
 import gql from 'graphql-tag';
 import React, { useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
@@ -41,6 +41,7 @@ import {
   SchemaValue,
   ShowToastEvent
 } from 'views/new-project/NewProjectViewMachine';
+import { Footer } from 'footer/Footer';
 
 const createProjectMutation = gql`
   mutation createProject($input: CreateProjectInput!) {
@@ -81,7 +82,6 @@ const isErrorPayload = (payload: GQLCreateProjectPayload): payload is GQLErrorPa
 
 export const NewProjectView = () => {
   const classes = useNewProjectViewStyles();
-  const { footer } = useBranding();
   const [{ value, context }, dispatch] = useMachine<NewProjectViewContext, NewProjectEvent>(newProjectViewMachine);
   const { newProjectView, toast } = value as SchemaValue;
   const { name, nameMessage, nameIsInvalid, message, newProjectId } = context;
@@ -167,7 +167,7 @@ export const NewProjectView = () => {
             </FormContainer>
           </Container>
         </main>
-        {footer}
+        <Footer />
       </div>
       <Snackbar
         anchorOrigin={{

--- a/frontend/src/views/projects/ProjectsView.tsx
+++ b/frontend/src/views/projects/ProjectsView.tsx
@@ -37,13 +37,7 @@ import EditIcon from '@material-ui/icons/Edit';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import { useMachine } from '@xstate/react';
-import {
-  useBranding,
-  httpOrigin,
-  DeleteProjectModal,
-  RenameProjectModal,
-  NavigationBar
-} from '@eclipse-sirius/sirius-components';
+import { httpOrigin, DeleteProjectModal, RenameProjectModal } from '@eclipse-sirius/sirius-components';
 import gql from 'graphql-tag';
 import React, { useEffect } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
@@ -67,6 +61,8 @@ import {
   SchemaValue,
   ShowToastEvent
 } from 'views/projects/ProjectsViewMachine';
+import { NavigationBar } from 'navigationBar/NavigationBar';
+import { Footer } from 'footer/Footer';
 
 const getProjectsQuery = gql`
   query getProjects {
@@ -112,7 +108,6 @@ const useProjectsViewStyles = makeStyles(theme => ({
 
 export const ProjectsView = () => {
   const classes = useProjectsViewStyles();
-  const { footer } = useBranding();
   const [{ value, context }, dispatch] = useMachine<ProjectsViewContext, ProjectsViewEvent>(projectsViewMachine);
   const { toast, projectsView } = value as SchemaValue;
   const { projects, selectedProject, menuAnchor, modalToDisplay, message } = context;
@@ -226,7 +221,7 @@ export const ProjectsView = () => {
             </Grid>
           </Container>
         </main>
-        {footer}
+        <Footer />
       </div>
       <Snackbar
         anchorOrigin={{

--- a/frontend/src/views/upload-project/UploadProjectView.tsx
+++ b/frontend/src/views/upload-project/UploadProjectView.tsx
@@ -17,7 +17,7 @@ import Snackbar from '@material-ui/core/Snackbar';
 import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
 import { useMachine } from '@xstate/react';
-import { Form, FormContainer, FileUpload, NavigationBar, sendFile } from '@eclipse-sirius/sirius-components';
+import { Form, FormContainer, FileUpload, sendFile } from '@eclipse-sirius/sirius-components';
 import gql from 'graphql-tag';
 import React from 'react';
 import { Redirect } from 'react-router-dom';
@@ -28,6 +28,7 @@ import {
   uploadProjectMachine,
   UploadProjectViewContext
 } from './UploadProjectViewMachine';
+import { NavigationBar } from 'navigationBar/NavigationBar';
 
 const uploadProjectMutation = gql`
   mutation uploadProject($input: UploadProjectInput!) {


### PR DESCRIPTION
### Type of this PR 

- [x] New feature or improvement

### Issue(s)

https://github.com/eclipse-sirius/sirius-web/issues/63
https://github.com/eclipse-sirius/sirius-web/issues/64

### What does this PR do?

It removes the use of "useBranding" in Sirius-web. It includes the migration of the _EditProjectNavBar_ to Material-UI because the result of removing the uses of "useBranding" was not "Nice".
