### PR TITLE
[releng] Switch to Sirius Components 0.3.3

### DIFF
--- a/backend/sirius-web-frontend/pom.xml
+++ b/backend/sirius-web-frontend/pom.xml
@@ -28,7 +28,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.3.2</sirius.components.version>
+		<sirius.components.version>0.3.3</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-sample-application/pom.xml
+++ b/backend/sirius-web-sample-application/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.3.2</sirius.components.version>
+		<sirius.components.version>0.3.3</sirius.components.version>
 		<flow.version>1.0.6-SNAPSHOT</flow.version>
 		<bpmn.version>4.0.3-SNAPSHOT</bpmn.version>
 	</properties>
@@ -84,6 +84,11 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-starter</artifactId>
+			<version>${sirius.components.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.sirius.web</groupId>
+			<artifactId>sirius-web-graphql</artifactId>
 			<version>${sirius.components.version}</version>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/services/ViewerProvider.java
+++ b/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/services/ViewerProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,12 +12,9 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.sample.services;
 
-import java.security.Principal;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.eclipse.sirius.web.graphql.datafetchers.IDataFetchingEnvironmentService;
 import org.eclipse.sirius.web.graphql.datafetchers.IViewerProvider;
 import org.eclipse.sirius.web.services.api.viewer.IViewer;
 import org.eclipse.sirius.web.services.api.viewer.User;
@@ -32,20 +29,9 @@ import graphql.schema.DataFetchingEnvironment;
  */
 @Service
 public class ViewerProvider implements IViewerProvider {
-
-    private final IDataFetchingEnvironmentService dataFetchingEnvironmentService;
-
-    public ViewerProvider(IDataFetchingEnvironmentService dataFetchingEnvironmentService) {
-        this.dataFetchingEnvironmentService = Objects.requireNonNull(dataFetchingEnvironmentService);
-    }
-
     @Override
     public Optional<IViewer> getViewer(DataFetchingEnvironment environment) {
-        // @formatter:off
-        return this.dataFetchingEnvironmentService.getPrincipal(environment)
-                .map(Principal::getName)
-                .map(username -> new User(UUID.randomUUID(), username));
-        // @formatter:on
+        return Optional.of(new User(UUID.randomUUID(), "system")); //$NON-NLS-1$
     }
 
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2529,9 +2529,9 @@
       "dev": true
     },
     "@eclipse-sirius/sirius-components": {
-      "version": "0.3.2",
-      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.3.2/55f87ce1cbae2ec5ecdf4a443c20a314b594a75e3dbefc4e39e5da3d4af1e6df",
-      "integrity": "sha512-NlW1OBToC0aQ/x17T36+6yhokUV6EOcVd/n+sI7eSXROK0BbSEKMGjqkzHlqNhVwt5shOlm8XBY1IcKeyoISVw==",
+      "version": "0.3.3",
+      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.3.3/c41dd9e144aaecf444803722f5f9cde60026c152acf0c978410b3fceff782e64",
+      "integrity": "sha512-p7pg/F2GRRV3IiNeM6HD2i7zqCnI5MB37FxrCXWnTJZymx5MA5S/IHbOulrHUfX6Gpsy7hVN4M/RFLSk5j7OsQ==",
       "requires": {
         "uuid": "8.3.2"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "3.3.20",
-    "@eclipse-sirius/sirius-components": "0.3.2",
+    "@eclipse-sirius/sirius-components": "0.3.3",
     "@material-ui/core": "4.11.4",
     "@material-ui/icons": "4.11.2",
     "@xstate/react": "1.3.4",


### PR DESCRIPTION
Now Sirius Components does not automatically provide a GraphQL API, so
Sirius Web needs to explicitely depend on its GraphQL API. The project
in question will soon move in the Sirius Web Git repository.

Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>