### PR TITLE
[fix] Fix typos in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@ To test _Sirius Web_ you have two possible options:
 If you want a quick overview of how Sirius Web looks and feels like without building the sample application yourself, you will simply need:
 
 * Java 11 (Java 12 or later are currently not supported)
-* Docker, or an existing PostgreSQL installation with a DB user that has admin rights on the database (those are need by the application to create its schema on first startup).
+* Docker, or an existing PostgreSQL installation with a DB user that has admin rights on the database (those are needed by the application to create its schema on first startup).
 
 Then, download the latest pre-built JAR:
 
@@ -166,7 +166,7 @@ From the `backend` directory:
 mvn clean package
 ----
 +
-The result is a read-to-run, Spring Boot "fat JAR" in `backend/sirius-web-sample-application/target/sirius-web-sample-application-0.0.1-SNAPSHOT.jar`.
+The result is a ready-to-run, Spring Boot "fat JAR" in `backend/sirius-web-sample-application/target/sirius-web-sample-application-0.0.1-SNAPSHOT.jar`.
 Refer to the instructions in the "Quick Start" section above to launch it.
 
 == License


### PR DESCRIPTION
This is a minor commit fixing 2 typoes I discovered while reading the README.

Signed-off-by: Laurent Delaigue <laurent.delaigue@obeo.fr>