### PR TITLE
[1282] Let users switch form description editors properly

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,6 +30,9 @@ https://github.com/eclipse-sirius/sirius-components/issues/1231[#1231] [diagram]
 - [backend] Switch to https://github.com/spring-projects/spring-boot/releases/tag/v2.7.2[Spring Boot 2.7.2]
 - [backend] Switch to the managed version of GraphQL Java, as of Spring Boot 2.7.2, we will thus use GraphQL Java 18.2
 
+=== Bug fixes
+
+- https://github.com/eclipse-sirius/sirius-components/issues/1282[#1282] [form] Let users switch form description editors properly
 
 === Improvements
 

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/FormDescriptionEditorRepresentation.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/FormDescriptionEditorRepresentation.tsx
@@ -57,10 +57,12 @@ import {
   InitializeRepresentationEvent,
   SchemaValue,
   ShowToastEvent,
+  SwitchFormDescriptionEditorEvent,
 } from './FormDescriptionEditorRepresentationMachine';
 import { WidgetEntry } from './WidgetEntry';
 import ViewColumnIcon from '@material-ui/icons/ViewColumn';
 import { isKind } from './WidgetOperations';
+
 const isErrorPayload = (payload: GQLAddWidgetPayload | GQLMoveWidgetPayload): payload is GQLErrorPayload =>
   payload.__typename === 'ErrorPayload';
 
@@ -128,10 +130,10 @@ const useFormDescriptionEditorStyles = makeStyles((theme) => ({
     height: theme.spacing(3),
   },
   noFormDescriptionEditor: {
+    flexGrow: 1,
     display: 'flex',
-    flexDirection: 'column',
     alignItems: 'center',
-    justifyItems: 'center',
+    justifyContent: 'center',
   },
 }));
 
@@ -148,7 +150,7 @@ export const FormDescriptionEditorRepresentation = ({
     FormDescriptionEditorRepresentationEvent
   >(formDescriptionEditorRepresentationMachine);
   const { toast, formDescriptionEditorRepresentation } = value as SchemaValue;
-  const { id, formDescriptionEditor, subscribers, message } = context;
+  const { id, formDescriptionEditorId, formDescriptionEditor, subscribers, message } = context;
 
   const input: GQLFormDescriptionEditorEventInput = {
     id,
@@ -221,6 +223,19 @@ export const FormDescriptionEditorRepresentation = ({
       }
     }
   }, [moveWidgetLoading, moveWidgetData, moveWidgetError, dispatch]);
+
+  /**
+   * Displays another form description editor if the selection indicates that we should display another representation.
+   */
+  useEffect(() => {
+    if (formDescriptionEditorId !== representationId) {
+      const switchFormDescriptionEditorEvent: SwitchFormDescriptionEditorEvent = {
+        type: 'SWITCH_FORM_DESCRIPTION_EDITOR',
+        formDescriptionEditorId: representationId,
+      };
+      dispatch(switchFormDescriptionEditorEvent);
+    }
+  }, [representationId, formDescriptionEditorId, dispatch]);
 
   useEffect(() => {
     if (error) {
@@ -451,7 +466,7 @@ export const FormDescriptionEditorRepresentation = ({
 
   if (formDescriptionEditorRepresentation === 'complete') {
     content = (
-      <div className={classes.main + ' ' + classes.noFormDescriptionEditor}>
+      <div className={classes.noFormDescriptionEditor}>
         <Typography variant="h5" align="center" data-testid="FormDescriptionEditor-complete-message">
           The form description editor does not exist
         </Typography>

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/FormDescriptionEditorRepresentationMachine.ts
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/FormDescriptionEditorRepresentationMachine.ts
@@ -48,12 +48,17 @@ export type SchemaValue = {
 
 export interface FormDescriptionEditorRepresentationContext {
   id: string;
+  formDescriptionEditorId: string;
   formDescriptionEditor: GQLFormDescriptionEditor;
   subscribers: Subscriber[];
   message: string | null;
 }
 export type ShowToastEvent = { type: 'SHOW_TOAST'; message: string };
 export type HideToastEvent = { type: 'HIDE_TOAST' };
+export type SwitchFormDescriptionEditorEvent = {
+  type: 'SWITCH_FORM_DESCRIPTION_EDITOR';
+  formDescriptionEditorId: string;
+};
 export type HandleSubscriptionResultEvent = {
   type: 'HANDLE_SUBSCRIPTION_RESULT';
   result: SubscriptionResult<GQLFormDescriptionEditorEventSubscription>;
@@ -67,6 +72,7 @@ export type InitializeRepresentationEvent = {
 export type FormDescriptionEditorRepresentationEvent =
   | ShowToastEvent
   | HideToastEvent
+  | SwitchFormDescriptionEditorEvent
   | CompleteEvent
   | InitializeRepresentationEvent
   | HandleSubscriptionResultEvent;
@@ -88,6 +94,7 @@ export const formDescriptionEditorRepresentationMachine = Machine<
     type: 'parallel',
     context: {
       id: uuid(),
+      formDescriptionEditorId: null,
       formDescriptionEditor: null,
       subscribers: [],
       message: null,
@@ -130,6 +137,12 @@ export const formDescriptionEditorRepresentationMachine = Machine<
           },
           ready: {
             on: {
+              SWITCH_FORM_DESCRIPTION_EDITOR: [
+                {
+                  target: 'loading',
+                  actions: 'switchFormDescriptionEditor',
+                },
+              ],
               HANDLE_SUBSCRIPTION_RESULT: [
                 {
                   actions: 'handleSubscriptionResult',
@@ -143,7 +156,16 @@ export const formDescriptionEditorRepresentationMachine = Machine<
               ],
             },
           },
-          complete: {},
+          complete: {
+            on: {
+              SWITCH_FORM_DESCRIPTION_EDITOR: [
+                {
+                  target: 'loading',
+                  actions: 'switchFormDescriptionEditor',
+                },
+              ],
+            },
+          },
         },
       },
     },
@@ -154,6 +176,10 @@ export const formDescriptionEditorRepresentationMachine = Machine<
         return {
           message: undefined,
         };
+      }),
+      switchFormDescriptionEditor: assign((_, event) => {
+        const { formDescriptionEditorId } = event as SwitchFormDescriptionEditorEvent;
+        return { id: uuid(), formDescriptionEditorId };
       }),
       handleComplete: assign((_) => {
         return {};


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1282
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?