### PR TITLE
[69] Improve material-UI CSS

### DIFF
--- a/frontend/src/help/help.tsx
+++ b/frontend/src/help/help.tsx
@@ -10,14 +10,26 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { Link } from '@material-ui/core';
+import { Link, IconButton } from '@material-ui/core';
+import { makeStyles, emphasize } from '@material-ui/core/styles';
 import HelpIcon from '@material-ui/icons/Help';
 import React from 'react';
 
+const useHelpStyle = makeStyles(theme => ({
+  onDarkBackground: {
+    '&:hover': {
+      backgroundColor: emphasize(theme.palette.secondary.main, 0.08)
+    }
+  }
+}));
+
 export const Help = () => {
+  const classes = useHelpStyle();
   return (
     <Link href="https://www.eclipse.org/sirius" rel="noopener noreferrer" target="_blank" color="inherit">
-      <HelpIcon />
+      <IconButton className={classes.onDarkBackground} color="inherit">
+        <HelpIcon />
+      </IconButton>
     </Link>
   );
 };

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -39,6 +39,7 @@ const baseTheme = createMuiTheme({
       light: '#514B79'
     },
     text: {
+      primary: '#261E58',
       disabled: '#B3BFC5',
       hint: '#B3BFC5'
     },
@@ -65,11 +66,6 @@ const baseTheme = createMuiTheme({
 
 const siriusWebTheme = createMuiTheme(
   {
-    palette: {
-      text: {
-        primary: baseTheme.palette.secondary.main
-      }
-    },
     overrides: {
       MuiAvatar: {
         colorDefault: {

--- a/frontend/src/navigationBar/NavigationBar.tsx
+++ b/frontend/src/navigationBar/NavigationBar.tsx
@@ -10,17 +10,26 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { Link } from '@material-ui/core';
+import { Link, IconButton } from '@material-ui/core';
 import AppBar from '@material-ui/core/AppBar';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, emphasize } from '@material-ui/core/styles';
 import Toolbar from '@material-ui/core/Toolbar';
 import Tooltip from '@material-ui/core/Tooltip';
 import { SiriusIcon } from '@eclipse-sirius/sirius-components';
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { Help } from 'help/help';
+import { NavigationBarProps } from './NavigationBar.types';
 
 const useNavigationbarStyles = makeStyles(theme => ({
+  navbar: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  appBarHeader: {
+    height: '4px',
+    backgroundColor: theme.palette.primary.main
+  },
   toolbar: {
     display: 'flex',
     flexDirection: 'row',
@@ -41,25 +50,36 @@ const useNavigationbarStyles = makeStyles(theme => ({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-end'
+  },
+  onDarkBackground: {
+    '&:hover': {
+      backgroundColor: emphasize(theme.palette.secondary.main, 0.08)
+    }
   }
 }));
 
-export const NavigationBar = () => {
+export const NavigationBar = ({ children }: NavigationBarProps) => {
   const classes = useNavigationbarStyles();
   return (
-    <AppBar position="static">
-      <Toolbar className={classes.toolbar}>
-        <div className={classes.left}>
-          <Tooltip title="Back to the homepage">
-            <Link component={RouterLink} to="/" className={classes.link} color="inherit">
-              <SiriusIcon fontSize="large" />
-            </Link>
-          </Tooltip>
-        </div>
-        <div className={classes.right}>
-          <Help />
-        </div>
-      </Toolbar>
-    </AppBar>
+    <div className={classes.navbar}>
+      <div className={classes.appBarHeader}></div>
+      <AppBar position="static">
+        <Toolbar className={classes.toolbar} variant="dense">
+          <div className={classes.left}>
+            <Tooltip title="Back to the homepage">
+              <Link component={RouterLink} to="/" className={classes.link} color="inherit">
+                <IconButton className={classes.onDarkBackground} color="inherit">
+                  <SiriusIcon fontSize="large" />
+                </IconButton>
+              </Link>
+            </Tooltip>
+          </div>
+          {children}
+          <div className={classes.right}>
+            <Help />
+          </div>
+        </Toolbar>
+      </AppBar>
+    </div>
   );
 };

--- a/frontend/src/navigationBar/NavigationBar.types.ts
+++ b/frontend/src/navigationBar/NavigationBar.types.ts
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { ReactNode } from 'react';
+
+export interface NavigationBarProps {
+  children?: ReactNode;
+}

--- a/frontend/src/views/edit-project/EditProjectNavbar/EditProjectNavbar.tsx
+++ b/frontend/src/views/edit-project/EditProjectNavbar/EditProjectNavbar.tsx
@@ -15,11 +15,10 @@ import {
   NewDocumentModal,
   RenameProjectModal,
   UploadDocumentModal,
-  SiriusIcon,
   ServerContext
 } from '@eclipse-sirius/sirius-components';
 import React, { useContext, useReducer } from 'react';
-import { Link } from '@material-ui/core';
+import { emphasize } from '@material-ui/core';
 import { Redirect } from 'react-router-dom';
 import { EditProjectNavbarProps } from 'views/edit-project/EditProjectNavbar/EditProjectNavbar.types';
 import {
@@ -33,43 +32,16 @@ import {
   REDIRECT__STATE
 } from './machine';
 import { initialState, reducer } from './reducer';
-import { Help } from 'help/help';
-import { Link as RouterLink } from 'react-router-dom';
-import {
-  AppBar,
-  makeStyles,
-  Toolbar,
-  Tooltip,
-  Typography,
-  IconButton,
-  Menu,
-  MenuItem,
-  ListItemIcon,
-  ListItemText
-} from '@material-ui/core';
-import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import { makeStyles, Typography, IconButton, Menu, MenuItem, ListItemIcon, ListItemText } from '@material-ui/core';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import PublishIcon from '@material-ui/icons/Publish';
+import { NavigationBar } from 'navigationBar/NavigationBar';
 
 const useEditProjectViewNavbarStyles = makeStyles(theme => ({
-  toolbar: {
-    display: 'grid',
-    gridTemplateRows: '1fr',
-    gridTemplateColumns: '1fr max-content 1fr'
-  },
-  left: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center'
-  },
-  link: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center'
-  },
   center: {
     display: 'flex',
     flexDirection: 'row',
@@ -78,11 +50,10 @@ const useEditProjectViewNavbarStyles = makeStyles(theme => ({
   title: {
     marginRight: theme.spacing(2)
   },
-  right: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'flex-end'
+  onDarkBackground: {
+    '&:hover': {
+      backgroundColor: emphasize(theme.palette.secondary.main, 0.08)
+    }
   }
 }));
 
@@ -145,36 +116,23 @@ export const EditProjectNavbar = ({ project }: EditProjectNavbarProps) => {
   }
   return (
     <>
-      <AppBar position="static">
-        <Toolbar className={classes.toolbar}>
-          <div className={classes.left}>
-            <Tooltip title="Back to the homepage">
-              <Link component={RouterLink} to="/" className={classes.link} color="inherit">
-                <SiriusIcon fontSize="large" />
-              </Link>
-            </Tooltip>
-          </div>
-
-          <div className={classes.center}>
-            <Typography variant="h6" noWrap className={classes.title}>
-              {project?.name}
-            </Typography>
-            <IconButton
-              edge="start"
-              aria-label="more"
-              aria-controls="more-menu"
-              aria-haspopup="true"
-              onClick={onMoreClick}
-              color="inherit">
-              <MoreHorizIcon />
-            </IconButton>
-          </div>
-
-          <div className={classes.right}>
-            <Help />
-          </div>
-        </Toolbar>
-      </AppBar>
+      <NavigationBar>
+        <div className={classes.center}>
+          <Typography variant="h6" noWrap className={classes.title}>
+            {project?.name}
+          </Typography>
+          <IconButton
+            className={classes.onDarkBackground}
+            edge="start"
+            aria-label="more"
+            aria-controls="more-menu"
+            aria-haspopup="true"
+            onClick={onMoreClick}
+            color="inherit">
+            <MoreVertIcon />
+          </IconButton>
+        </div>
+      </NavigationBar>
 
       <Menu
         open={viewState === CONTEXTUAL_MENU_DISPLAYED__STATE}

--- a/frontend/src/views/projects/ProjectsView.tsx
+++ b/frontend/src/views/projects/ProjectsView.tsx
@@ -210,7 +210,7 @@ export const ProjectsView = () => {
                         component={RouterLink}
                         data-testid="create"
                         color="primary"
-                        variant="contained">
+                        variant="outlined">
                         Upload
                       </Button>
                     </div>


### PR DESCRIPTION
- Navbar have been reworked, EditProjectNavbar depends on Navigationbar
- Adds the small magenta bar on top of the navbar
- Uses a smaller navbar
- Fix the hover on navigation bar elements
- Fix project menu button orientation
- Fix default text color

Bug: https://github.com/eclipse-sirius/sirius-web/issues/69
Signed-off-by: Guillaume Coutable <guillaume.coutable@obeo.fr>