### PR TITLE
[979] Prevent the Node list to be created at the wrong position

### DIFF
--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodePositionProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodePositionProvider.java
@@ -17,9 +17,9 @@ import java.util.Optional;
 import org.eclipse.sirius.web.diagrams.NodeType;
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.Size;
-import org.eclipse.sirius.web.diagrams.events.NodeCreationEvent;
 import org.eclipse.sirius.web.diagrams.events.IDiagramEvent;
 import org.eclipse.sirius.web.diagrams.events.MoveEvent;
+import org.eclipse.sirius.web.diagrams.events.NodeCreationEvent;
 import org.eclipse.sirius.web.diagrams.events.ResizeEvent;
 import org.eclipse.sirius.web.diagrams.layout.LayoutOptionValues;
 import org.eclipse.sirius.web.diagrams.layout.incremental.IncrementalLayoutEngine;
@@ -55,7 +55,7 @@ public class NodePositionProvider {
         Optional<Position> optionalPosition = this.getSpecificNodePositionFromEvent(optionalDiagramElementEvent, node);
         if (optionalPosition.isPresent() && !NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
             position = optionalPosition.get();
-        } else if (!this.isAlreadyPositioned(node) || NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
+        } else if (!this.isAlreadyPositioned(node)) {
             Optional<Position> optionalStartingPosition = this.getOptionalStartingPositionFromEvent(optionalDiagramElementEvent);
             if (optionalStartingPosition.isPresent() && this.last == null && !NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
                 // The node has been created by a tool and has a fixed position

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
@@ -113,7 +113,8 @@ public class ContainmentUpdater {
     }
 
     private void updateContentPosition(NodeLayoutData nodeLayoutData) {
-        double nextYChildPosition = nodeLayoutData.getLabel().getTextBounds().getSize().getHeight() + LayoutOptionValues.NODE_LIST_ELK_PADDING_TOP + LayoutOptionValues.DEFAULT_ELK_NODE_LABELS_PADDING;
+        double nextYChildPosition = nodeLayoutData.getLabel().getPosition().getY() + nodeLayoutData.getLabel().getTextBounds().getSize().getHeight() + LayoutOptionValues.NODE_LIST_ELK_PADDING_TOP
+                + LayoutOptionValues.DEFAULT_ELK_NODE_LABELS_PADDING;
         for (NodeLayoutData childLayoutData : nodeLayoutData.getChildrenNodes()) {
             double currentYChildPosition = childLayoutData.getPosition().getY();
             if (currentYChildPosition != nextYChildPosition) {

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/OverlapsUpdater.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/OverlapsUpdater.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.eclipse.sirius.web.diagrams.NodeType;
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.Size;
 import org.eclipse.sirius.web.diagrams.layout.incremental.IncrementalLayoutEngine;
@@ -74,7 +75,7 @@ public class OverlapsUpdater {
         List<NodeLayoutData[]> overlaps = new ArrayList<>();
         for (NodeLayoutData sibling : node.getParent().getChildrenNodes()) {
             // we only consider solvable overlaps
-            if (!sibling.equals(node) && !sibling.isPinned() && !this.fixedNodes.contains(sibling)) {
+            if (this.canOverlap(node, sibling)) {
                 Position siblingPosition = sibling.getPosition();
                 Size siblingSize = sibling.getSize();
                 // @formatter:off
@@ -88,6 +89,10 @@ public class OverlapsUpdater {
             }
         }
         return overlaps;
+    }
+
+    private boolean canOverlap(NodeLayoutData node, NodeLayoutData sibling) {
+        return !sibling.equals(node) && !sibling.isPinned() && !this.fixedNodes.contains(sibling) && !NodeType.NODE_LIST_ITEM.equals(node.getNodeType());
     }
 
     private Position computeNewPosition(NodeLayoutData node1, NodeLayoutData node2) {


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/979

### What does this PR do?

- Prevent computing the position of list items at every refresh
- Prevent the overlap updater to consider list items.
- Use the same algorithm to compute the position of list-items in
containment updater than in the node position provider.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify
