### PR TITLE
[enh] Added i18n support for odesign

### DIFF
--- a/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/representations/ODesignReader.java
+++ b/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/representations/ODesignReader.java
@@ -14,11 +14,22 @@ package org.eclipse.sirius.components.compatibility.services.representations;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.URLConnection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
 
+import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
@@ -31,6 +42,7 @@ import org.eclipse.sirius.properties.ext.widgets.reference.propertiesextwidgetsr
 import org.eclipse.sirius.viewpoint.ViewpointPackage;
 import org.eclipse.sirius.viewpoint.description.DescriptionPackage;
 import org.eclipse.sirius.viewpoint.description.Group;
+import org.eclipse.sirius.viewpoint.description.IdentifiedElement;
 import org.eclipse.sirius.viewpoint.description.validation.ValidationPackage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,12 +61,24 @@ public class ODesignReader {
 
     private static final String ENVIRONMENT_ODESIGN_URI = "environment:/viewpoint"; //$NON-NLS-1$
 
+    private static final String PROPERTIES_FILE_NAME = "plugin"; //$NON-NLS-1$
+
+    private static final String PROPERTIES_FILE_EXTENSION = ".properties"; //$NON-NLS-1$
+
+    private static final String BUNDLE_LOCALIZATION = "Bundle-Localization"; //$NON-NLS-1$
+
     private final Logger logger = LoggerFactory.getLogger(ODesignReader.class);
 
     public Optional<Group> read(ClassPathResource classPathResource) {
         Optional<Group> optionalGroup = Optional.empty();
         try (InputStream inputStream = classPathResource.getInputStream()) {
             optionalGroup = this.read(classPathResource.getFilename(), inputStream);
+            if (optionalGroup.isPresent()) {
+                ResourceBundle resourceBundle = this.findResourceBundle(classPathResource, Locale.getDefault());
+                if (resourceBundle != null) {
+                    this.localizeGroup(optionalGroup.get(), resourceBundle);
+                }
+            }
         } catch (IOException exception) {
             this.logger.warn(exception.getMessage(), exception);
         }
@@ -115,5 +139,97 @@ public class ODesignReader {
         options.put(XMLResource.OPTION_USE_XML_NAME_TO_FEATURE_MAP, new HashMap<>());
         return options;
 
+    }
+
+    private ResourceBundle findResourceBundle(ClassPathResource classPathResource, Locale locale) throws IOException {
+        URLConnection urlConnection = classPathResource.getURL().openConnection();
+        if (urlConnection instanceof JarURLConnection) {
+            JarURLConnection jarUrlConnection = (JarURLConnection) urlConnection;
+            JarFile jarFile = jarUrlConnection.getJarFile();
+
+            // Determine properties file name
+            String propertiesFileName = PROPERTIES_FILE_NAME;
+            Manifest manifest = jarFile.getManifest();
+            if (manifest != null) {
+                Attributes attributes = manifest.getMainAttributes();
+                String bundleLocalizationValue = attributes.getValue(BUNDLE_LOCALIZATION);
+                if (bundleLocalizationValue != null) {
+                    propertiesFileName = bundleLocalizationValue;
+                }
+            }
+
+            // Find the most specific properties file for the locale
+            ZipEntry propertiesEntry = this.findPropertiesEntry(jarFile, propertiesFileName, locale);
+
+            // Return property resource bundle if found
+            if (propertiesEntry != null) {
+                InputStream inputStream = jarFile.getInputStream(propertiesEntry);
+                PropertyResourceBundle bundle = new PropertyResourceBundle(inputStream);
+                inputStream.close();
+                return bundle;
+            }
+        }
+        return null;
+    }
+
+    private ZipEntry findPropertiesEntry(JarFile jarFile, String propertiesFileName, Locale locale) {
+        String fileName = propertiesFileName;
+        ZipEntry propertiesEntry = jarFile.getEntry(fileName + PROPERTIES_FILE_EXTENSION);
+
+        String language = locale.getLanguage();
+        if (language.isEmpty()) {
+            return propertiesEntry;
+        }
+        fileName += '_' + language;
+        ZipEntry localizationPropertiesEntry = jarFile.getEntry(fileName + PROPERTIES_FILE_EXTENSION);
+        if (localizationPropertiesEntry != null) {
+            propertiesEntry = localizationPropertiesEntry;
+        }
+
+        String script = locale.getScript();
+        if (!script.isEmpty()) {
+            fileName += '_' + script;
+            localizationPropertiesEntry = jarFile.getEntry(fileName + PROPERTIES_FILE_EXTENSION);
+            if (localizationPropertiesEntry != null) {
+                propertiesEntry = localizationPropertiesEntry;
+            }
+        }
+
+        String country = locale.getCountry();
+        if (!country.isEmpty()) {
+            fileName += '_' + country;
+            localizationPropertiesEntry = jarFile.getEntry(fileName + PROPERTIES_FILE_EXTENSION);
+            if (localizationPropertiesEntry != null) {
+                propertiesEntry = localizationPropertiesEntry;
+            }
+
+            String variant = locale.getVariant();
+            if (!variant.isEmpty()) {
+                fileName += '_' + variant;
+                localizationPropertiesEntry = jarFile.getEntry(fileName + PROPERTIES_FILE_EXTENSION);
+                if (localizationPropertiesEntry != null) {
+                    propertiesEntry = localizationPropertiesEntry;
+                }
+            }
+        }
+
+        return propertiesEntry;
+    }
+
+    private void localizeGroup(Group group, ResourceBundle resourceBundle) {
+        TreeIterator<EObject> iterator = group.eAllContents();
+        while (iterator.hasNext()) {
+            EObject object = iterator.next();
+            if (object instanceof IdentifiedElement) {
+                IdentifiedElement element = (IdentifiedElement) object;
+                String label = element.getLabel();
+                if (label != null && label.length() >= 2 && label.charAt(0) == '%') {
+                    label = label.substring(1);
+                    if (label.charAt(0) != '%' && resourceBundle.containsKey(label)) {
+                        element.setLabel(resourceBundle.getString(label));
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Denis Nikiforov <denis.nikif@gmail.com>

### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

No.

### What does this PR do?

Adds internationalization support for odesign files. Gets the current locale and finds a properties-file in the jar-file of an odesign-file. Updates all strings starting with % in the Sirius-specification read.

### Screenshot/screencast of this PR

No. 

### Potential side effects

Maybe the change can break odesign reading somehow, but shouldn't.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test : 1) add an odesign bundle with a localized properties file 2) create a diagram 3) invoke a tool palette 4) names of node creation tools should be localized

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
