### PR TITLE
Add (conditional) support for studio definitions in the sample application

### DIFF
--- a/backend/sirius-web-sample-application/pom.xml
+++ b/backend/sirius-web-sample-application/pom.xml
@@ -117,6 +117,21 @@
 			<version>${sirius.components.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.sirius.web</groupId>
+			<artifactId>sirius-web-domain-edit</artifactId>
+			<version>${sirius.components.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.sirius.web</groupId>
+			<artifactId>sirius-web-domain-design</artifactId>
+			<version>${sirius.components.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.sirius.web</groupId>
+			<artifactId>sirius-web-view-edit</artifactId>
+			<version>${sirius.components.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>fr.obeo.dsl.designer.sample.flow</groupId>
 			<artifactId>fr.obeo.dsl.designer.sample.flow</artifactId>
 			<version>${flow.version}</version>

--- a/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/CustomImagesLoader.java
+++ b/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/CustomImagesLoader.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.sample.configuration;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+import org.eclipse.sirius.web.persistence.entities.CustomImageEntity;
+import org.eclipse.sirius.web.persistence.repositories.ICustomImageRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Loads custom images into the database on startup.
+ *
+ * @author pcdavid
+ */
+@Component
+public class CustomImagesLoader implements CommandLineRunner {
+
+    private final Logger logger = LoggerFactory.getLogger(CustomImagesLoader.class);
+
+    private final ICustomImageRepository customImageRepository;
+
+    public CustomImagesLoader(ICustomImageRepository customImageRepository) {
+        this.customImageRepository = Objects.requireNonNull(customImageRepository);
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (this.customImageRepository.count() == 0) {
+            this.loadImages(Paths.get(System.getProperty("org.eclipse.sirius.web.customImages.path"))); //$NON-NLS-1$
+        }
+    }
+
+    private void loadImages(Path path) throws IOException {
+        if (Files.isDirectory(path)) {
+            Files.list(path).forEach(imgPath -> {
+                try {
+                    CustomImageEntity customImageEntity = new CustomImageEntity();
+                    customImageEntity.setLabel(this.getImageLabel(imgPath));
+                    customImageEntity.setFileName(imgPath.getFileName().toString());
+                    customImageEntity.setContent(Files.readAllBytes(imgPath));
+                    customImageEntity = this.customImageRepository.save(customImageEntity);
+                } catch (IOException exception) {
+                    this.logger.warn(exception.getMessage(), exception);
+                }
+            });
+        }
+    }
+
+    private String getImageLabel(Path imgPath) {
+        String label = imgPath.getFileName().toString();
+        label = label.replace("shape_", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        label = label.replace(".svg", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        label = Character.toUpperCase(label.charAt(0)) + label.substring(1);
+        return label;
+    }
+
+}

--- a/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StereotypeBuilder.java
+++ b/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StereotypeBuilder.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.sample.configuration;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.xmi.XMLParserPool;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
+import org.eclipse.emf.ecore.xmi.impl.XMLParserPoolImpl;
+import org.eclipse.sirius.emfjson.resource.JsonResource;
+import org.eclipse.sirius.web.emf.services.SiriusWebJSONResourceFactoryImpl;
+import org.eclipse.sirius.web.emf.utils.EMFResourceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * Helper to create a document stereotype from an EMF model.
+ *
+ * @author pcdavid
+ */
+public class StereotypeBuilder {
+    private static XMLParserPool parserPool = new XMLParserPoolImpl();
+
+    private final Logger logger = LoggerFactory.getLogger(StereotypeBuilder.class);
+
+    private final Timer timer;
+
+    public StereotypeBuilder(String timerName, MeterRegistry meterRegistry) {
+        this.timer = Timer.builder(timerName).register(meterRegistry);
+    }
+
+    public String getStereotypeBody(EObject rootEObject) {
+        JsonResource resource = new SiriusWebJSONResourceFactoryImpl().createResource(URI.createURI("inmemory")); //$NON-NLS-1$
+        if (rootEObject != null) {
+            resource.getContents().add(rootEObject);
+        }
+
+        String content = ""; //$NON-NLS-1$
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Map<String, Object> options = new HashMap<>();
+            options.put(JsonResource.OPTION_ENCODING, JsonResource.ENCODING_UTF_8);
+            options.put(JsonResource.OPTION_SCHEMA_LOCATION, Boolean.TRUE);
+
+            resource.save(outputStream, options);
+
+            content = outputStream.toString();
+        } catch (IOException exception) {
+            this.logger.error(exception.getMessage(), exception);
+        }
+        return content;
+    }
+
+    public String getStereotypeBody(ClassPathResource classPathResource) {
+        long start = System.currentTimeMillis();
+
+        String content = ""; //$NON-NLS-1$
+        try (var inputStream = classPathResource.getInputStream()) {
+            URI uri = URI.createURI(classPathResource.getFilename());
+            Resource inputResource = this.loadFromXMI(uri, inputStream);
+            content = this.saveAsJSON(uri, inputResource);
+        } catch (IOException exception) {
+            this.logger.error(exception.getMessage(), exception);
+        }
+
+        long end = System.currentTimeMillis();
+        this.timer.record(end - start, TimeUnit.MILLISECONDS);
+
+        return content;
+    }
+
+    private Resource loadFromXMI(URI uri, InputStream inputStream) throws IOException {
+        Resource inputResource = new XMIResourceImpl(uri);
+        Map<String, Object> xmiLoadOptions = new EMFResourceUtils().getFastXMILoadOptions(parserPool);
+        inputResource.load(inputStream, xmiLoadOptions);
+        return inputResource;
+    }
+
+    private String saveAsJSON(URI uri, Resource inputResource) throws IOException {
+        String content;
+        JsonResource ouputResource = new SiriusWebJSONResourceFactoryImpl().createResource(uri);
+        ouputResource.getContents().addAll(inputResource.getContents());
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Map<String, Object> jsonSaveOptions = new EMFResourceUtils().getFastJSONSaveOptions();
+            jsonSaveOptions.put(JsonResource.OPTION_ENCODING, JsonResource.ENCODING_UTF_8);
+            jsonSaveOptions.put(JsonResource.OPTION_SCHEMA_LOCATION, Boolean.TRUE);
+            ouputResource.save(outputStream, jsonSaveOptions);
+            content = outputStream.toString(StandardCharsets.UTF_8);
+        }
+        return content;
+    }
+}

--- a/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StereotypeDescriptionRegistryConfigurer.java
+++ b/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StereotypeDescriptionRegistryConfigurer.java
@@ -14,38 +14,15 @@ package org.eclipse.sirius.web.sample.configuration;
 
 import fr.obeo.dsl.designer.sample.flow.FlowFactory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.xmi.XMLParserPool;
-import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
-import org.eclipse.emf.ecore.xmi.impl.XMLParserPoolImpl;
-import org.eclipse.sirius.emfjson.resource.JsonResource;
 import org.eclipse.sirius.web.api.configuration.IStereotypeDescriptionRegistry;
 import org.eclipse.sirius.web.api.configuration.IStereotypeDescriptionRegistryConfigurer;
 import org.eclipse.sirius.web.api.configuration.StereotypeDescription;
-import org.eclipse.sirius.web.emf.services.SiriusWebJSONResourceFactoryImpl;
-import org.eclipse.sirius.web.emf.utils.EMFResourceUtils;
-import org.obeonetwork.dsl.bpmn2.Bpmn2Factory;
-import org.obeonetwork.dsl.bpmn2.Lane;
-import org.obeonetwork.dsl.bpmn2.LaneSet;
-import org.obeonetwork.dsl.bpmn2.Process;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 
 /**
  * Configuration used to register new stereotype descriptions.
@@ -69,14 +46,10 @@ public class StereotypeDescriptionRegistryConfigurer implements IStereotypeDescr
 
     private static final String TIMER_NAME = "siriusweb_stereotype_load"; //$NON-NLS-1$
 
-    private static XMLParserPool parserPool = new XMLParserPoolImpl();
-
-    private final Logger logger = LoggerFactory.getLogger(StereotypeDescriptionRegistryConfigurer.class);
-
-    private final Timer timer;
+    private final StereotypeBuilder stereotypeBuilder;
 
     public StereotypeDescriptionRegistryConfigurer(MeterRegistry meterRegistry) {
-        this.timer = Timer.builder(TIMER_NAME).register(meterRegistry);
+        this.stereotypeBuilder = new StereotypeBuilder(TIMER_NAME, meterRegistry);
     }
 
     @Override
@@ -87,88 +60,14 @@ public class StereotypeDescriptionRegistryConfigurer implements IStereotypeDescr
     }
 
     private String getEmptyFlowContent() {
-        return this.getEmptyContent(FlowFactory.eINSTANCE.createSystem());
+        return this.stereotypeBuilder.getStereotypeBody(FlowFactory.eINSTANCE.createSystem());
     }
 
     private String getRobotFlowContent() {
-        return this.getContent(new ClassPathResource("robot.flow")); //$NON-NLS-1$
+        return this.stereotypeBuilder.getStereotypeBody(new ClassPathResource("robot.flow")); //$NON-NLS-1$
     }
 
     private String getBigGuyFlowContent() {
-        return this.getContent(new ClassPathResource("Big_Guy.flow")); //$NON-NLS-1$
+        return this.stereotypeBuilder.getStereotypeBody(new ClassPathResource("Big_Guy.flow")); //$NON-NLS-1$
     }
-
-    private String getEmptyBPMNContent() {
-        Process process = Bpmn2Factory.eINSTANCE.createProcess();
-        LaneSet laneSet = Bpmn2Factory.eINSTANCE.createLaneSet();
-        laneSet.setName("Lane set"); //$NON-NLS-1$
-        process.getLaneSets().add(laneSet);
-        Lane lane = Bpmn2Factory.eINSTANCE.createLane();
-        lane.setName("Lane"); //$NON-NLS-1$
-        laneSet.getLanes().add(lane);
-        return this.getEmptyContent(process);
-    }
-
-    private String getNobelBPMNContent() {
-        return this.getContent(new ClassPathResource("definitions.bpmn")); //$NON-NLS-1$
-    }
-
-    private String getEmptyContent(EObject rootEObject) {
-        JsonResource resource = new SiriusWebJSONResourceFactoryImpl().createResource(URI.createURI("inmemory")); //$NON-NLS-1$
-        resource.getContents().add(rootEObject);
-
-        String content = ""; //$NON-NLS-1$
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-            Map<String, Object> options = new HashMap<>();
-            options.put(JsonResource.OPTION_ENCODING, JsonResource.ENCODING_UTF_8);
-            options.put(JsonResource.OPTION_SCHEMA_LOCATION, Boolean.TRUE);
-
-            resource.save(outputStream, options);
-
-            content = outputStream.toString();
-        } catch (IOException exception) {
-            this.logger.error(exception.getMessage(), exception);
-        }
-        return content;
-    }
-
-    private String getContent(ClassPathResource classPathResource) {
-        long start = System.currentTimeMillis();
-
-        String content = ""; //$NON-NLS-1$
-        try (var inputStream = classPathResource.getInputStream()) {
-            URI uri = URI.createURI(classPathResource.getFilename());
-            Resource inputResource = this.loadFromXMI(uri, inputStream);
-            content = this.saveAsJSON(uri, inputResource);
-        } catch (IOException exception) {
-            this.logger.error(exception.getMessage(), exception);
-        }
-
-        long end = System.currentTimeMillis();
-        this.timer.record(end - start, TimeUnit.MILLISECONDS);
-
-        return content;
-    }
-
-    private Resource loadFromXMI(URI uri, InputStream inputStream) throws IOException {
-        Resource inputResource = new XMIResourceImpl(uri);
-        Map<String, Object> xmiLoadOptions = new EMFResourceUtils().getFastXMILoadOptions(parserPool);
-        inputResource.load(inputStream, xmiLoadOptions);
-        return inputResource;
-    }
-
-    private String saveAsJSON(URI uri, Resource inputResource) throws IOException {
-        String content;
-        JsonResource ouputResource = new SiriusWebJSONResourceFactoryImpl().createResource(uri);
-        ouputResource.getContents().addAll(inputResource.getContents());
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-            Map<String, Object> jsonSaveOptions = new EMFResourceUtils().getFastJSONSaveOptions();
-            jsonSaveOptions.put(JsonResource.OPTION_ENCODING, JsonResource.ENCODING_UTF_8);
-            jsonSaveOptions.put(JsonResource.OPTION_SCHEMA_LOCATION, Boolean.TRUE);
-            ouputResource.save(outputStream, jsonSaveOptions);
-            content = outputStream.toString(StandardCharsets.UTF_8);
-        }
-        return content;
-    }
-
 }

--- a/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StudioConfiguration.java
+++ b/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StudioConfiguration.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.sample.configuration;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.sirius.web.api.configuration.IStereotypeDescriptionRegistry;
+import org.eclipse.sirius.web.api.configuration.IStereotypeDescriptionRegistryConfigurer;
+import org.eclipse.sirius.web.api.configuration.StereotypeDescription;
+import org.eclipse.sirius.web.compat.services.api.ISiriusConfiguration;
+import org.eclipse.sirius.web.domain.Domain;
+import org.eclipse.sirius.web.domain.DomainFactory;
+import org.eclipse.sirius.web.domain.DomainPackage;
+import org.eclipse.sirius.web.domain.provider.DomainItemProviderAdapterFactory;
+import org.eclipse.sirius.web.view.ViewFactory;
+import org.eclipse.sirius.web.view.ViewPackage;
+import org.eclipse.sirius.web.view.provider.ViewItemProviderAdapterFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Registers the EMF metamodels and stereotypes needed for studio authoring.
+ *
+ * @author pcdavid
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "org.eclipse.sirius.web.features", name = "studioDefinition")
+public class StudioConfiguration {
+
+    public static final UUID EMPTY_DOMAIN_ID = UUID.nameUUIDFromBytes("empty_domain".getBytes()); //$NON-NLS-1$
+
+    public static final String EMPTY_DOMAIN_LABEL = "Empty Domain Definition"; //$NON-NLS-1$
+
+    public static final UUID EMPTY_VIEW_ID = UUID.nameUUIDFromBytes("empty_view".getBytes()); //$NON-NLS-1$
+
+    public static final String EMPTY_VIEW_LABEL = "Empty View Definition"; //$NON-NLS-1$
+
+    public static final UUID EMPTY_DOCUMENT_ID = UUID.nameUUIDFromBytes("empty_document".getBytes()); //$NON-NLS-1$
+
+    public static final String EMPTY_DOCUMENT_LABEL = "Empty Document"; //$NON-NLS-1$
+
+    private static final String TIMER_NAME = "siriusweb_studio_stereotype_load"; //$NON-NLS-1$
+
+    private final StereotypeBuilder stereotypeBuilder;
+
+    public StudioConfiguration(MeterRegistry meterRegistry) {
+        this.stereotypeBuilder = new StereotypeBuilder(TIMER_NAME, meterRegistry);
+    }
+
+    @Bean
+    public EPackage domainEPackage() {
+        return DomainPackage.eINSTANCE;
+    }
+
+    @Bean
+    public AdapterFactory domainAdapterFactory() {
+        return new DomainItemProviderAdapterFactory();
+    }
+
+    @Bean
+    public EPackage viewEPackage() {
+        return ViewPackage.eINSTANCE;
+    }
+
+    @Bean
+    public AdapterFactory viewAdapterFactory() {
+        return new ViewItemProviderAdapterFactory();
+    }
+
+    @Bean
+    public IStereotypeDescriptionRegistryConfigurer studioStereotypesConfigurer() {
+        return (IStereotypeDescriptionRegistry registry) -> {
+            registry.add(new StereotypeDescription(EMPTY_DOMAIN_ID, EMPTY_DOMAIN_LABEL, this::getEmptyDomainContent));
+            registry.add(new StereotypeDescription(EMPTY_VIEW_ID, EMPTY_VIEW_LABEL, this::getEmptyViewContent));
+            registry.add(new StereotypeDescription(EMPTY_DOCUMENT_ID, EMPTY_DOCUMENT_LABEL, this::getEmptyContent));
+        };
+    }
+
+    @Bean
+    ISiriusConfiguration domainModelerDefinition() {
+        return () -> List.of("description/domain.odesign"); //$NON-NLS-1$
+    }
+
+    private String getEmptyContent() {
+        return this.stereotypeBuilder.getStereotypeBody((EObject) null);
+    }
+
+    private String getEmptyDomainContent() {
+        Domain domain = DomainFactory.eINSTANCE.createDomain();
+        domain.setName("SampleDomain"); //$NON-NLS-1$
+        domain.setUri("domain://sample"); //$NON-NLS-1$
+        return this.stereotypeBuilder.getStereotypeBody(domain);
+    }
+
+    private String getEmptyViewContent() {
+        return this.stereotypeBuilder.getStereotypeBody(ViewFactory.eINSTANCE.createView());
+    }
+}


### PR DESCRIPTION
- [221, 243] Add domain and view modelers to the sample app
- [441] Add sample image loader on startup

None of the changes does anything by default. The domain & view modelers are only enabled if the `org.eclipse.sirius.web.features.studioDefinition` feature flag is set, and the image loader does nothing if `org.eclipse.sirius.web.customImages.path` is not set to a local path with matching image files.
