### PR TITLE
Enhance border node positioning (no overlap, border node creation)

### DIFF
--- a/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/provider/BorderNodeBoundsProvider.java
+++ b/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/provider/BorderNodeBoundsProvider.java
@@ -1,0 +1,413 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.layout.incremental.provider;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
+import org.eclipse.sirius.components.diagrams.events.IDiagramEvent;
+import org.eclipse.sirius.components.diagrams.events.MoveEvent;
+import org.eclipse.sirius.components.diagrams.events.ResizeEvent;
+import org.eclipse.sirius.components.diagrams.layout.ISiriusWebLayoutConfigurator;
+import org.eclipse.sirius.components.diagrams.layout.incremental.data.NodeLayoutData;
+import org.eclipse.sirius.components.diagrams.layout.incremental.utils.Bounds;
+import org.eclipse.sirius.components.diagrams.layout.incremental.utils.Geometry;
+import org.eclipse.sirius.components.diagrams.layout.incremental.utils.PointOnRectangleInfo;
+import org.eclipse.sirius.components.diagrams.layout.incremental.utils.RectangleSide;
+
+/**
+ * Provides the position to apply to a BorderNode.
+ *
+ * @author lfasani
+ */
+public class BorderNodeBoundsProvider {
+
+    private static final Position UNDEFINED_POSITION = Position.at(-1, -1);
+
+    private static final Size UNDEFINED_SIZE = Size.of(-1, -1);
+
+    private NodeSizeProvider nodeSizeProvider = new NodeSizeProvider(new ImageSizeProvider());
+
+    /**
+     * Provides the new position of the given border node.If the position is no need to be updated, the current position
+     * is returned.
+     *
+     * @return
+     */
+    public List<BorderNodesOnSide> updateBorderNodesBounds(Optional<IDiagramEvent> optionalDiagramElementEvent, NodeLayoutData parentNode, ISiriusWebLayoutConfigurator layoutConfigurator) {
+        List<NodeLayoutData> borderNodesLayoutData = parentNode.getBorderNodes();
+
+        Optional<NodeLayoutData> borderNodeMovedOrResized = this.getBorderNodesMovedOrResized(optionalDiagramElementEvent, borderNodesLayoutData);
+        List<NodeLayoutData> borderNodesToCreate = this.getBorderNodesToCreate(borderNodesLayoutData);
+        List<NodeLayoutData> borderNodesNotCreated = new ArrayList<>(borderNodesLayoutData);
+        borderNodesNotCreated.removeAll(borderNodesToCreate);
+        List<NodeLayoutData> borderNodesNotChanged = new ArrayList<>(borderNodesLayoutData);
+        if (borderNodeMovedOrResized.isPresent()) {
+            borderNodesNotChanged.remove(borderNodeMovedOrResized.get());
+        }
+
+        if (borderNodeMovedOrResized.isPresent()) {
+            // update the position of the border node if it has been explicitly moved or resized
+            this.updateChangedBorderNodeBounds(optionalDiagramElementEvent, borderNodesLayoutData, parentNode, borderNodeMovedOrResized.get(), layoutConfigurator);
+        }
+
+        for (NodeLayoutData currentBorderNode : borderNodesNotChanged) {
+            Size size = this.nodeSizeProvider.getSize(optionalDiagramElementEvent, currentBorderNode, layoutConfigurator);
+            if (!this.getRoundedSize(size).equals(this.getRoundedSize(currentBorderNode.getSize()))) {
+                currentBorderNode.setSize(size);
+                currentBorderNode.setChanged(true);
+            }
+        }
+
+        // recompute the border node
+        List<BorderNodesOnSide> borderNodesPerSide = this.snapAndOrderBorderNodes(borderNodesNotCreated, parentNode.getSize(), layoutConfigurator);
+
+        // Add the new border nodes
+        for (NodeLayoutData borderNodeToCreate : borderNodesToCreate) {
+            this.updateCreatedBorderNodePosition(borderNodesPerSide, borderNodeToCreate, parentNode.getSize(), layoutConfigurator);
+        }
+
+        return borderNodesPerSide;
+    }
+
+    /**
+     * Find space for created border nodes from North then close wise.<br/>
+     * If not found the border node is added on north, at the right of the latest north border node.
+     */
+    private void updateCreatedBorderNodePosition(List<BorderNodesOnSide> borderNodesPerSide, NodeLayoutData createdBorderNode, Size parentSize, ISiriusWebLayoutConfigurator layoutConfigurator) {
+        double gapBeweenTwoBorderNodes = Optional.ofNullable(layoutConfigurator.configureByType(createdBorderNode.getNodeType()).getProperty(CoreOptions.SPACING_PORT_PORT)).orElse(0.);
+        double portOffset = Optional.ofNullable(layoutConfigurator.configureByType(createdBorderNode.getNodeType()).getProperty(CoreOptions.PORT_BORDER_OFFSET)).orElse(0.);
+
+        boolean found = false;
+        for (RectangleSide side : RectangleSide.values()) {
+            Optional<BorderNodesOnSide> borderNodesOnSide = borderNodesPerSide.stream().filter(b -> side.equals(b.getSide())).findFirst();
+
+            if (RectangleSide.NORTH.equals(side) || RectangleSide.SOUTH.equals(side)) {
+                found = this.updateCreatedNorthSouthBorderNodePosition(side, borderNodesPerSide, borderNodesOnSide, createdBorderNode, parentSize, gapBeweenTwoBorderNodes, portOffset);
+                if (found) {
+                    break;
+                }
+            } else {
+                found = this.updateCreatedEastWestBorderNodePosition(side, borderNodesPerSide, borderNodesOnSide, createdBorderNode, parentSize, gapBeweenTwoBorderNodes, portOffset);
+                if (found) {
+                    break;
+                }
+            }
+        }
+
+        if (!found) {
+            // Add the border on the north
+            List<NodeLayoutData> borderNodesOnNorth = new ArrayList<>();
+            // @formatter:off
+            borderNodesOnNorth = borderNodesPerSide.stream()
+                    .filter(b -> RectangleSide.NORTH.equals(b.getSide()))
+                    .findFirst()
+                    .orElse(new BorderNodesOnSide(RectangleSide.NORTH, borderNodesOnNorth))
+                    .getBorderNodes();
+            // @formatter:on
+            if (borderNodesOnNorth.isEmpty()) {
+                createdBorderNode.setPosition(Position.at(gapBeweenTwoBorderNodes, -createdBorderNode.getSize().getHeight() + portOffset));
+            } else {
+                NodeLayoutData lastBorderNodeOnNorth = borderNodesOnNorth.get(borderNodesOnNorth.size() - 1);
+                createdBorderNode.setPosition(Position.at(lastBorderNodeOnNorth.getPosition().getX() + lastBorderNodeOnNorth.getSize().getWidth() + gapBeweenTwoBorderNodes,
+                        -createdBorderNode.getSize().getHeight() + portOffset));
+            }
+        }
+    }
+
+    private boolean updateCreatedEastWestBorderNodePosition(RectangleSide side, List<BorderNodesOnSide> borderNodesPerSide, Optional<BorderNodesOnSide> borderNodesOnSide,
+            NodeLayoutData createdBorderNode, Size parentSize, double gapBeweenTwoBorderNodes, double portOffset) {
+        double y = 0;
+        boolean found = false;
+        if (borderNodesOnSide.isEmpty() && (parentSize.getHeight() > createdBorderNode.getSize().getHeight())) {
+            found = true;
+            y = 0.;
+        } else if (borderNodesOnSide.isPresent()) {
+            List<NodeLayoutData> borderNodes = borderNodesOnSide.get().getBorderNodes();
+            int nbBorderNodes = borderNodes.size();
+            for (int i = 0; i < nbBorderNodes && !found; i++) {
+                NodeLayoutData currentBorderNode = borderNodes.get(i);
+                if (i == 0) {
+                    double availableSpace = currentBorderNode.getPosition().getY();
+                    if (availableSpace >= (createdBorderNode.getSize().getHeight() + gapBeweenTwoBorderNodes)) {
+                        found = true;
+                        y = 0;
+                        break;
+                    }
+                }
+                if (i == nbBorderNodes - 1) {
+                    double availableSpace = parentSize.getHeight() - currentBorderNode.getPosition().getY() - currentBorderNode.getSize().getHeight();
+                    if (availableSpace >= (createdBorderNode.getSize().getHeight() + gapBeweenTwoBorderNodes)) {
+                        found = true;
+                        y = currentBorderNode.getPosition().getY() + currentBorderNode.getSize().getHeight() + gapBeweenTwoBorderNodes;
+                    }
+                } else {
+                    NodeLayoutData followingBorderNode = borderNodes.get(i + 1);
+                    double availableSpaceBetweenCenterOfTwoNodes = followingBorderNode.getPosition().getY() - currentBorderNode.getPosition().getY() - currentBorderNode.getSize().getHeight();
+                    if (availableSpaceBetweenCenterOfTwoNodes >= (createdBorderNode.getSize().getHeight() + 2 * gapBeweenTwoBorderNodes)) {
+                        found = true;
+                        y = currentBorderNode.getPosition().getY() + currentBorderNode.getSize().getHeight() + gapBeweenTwoBorderNodes;
+                    }
+                }
+            }
+        }
+        if (found) {
+            if (RectangleSide.WEST.equals(side)) {
+                createdBorderNode.setPosition(Position.at(-createdBorderNode.getSize().getWidth() - portOffset, y));
+            } else if (RectangleSide.EAST.equals(side)) {
+                createdBorderNode.setPosition(Position.at(parentSize.getWidth() + portOffset, y));
+            }
+            if (borderNodesOnSide.isEmpty()) {
+                borderNodesPerSide.add(new BorderNodesOnSide(side, Arrays.asList(createdBorderNode)));
+            } else {
+                borderNodesOnSide.get().getBorderNodes().add(createdBorderNode);
+            }
+        }
+
+        return found;
+    }
+
+    private boolean updateCreatedNorthSouthBorderNodePosition(RectangleSide side, List<BorderNodesOnSide> borderNodesPerSide, Optional<BorderNodesOnSide> borderNodesOnSide,
+            NodeLayoutData createdBorderNode, Size parentSize, double gapBeweenTwoBorderNodes, double portOffset) {
+        double x = 0;
+        boolean found = false;
+        if (borderNodesOnSide.isEmpty() && (parentSize.getWidth() > createdBorderNode.getSize().getWidth())) {
+            found = true;
+            x = 0.;
+        } else if (borderNodesOnSide.isPresent()) {
+            List<NodeLayoutData> borderNodes = borderNodesOnSide.get().getBorderNodes();
+            int nbBorderNodes = borderNodes.size();
+            for (int i = 0; i < nbBorderNodes && !found; i++) {
+                NodeLayoutData currentBorderNode = borderNodes.get(i);
+                if (i == 0) {
+                    double availableSpace = currentBorderNode.getPosition().getX();
+                    if (availableSpace >= (createdBorderNode.getSize().getWidth() + gapBeweenTwoBorderNodes)) {
+                        found = true;
+                        x = 0;
+                        break;
+                    }
+                }
+                if (i == nbBorderNodes - 1) {
+                    double availableSpace = parentSize.getWidth() - currentBorderNode.getPosition().getX() - currentBorderNode.getSize().getWidth();
+                    if (availableSpace >= (createdBorderNode.getSize().getWidth() + gapBeweenTwoBorderNodes)) {
+                        found = true;
+                        x = currentBorderNode.getPosition().getX() + currentBorderNode.getSize().getWidth() + gapBeweenTwoBorderNodes;
+                    }
+                } else {
+                    NodeLayoutData followingBorderNode = borderNodes.get(i + 1);
+                    double availableSpaceBetweenCenterOfTwoNodes = followingBorderNode.getPosition().getX() - currentBorderNode.getPosition().getX() - currentBorderNode.getSize().getWidth();
+                    if (availableSpaceBetweenCenterOfTwoNodes >= (createdBorderNode.getSize().getWidth() + 2 * gapBeweenTwoBorderNodes)) {
+                        found = true;
+                        x = currentBorderNode.getPosition().getX() + currentBorderNode.getSize().getWidth() + gapBeweenTwoBorderNodes;
+                    }
+                }
+            }
+        }
+        if (found) {
+            if (RectangleSide.NORTH.equals(side)) {
+                createdBorderNode.setPosition(Position.at(x, -createdBorderNode.getSize().getHeight() - portOffset));
+            } else if (RectangleSide.SOUTH.equals(side)) {
+                createdBorderNode.setPosition(Position.at(x, parentSize.getHeight() + portOffset));
+            }
+            if (borderNodesOnSide.isEmpty()) {
+                borderNodesPerSide.add(new BorderNodesOnSide(side, Arrays.asList(createdBorderNode)));
+            } else {
+                borderNodesOnSide.get().getBorderNodes().add(createdBorderNode);
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Update the border node by snapping it to the parentRectangle, that is moving it to the closest point of the
+     * parentRectangle.
+     *
+     * @param borderNodesLayoutData
+     *            the border nodes which position is given in the rectangle upper right corner coordinates system
+     * @return for each side of the given parentRectangle, the list of the updates border node
+     */
+    public List<BorderNodesOnSide> snapAndOrderBorderNodes(List<NodeLayoutData> borderNodesLayoutData, Size parentRectangle, ISiriusWebLayoutConfigurator layoutConfigurator) {
+        EnumMap<RectangleSide, List<NodeLayoutData>> borderNodesPerSide = new EnumMap<>(RectangleSide.class);
+
+        Geometry geometry = new Geometry();
+
+        for (NodeLayoutData borderNodeLayoutData : borderNodesLayoutData) {
+            double portOffset = layoutConfigurator.configureByType(borderNodeLayoutData.getNodeType()).getProperty(CoreOptions.PORT_BORDER_OFFSET).doubleValue();
+
+            Bounds borderNodeRectangle = Bounds.newBounds().position(borderNodeLayoutData.getPosition()).size(borderNodeLayoutData.getSize()).build();
+            PointOnRectangleInfo borderNodePositionOnSide = geometry.snapBorderNodeOnRectangle(borderNodeRectangle, parentRectangle, portOffset);
+            // update the border node
+            borderNodeLayoutData.setPosition(borderNodePositionOnSide.getPosition());
+
+            borderNodesPerSide.computeIfAbsent(borderNodePositionOnSide.getSide(), side -> new ArrayList<>());
+            borderNodesPerSide.get(borderNodePositionOnSide.getSide()).add(borderNodeLayoutData);
+        }
+
+        // @formatter:off
+        return borderNodesPerSide.entrySet().stream()
+                .map(entry -> {
+                    // reorder from left to right or from top to bottom
+                    List<NodeLayoutData> borderNodes = entry.getValue();
+                    RectangleSide side = entry.getKey();
+                    if (RectangleSide.NORTH.equals(side) || RectangleSide.SOUTH.equals(side)) {
+                        Collections.sort(borderNodes, (bn1, bn2) -> Double.compare(bn1.getPosition().getX(), bn2.getPosition().getX()));
+                    } else {
+                        Collections.sort(borderNodes, (bn1, bn2) -> Double.compare(bn1.getPosition().getY(), bn2.getPosition().getY()));
+                    }
+                    return new BorderNodesOnSide(entry.getKey(), borderNodes);
+                })
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+
+    private void updateChangedBorderNodeBounds(Optional<IDiagramEvent> optionalDiagramElementEvent, List<NodeLayoutData> borderNodesLayoutData, NodeLayoutData parentNode,
+            NodeLayoutData changedBorderNode, ISiriusWebLayoutConfigurator layoutConfigurator) {
+        Size newSize = Size.of(changedBorderNode.getSize().getWidth(), changedBorderNode.getSize().getHeight());
+        Position newPosition = Position.at(changedBorderNode.getPosition().getX(), changedBorderNode.getPosition().getY());
+
+        // @formatter:off
+        Optional<ResizeEvent> resizeEventOpt = optionalDiagramElementEvent.filter(ResizeEvent.class::isInstance)
+            .map(ResizeEvent.class::cast)
+            .filter(resizeEvent -> changedBorderNode.getId().equals(resizeEvent.getNodeId()));
+        // @formatter:on
+
+        if (resizeEventOpt.isPresent()) {
+            Position oldPosition = changedBorderNode.getPosition();
+
+            newSize = Size.of(resizeEventOpt.get().getNewSize().getWidth(), resizeEventOpt.get().getNewSize().getHeight());
+            double newX = oldPosition.getX() - resizeEventOpt.get().getPositionDelta().getX();
+            double newY = oldPosition.getY() - resizeEventOpt.get().getPositionDelta().getY();
+            newPosition = Position.at(newX, newY);
+
+            // Limit the resize if the border node goes outside the parent node
+            Size parentSize = parentNode.getSize();
+            Position parentPosition = parentNode.getPosition();
+
+            // TODO : just written and not tested
+            List<BorderNodesOnSide> snapAndOrderBorderNodes = this.snapAndOrderBorderNodes(Arrays.asList(changedBorderNode), parentSize, layoutConfigurator);
+            if (snapAndOrderBorderNodes.size() == 1) {
+                RectangleSide side = snapAndOrderBorderNodes.get(0).getSide();
+                if (RectangleSide.EAST.equals(side) || RectangleSide.WEST.equals(side)) {
+                    if (newPosition.getY() + newSize.getHeight() > parentSize.getHeight()) {
+                        newSize = Size.of(newPosition.getX(), parentSize.getHeight() - newPosition.getY());
+                    } else if (newPosition.getY() < 0) {
+                        newPosition = Position.at(newPosition.getX(), 0.);
+                        newSize = Size.of(newSize.getWidth(), parentPosition.getY() - parentSize.getHeight());
+                    }
+                } else if (RectangleSide.NORTH.equals(side) || RectangleSide.SOUTH.equals(side)) {
+                    if (newPosition.getX() + newSize.getWidth() > parentSize.getWidth()) {
+                        newSize = Size.of(parentSize.getWidth() - newPosition.getX(), newSize.getHeight());
+                    } else if (newPosition.getX() < 0) {
+                        newPosition = Position.at(0., newPosition.getY());
+                        newSize = Size.of(newPosition.getX() - newSize.getWidth(), newSize.getHeight());
+                    }
+                }
+            }
+        }
+
+        // @formatter:off
+        Optional<MoveEvent> moveEventOpt = optionalDiagramElementEvent.filter(MoveEvent.class::isInstance)
+                .map(MoveEvent.class::cast)
+                .filter(moveEvent -> changedBorderNode.getId().equals(moveEvent.getNodeId()));
+        // @formatter:on
+        if (moveEventOpt.isPresent()) {
+            double newX = moveEventOpt.get().getNewPosition().getX();
+            double newY = moveEventOpt.get().getNewPosition().getY();
+            newPosition = Position.at(newX, newY);
+        }
+
+        // check that there is no overlapping with other border nodes
+        List<NodeLayoutData> otherBorderNodes = new ArrayList<>(borderNodesLayoutData);
+        otherBorderNodes.remove(changedBorderNode);
+        Geometry geometry = new Geometry();
+        Bounds changedBorderNodeBounds = Bounds.newBounds().position(newPosition).size(newSize).build();
+        boolean isOverlapping = false;
+        for (NodeLayoutData otherBorderNode : otherBorderNodes) {
+            Bounds otherBorderNodeBounds = Bounds.newBounds().position(otherBorderNode.getPosition()).size(otherBorderNode.getSize()).build();
+            isOverlapping = geometry.isOverlapping(changedBorderNodeBounds, otherBorderNodeBounds);
+            if (isOverlapping) {
+                break;
+            }
+        }
+
+        if (!isOverlapping) {
+            Position oldPosition = changedBorderNode.getPosition();
+            if (!newPosition.equals(oldPosition)) {
+                changedBorderNode.setPosition(newPosition);
+                changedBorderNode.setChanged(true);
+                changedBorderNode.setPinned(true);
+            }
+            Size oldSize = changedBorderNode.getSize();
+            if (!newSize.equals(oldSize)) {
+                changedBorderNode.setSize(newSize);
+                changedBorderNode.setChanged(true);
+                changedBorderNode.setPinned(true);
+            }
+        }
+    }
+
+    private Optional<NodeLayoutData> getBorderNodesMovedOrResized(Optional<IDiagramEvent> optionalDiagramElementEvent, List<NodeLayoutData> borderNodesLayoutData) {
+        // @formatter:off
+        Optional<NodeLayoutData> borderNodeMovedOrResized = optionalDiagramElementEvent
+                .map(event -> {
+                        String nodeId = null;
+                        if (event instanceof MoveEvent) {
+                            nodeId =  ((MoveEvent) event).getNodeId();
+                        } else if (event instanceof ResizeEvent) {
+                            nodeId =  ((ResizeEvent) event).getNodeId();
+                        }
+                        return nodeId;
+                    })
+                .map(nodeId -> {
+                        return borderNodesLayoutData.stream()
+                                .filter(borderNode -> nodeId.equals(borderNode.getId()))
+                                .findFirst().orElse(null);
+                    });
+
+        // @formatter:on
+        return borderNodeMovedOrResized;
+    }
+
+    public List<NodeLayoutData> getBorderNodesToCreate(List<NodeLayoutData> borderNodesLayoutData) {
+        List<NodeLayoutData> newBorderNodes = borderNodesLayoutData.stream().filter(this::isNewBorderNode).collect(Collectors.toList());
+        return newBorderNodes;
+    }
+
+    private boolean isNewBorderNode(NodeLayoutData borderNode) {
+        return UNDEFINED_POSITION.equals(borderNode.getPosition()) && UNDEFINED_SIZE.equals(borderNode.getSize());
+    }
+
+    /**
+     * Round size to 1/1000 of a pixel. It is needed when an image has a width or height with a very big decimal part
+     * (e.g: 140.0004672837)
+     *
+     * @param size
+     *            the {@link Size} to round.
+     * @return the rounded size.
+     */
+    private Size getRoundedSize(Size size) {
+        BigDecimal roundedWidth = BigDecimal.valueOf(size.getWidth()).setScale(4, RoundingMode.HALF_UP);
+        BigDecimal roundedHeight = BigDecimal.valueOf(size.getHeight()).setScale(4, RoundingMode.HALF_UP);
+        return Size.of(roundedWidth.doubleValue(), roundedHeight.doubleValue());
+    }
+}

--- a/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/provider/BorderNodesOnSide.java
+++ b/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/provider/BorderNodesOnSide.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.components.diagrams.layout.incremental;
+package org.eclipse.sirius.components.diagrams.layout.incremental.provider;
 
 import java.util.List;
 import java.util.Objects;

--- a/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/provider/NodeLabelPositionProvider.java
+++ b/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/provider/NodeLabelPositionProvider.java
@@ -23,7 +23,6 @@ import org.eclipse.elk.core.options.NodeLabelPlacement;
 import org.eclipse.sirius.components.diagrams.NodeType;
 import org.eclipse.sirius.components.diagrams.Position;
 import org.eclipse.sirius.components.diagrams.layout.ISiriusWebLayoutConfigurator;
-import org.eclipse.sirius.components.diagrams.layout.incremental.BorderNodesOnSide;
 import org.eclipse.sirius.components.diagrams.layout.incremental.data.LabelLayoutData;
 import org.eclipse.sirius.components.diagrams.layout.incremental.data.NodeLayoutData;
 import org.eclipse.sirius.components.diagrams.layout.incremental.utils.RectangleSide;

--- a/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/utils/Geometry.java
+++ b/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/utils/Geometry.java
@@ -230,4 +230,18 @@ public final class Geometry {
         return new PointOnRectangleInfo(newBorderNodePosition, currentClosestSide);
     }
 
+    public boolean isOverlapping(Bounds rectangle1, Bounds rectangle2) {
+        boolean isOverlapping = true;
+        Position topRight1 = Position.at(rectangle1.getPosition().getX() + rectangle1.getSize().getWidth(), rectangle1.getPosition().getY());
+        Position bottomLeft1 = Position.at(rectangle1.getPosition().getX(), rectangle1.getPosition().getY() + rectangle1.getSize().getHeight());
+        Position topRight2 = Position.at(rectangle2.getPosition().getX() + rectangle2.getSize().getWidth(), rectangle2.getPosition().getY());
+        Position bottomLeft2 = Position.at(rectangle2.getPosition().getX(), rectangle2.getPosition().getY() + rectangle2.getSize().getHeight());
+        if (topRight1.getY() > bottomLeft2.getY() || bottomLeft1.getY() < topRight2.getY()) {
+            isOverlapping = false;
+        }
+        if (topRight1.getX() < bottomLeft2.getX() || bottomLeft1.getX() > topRight2.getX()) {
+            isOverlapping = false;
+        }
+        return isOverlapping;
+    }
 }

--- a/doc/adrs/049_border_node_overlap_strategy.adoc
+++ b/doc/adrs/049_border_node_overlap_strategy.adoc
@@ -1,0 +1,25 @@
+= ADR-049 - Border nodes overlap strategy
+
+== Context
+
+This adr is about the way the border should behave when
+* being resized/moved
+* the parent container is resized
+* a new border node is created
+
+== Constraint
+
+The chosen constraints come from the Sirius Desktop experience.
+* It should not possible to resize or move a node if it overlaps another node or if it goes outside the side of the parent rectangle
+* resizing the parent node should not impact the absolute position of the border nodes except for those on the shifted sides. This is particularly important if there are edges linked to the border nodes.
+* resizing the parent node should be limited so that the border nodes does not goes oustside the parent node
+
+== Decision
+
+The feedback and the incremental layout should take the constraints into account.
+
+== Status
+
+WIP
+
+== Consequences

--- a/frontend/src/diagram/sprotty/resize/siriusResize.ts
+++ b/frontend/src/diagram/sprotty/resize/siriusResize.ts
@@ -11,8 +11,19 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { decorate, inject } from 'inversify';
-import { Command, CommandExecutionContext, CommandReturn, SModelElement, SNode, SPort, TYPES } from 'sprotty';
-import { Action, Dimension, Point } from 'sprotty-protocol';
+import {
+  Command,
+  CommandExecutionContext,
+  CommandReturn,
+  SModelElement,
+  SNode,
+  SPort,
+  SShapeElement,
+  TYPES,
+} from 'sprotty';
+import { Action, Bounds, Dimension, Point } from 'sprotty-protocol';
+import { snapToRectangle } from '../utils/geometry';
+import { RectangleSide } from '../utils/geometry.types';
 
 export class ResizeAction implements Action {
   kind = SiriusResizeCommand.KIND;
@@ -46,6 +57,36 @@ export class SiriusResizeCommand extends Command {
       let validPositionDelta = positionDelta;
       let validSize = elementResize.newSize;
       let validPosition = elementResize.newPosition;
+
+      // TODO this code is just written and has bugs
+      if (this.isPort(element)) {
+        const parent = element.parent as SShapeElement;
+        const parentWidth: number = parent.bounds.width;
+        const parentHeight: number = parent.bounds.height;
+
+        const currentSPortCenter: Point = Bounds.center(element.bounds);
+        const { side } = snapToRectangle(currentSPortCenter, {
+          x: 0, // because newSportPosition has coordinates relative to parent
+          y: 0,
+          width: parentWidth,
+          height: parentHeight,
+        });
+        if (side === RectangleSide.east || side === RectangleSide.west) {
+          if (validPosition.y + validSize.height > parentHeight) {
+            validSize = { width: validPosition.x, height: parentHeight - validPosition.y };
+          } else if (validPosition.y < 0) {
+            validPosition = { x: validPosition.x, y: 0 };
+            validSize = { width: validSize.width, height: element.bounds.y - element.bounds.height };
+          }
+        } else if (side === RectangleSide.north || side === RectangleSide.south) {
+          if (validPosition.x + validSize.width > parentWidth) {
+            validSize = { width: parentWidth - validPosition.x, height: validSize.height };
+          } else if (validPosition.x < 0) {
+            validPosition = { x: 0, y: validPosition.y };
+            validSize = { width: element.bounds.x - element.bounds.width, height: validSize.height };
+          }
+        }
+      }
 
       if (this.isNode(element)) {
         //If the element size is decreased, we compute a valid size and position to make sure that all children are still within the new bounds.

--- a/frontend/src/diagram/sprotty/siriusDragAndDropMouseListener.ts
+++ b/frontend/src/diagram/sprotty/siriusDragAndDropMouseListener.ts
@@ -158,33 +158,48 @@ export class SiriusDragAndDropMouseListener extends MoveMouseListener {
         y: currentSPortCenter.y + translationPoint.y,
       };
 
-      const { pointOnRectangleSide, side } = snapToRectangle(candidateSPortCenter, {
+      const { pointOnRectangle, side } = snapToRectangle(candidateSPortCenter, {
         x: 0, // because newSportPosition has coordinates relative to parent
         y: 0,
         width: parent.bounds.width,
         height: parent.bounds.height,
       });
 
+      //shift to keep inside the side
+      let adaptedPointOnRectangleX: number = pointOnRectangle.x;
+      let adaptedPointOnRectangleY: number = pointOnRectangle.y;
+      if (side === RectangleSide.north || side === RectangleSide.south) {
+        adaptedPointOnRectangleX = Math.max(
+          Math.min(pointOnRectangle.x, parent.bounds.width - sPort.bounds.width / 2),
+          sPort.bounds.width / 2
+        );
+      } else if (side === RectangleSide.east || side === RectangleSide.west) {
+        adaptedPointOnRectangleY = Math.max(
+          Math.min(pointOnRectangle.y, parent.bounds.height - sPort.bounds.height / 2),
+          sPort.bounds.height / 2
+        );
+      }
+
       // Move the port according to the offset and the side position
       if (side === RectangleSide.north) {
         portPosition = {
-          x: pointOnRectangleSide.x - sPort.bounds.width / 2,
-          y: pointOnRectangleSide.y - sPort.bounds.height + PORT_OFFSET,
+          x: adaptedPointOnRectangleX - sPort.bounds.width / 2,
+          y: adaptedPointOnRectangleY - sPort.bounds.height + PORT_OFFSET,
         };
       } else if (side === RectangleSide.south) {
         portPosition = {
-          x: pointOnRectangleSide.x - sPort.bounds.width / 2,
-          y: pointOnRectangleSide.y - PORT_OFFSET,
+          x: adaptedPointOnRectangleX - sPort.bounds.width / 2,
+          y: adaptedPointOnRectangleY - PORT_OFFSET,
         };
       } else if (side === RectangleSide.west) {
         portPosition = {
-          x: pointOnRectangleSide.x - sPort.bounds.width + PORT_OFFSET,
-          y: pointOnRectangleSide.y - sPort.bounds.height / 2,
+          x: adaptedPointOnRectangleX - sPort.bounds.width + PORT_OFFSET,
+          y: adaptedPointOnRectangleY - sPort.bounds.height / 2,
         };
       } else if (side === RectangleSide.east) {
         portPosition = {
-          x: pointOnRectangleSide.x - PORT_OFFSET,
-          y: pointOnRectangleSide.y - sPort.bounds.height / 2,
+          x: adaptedPointOnRectangleX - PORT_OFFSET,
+          y: adaptedPointOnRectangleY - sPort.bounds.height / 2,
         };
       }
     }

--- a/frontend/src/diagram/sprotty/utils/geometry.ts
+++ b/frontend/src/diagram/sprotty/utils/geometry.ts
@@ -11,7 +11,7 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { Bounds, Point } from 'sprotty-protocol/';
-import { RectangleSide, SnapPointToRectangleInfo, SnapToRectangleInfo } from './geometry.types';
+import { PointOnRectangleInfo, RectangleSide, SnapPointToRectangleInfo } from './geometry.types';
 
 /**
  * Returns the distance between the point p and the segment made of p1 and p2
@@ -54,7 +54,7 @@ export const closestPointOnSegment = (p: Point, p1: Point, p2: Point): Point => 
 /**
  * Returns a point on the rectangle that is the closest from the given p point.
  */
-export const snapToRectangle = (point: Point, rectangle: Bounds): SnapToRectangleInfo => {
+export const snapToRectangle = (point: Point, rectangle: Bounds): PointOnRectangleInfo => {
   const upperLeftCorner: Point = { x: rectangle.x, y: rectangle.y };
   const upperRightCorner: Point = { x: rectangle.x + rectangle.width, y: rectangle.y };
   const bottomLeftCorner: Point = { x: rectangle.x, y: rectangle.y + rectangle.height };
@@ -83,7 +83,7 @@ export const snapToRectangle = (point: Point, rectangle: Bounds): SnapToRectangl
     RectangleSide.west
   );
 
-  return { pointOnRectangleSide: closestPointInfo.pointOnSegment, side: closestPointInfo.side };
+  return { pointOnRectangle: closestPointInfo.pointOnSegment, side: closestPointInfo.side };
 };
 
 const computeClosestPoint = (

--- a/frontend/src/diagram/sprotty/utils/geometry.types.ts
+++ b/frontend/src/diagram/sprotty/utils/geometry.types.ts
@@ -18,8 +18,8 @@ export enum RectangleSide {
   'west',
   'east',
 }
-export interface SnapToRectangleInfo {
-  pointOnRectangleSide: Point;
+export interface PointOnRectangleInfo {
+  pointOnRectangle: Point;
   side: RectangleSide;
 }
 


### PR DESCRIPTION
Is is still under worked.

What is done on Back-end:
* the border creation is implemented and it lacks the parent resize when
there is no space for the new border node
* the parent resize is implemented
* a just written and not tested code when resizing the border node
* a code that cancel the move of the border node is there is overlap ->
we could enhance this code to adapt the position instead of canceling
the move

Front-end
* code to avoid that the node goes outside the container
* a not written and not tested code when resizing the border node
Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [X] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

See adr

### What does this PR do?

See adr

