### PR TITLE
[937] Integrate diagram SVG export to the frontend

### DIFF
--- a/backend/sirius-web-frontend/pom.xml
+++ b/backend/sirius-web-frontend/pom.xml
@@ -28,7 +28,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>2022.01.6</sirius.components.version>
+		<sirius.components.version>2022.01.7</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-graphql-schema/pom.xml
+++ b/backend/sirius-web-graphql-schema/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>2022.01.6</sirius.components.version>
+		<sirius.components.version>2022.01.7</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-graphql/pom.xml
+++ b/backend/sirius-web-graphql/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>2022.01.6</sirius.components.version>
+		<sirius.components.version>2022.01.7</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-persistence/pom.xml
+++ b/backend/sirius-web-persistence/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>2022.01.6</sirius.components.version>
+		<sirius.components.version>2022.01.7</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-sample-application/pom.xml
+++ b/backend/sirius-web-sample-application/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>2022.01.6</sirius.components.version>
+		<sirius.components.version>2022.01.7</sirius.components.version>
 		<flow.version>1.0.10-SNAPSHOT</flow.version>
 		<bpmn.version>4.0.3-SNAPSHOT</bpmn.version>
 	</properties>

--- a/backend/sirius-web-services-api/pom.xml
+++ b/backend/sirius-web-services-api/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>2022.01.6</sirius.components.version>
+		<sirius.components.version>2022.01.7</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-services/pom.xml
+++ b/backend/sirius-web-services/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>2022.01.6</sirius.components.version>
+		<sirius.components.version>2022.01.7</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-spring/pom.xml
+++ b/backend/sirius-web-spring/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>2022.01.6</sirius.components.version>
+		<sirius.components.version>2022.01.7</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-spring/src/main/java/org/eclipse/sirius/web/spring/controllers/RepresentationController.java
+++ b/backend/sirius-web-spring/src/main/java/org/eclipse/sirius/web/spring/controllers/RepresentationController.java
@@ -1,0 +1,105 @@
+/***********************************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.controllers;
+
+import java.io.ByteArrayInputStream;
+import java.util.Objects;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
+import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.ExportRepresentationInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.ExportRepresentationPayload;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * The entry point of the HTTP API to export representations.
+ * <p>
+ * This endpoint will be available on the API base path prefix followed by the representation Id used as a suffix. As
+ * such, users will be able to send representation export request to the following URL:
+ * </p>
+ *
+ * <pre>
+ * PROTOCOL://DOMAIN.TLD(:PORT)/API_BASE_PATH/editingcontexts/EDITING_CONTEXT_ID/representations/REPRESENTATION_ID
+ * </pre>
+ *
+ * <p>
+ * In a development environment, the URL will most likely be:
+ * </p>
+ *
+ * <pre>
+ * http://localhost:8080/api/editingcontexts/EDITING_CONTEXT_ID/representations/REPRESENTATION_ID
+ * </pre>
+ *
+ * @author rpage
+ */
+@Controller
+@RequestMapping(URLConstants.REPRESENTATION_BASE_PATH)
+public class RepresentationController {
+    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+
+    public RepresentationController(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
+        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    }
+
+    @GetMapping(path = "/{representationId}")
+    @ResponseBody
+    public ResponseEntity<Resource> getRepresentation(HttpServletRequest request, @PathVariable String editingContextId, @PathVariable String representationId) {
+        IDiagramInput input = new ExportRepresentationInput(UUID.randomUUID(), representationId);
+        // @formatter:off
+        return this.editingContextEventProcessorRegistry
+                .dispatchEvent(editingContextId, input)
+                .map(payload -> {
+                    ResponseEntity<Resource> response;
+                    if (payload instanceof ExportRepresentationPayload) {
+                        ExportRepresentationPayload exportPayload = (ExportRepresentationPayload) payload;
+                        byte[] bytes = exportPayload.getContent().getBytes();
+                        String name = exportPayload.getName();
+                        response = this.toResponseEntity(name, bytes);
+                    } else {
+                        response = new ResponseEntity<>(null, new HttpHeaders(), HttpStatus.NOT_FOUND);
+                    }
+                    return response;
+                })
+                .block();
+        // @formatter:on
+    }
+
+    private ResponseEntity<Resource> toResponseEntity(String name, byte[] bytes) {
+        // @formatter:off
+        ContentDisposition contentDisposition = ContentDisposition.builder("attachment")  //$NON-NLS-1$
+                .filename(name)
+                .build();
+        // @formatter:on
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentDisposition(contentDisposition);
+        headers.setContentType(MediaType.APPLICATION_XML);
+        headers.setContentLength(bytes.length);
+        InputStreamResource resource = new InputStreamResource(new ByteArrayInputStream(bytes));
+        return new ResponseEntity<>(resource, headers, HttpStatus.OK);
+    }
+}

--- a/backend/sirius-web-spring/src/main/java/org/eclipse/sirius/web/spring/controllers/URLConstants.java
+++ b/backend/sirius-web-spring/src/main/java/org/eclipse/sirius/web/spring/controllers/URLConstants.java
@@ -32,6 +32,8 @@ public final class URLConstants {
 
     public static final String PROJECT_BASE_PATH = API_BASE_PATH + "/projects"; //$NON-NLS-1$
 
+    public static final String REPRESENTATION_BASE_PATH = API_BASE_PATH + "/editingcontexts/{editingContextId}/representations"; //$NON-NLS-1$
+
     public static final String ANY_PATTERN = "/**"; //$NON-NLS-1$
 
     private URLConstants() {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@apollo/client": "3.4.7",
-        "@eclipse-sirius/sirius-components": "2022.01.6",
+        "@eclipse-sirius/sirius-components": "2022.01.7",
         "@material-ui/core": "4.12.3",
         "@material-ui/icons": "4.11.2",
         "@xstate/react": "1.6.3",
@@ -2019,9 +2019,9 @@
       "dev": true
     },
     "node_modules/@eclipse-sirius/sirius-components": {
-      "version": "2022.1.6",
-      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/2022.1.6/52c4ed7d54dff080ee101416444956cd3c923b2a890638dd5d02ca5eb3500e83",
-      "integrity": "sha512-Nxo8nOR5+5gZXhMZIMSs9a7hwwreKd7z3fJnPLAzJaFRYyABduTO0I3MFIa5PMJzYZhJtJPsBUWbiRLG+Pvm8A==",
+      "version": "2022.1.7",
+      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/2022.1.7/21283b82ba6c87c5026a136047e1e05dbc21c30db6a7ed244b83d1b2bd656f13",
+      "integrity": "sha512-fI6WDzA/mPM5AAJgNOtPCZR6cHsbkOfFEBzotnJU5SHeThrx/T2qqiTq6glYYHIeUoyTPc2BF4KA1HLY7p/Peg==",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"
@@ -24753,9 +24753,9 @@
       "dev": true
     },
     "@eclipse-sirius/sirius-components": {
-      "version": "2022.1.6",
-      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/2022.1.6/52c4ed7d54dff080ee101416444956cd3c923b2a890638dd5d02ca5eb3500e83",
-      "integrity": "sha512-Nxo8nOR5+5gZXhMZIMSs9a7hwwreKd7z3fJnPLAzJaFRYyABduTO0I3MFIa5PMJzYZhJtJPsBUWbiRLG+Pvm8A==",
+      "version": "2022.1.7",
+      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/2022.1.7/21283b82ba6c87c5026a136047e1e05dbc21c30db6a7ed244b83d1b2bd656f13",
+      "integrity": "sha512-fI6WDzA/mPM5AAJgNOtPCZR6cHsbkOfFEBzotnJU5SHeThrx/T2qqiTq6glYYHIeUoyTPc2BF4KA1HLY7p/Peg==",
       "requires": {
         "uuid": "8.3.2"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "3.4.7",
-    "@eclipse-sirius/sirius-components": "2022.01.6",
+    "@eclipse-sirius/sirius-components": "2022.01.7",
     "@material-ui/core": "4.12.3",
     "@material-ui/icons": "4.11.2",
     "@xstate/react": "1.6.3",


### PR DESCRIPTION
### Issue
Feature: [#937](https://github.com/eclipse-sirius/sirius-components/issues/937)

### What does this PR do?

Adds a new tree item context menu on diagrams, allowing the user to export them to an SVG file. This requires the PR https://github.com/eclipse-sirius/sirius-components/pull/907 to be accepted