### PR TITLE
[1297] An edge without label does not have its layout calculated again

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,21 @@
 = Changelog
 
+== v2022.11.0 (unrelease)
+
+=== Architectural decision records
+
+=== Breaking changes
+
+=== Dependency update
+
+=== Bug fixes
+
+- https://github.com/eclipse-sirius/sirius-components/issues/1297[#1297] [layout] Fix flying edges when they have no label
+
+=== Improvements
+
+=== New Features
+
 == v2022.9.0
 
 === Architectural decision records

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/IncrementalLayoutEngine.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/IncrementalLayoutEngine.java
@@ -100,9 +100,18 @@ public class IncrementalLayoutEngine {
 
         // finally we recompute the edges that needs to
         for (EdgeLayoutData edge : diagram.getEdges()) {
-            if (this.hasChanged(edge.getSource()) || this.hasChanged(edge.getTarget()) || !this.isLabelPositioned(edge) || !this.isEdgePositioned(edge)) {
+            if (this.hasChanged(edge.getSource()) || this.hasChanged(edge.getTarget()) || !this.isEdgePositioned(edge)) {
                 this.layoutEdge(optionalDiagramElementEvent, edge);
             }
+            if (this.shouldLayoutEdgeLabel(edge)) {
+                this.layoutEdgeLabel(edge);
+            }
+        }
+    }
+
+    private void layoutEdgeLabel(EdgeLayoutData edge) {
+        if (edge.getCenterLabel() != null) {
+            edge.getCenterLabel().setPosition(this.edgeLabelPositionProvider.getCenterPosition(edge, edge.getCenterLabel()));
         }
     }
 
@@ -112,13 +121,14 @@ public class IncrementalLayoutEngine {
      * This can be removed when we will consider all diagram should have been migrated
      */
     private boolean isEdgePositioned(EdgeLayoutData edge) {
-        return edge.getSourceAnchorRelativePosition() != null && edge.getTargetAnchorRelativePosition() != null;
+        return edge.getSourceAnchorRelativePosition() != null && edge.getTargetAnchorRelativePosition() != null && !edge.getSourceAnchorRelativePosition().equals(Ratio.UNDEFINED)
+                && !edge.getTargetAnchorRelativePosition().equals(Ratio.UNDEFINED);
     }
 
-    private boolean isLabelPositioned(EdgeLayoutData edge) {
+    private boolean shouldLayoutEdgeLabel(EdgeLayoutData edge) {
         if (edge.getCenterLabel() != null) {
             Position position = edge.getCenterLabel().getPosition();
-            return position.getX() != -1 || position.getY() != -1;
+            return position.getX() == -1 && position.getY() == -1;
         }
         return false;
     }
@@ -376,11 +386,6 @@ public class IncrementalLayoutEngine {
 
         // recompute the edge routing points
         edge.setRoutingPoints(this.edgeRoutingPointsProvider.getRoutingPoints(edge));
-
-        // recompute edge labels
-        if (edge.getCenterLabel() != null) {
-            edge.getCenterLabel().setPosition(this.edgeLabelPositionProvider.getCenterPosition(edge, edge.getCenterLabel()));
-        }
     }
 
     /**

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/TestLayoutDiagramBuilder.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/TestLayoutDiagramBuilder.java
@@ -74,6 +74,12 @@ public final class TestLayoutDiagramBuilder {
         return edgeBuilder;
     }
 
+    public EdgeBuilder edge() {
+        EdgeBuilder edgeBuilder = new EdgeBuilder(this, this.edgeIdPrefixToCount);
+        this.edgeBuilders.add(edgeBuilder);
+        return edgeBuilder;
+    }
+
     public Diagram build() {
         Map<String, String> targetObjectIdToNodeId = new HashMap<>();
         List<Node> nodes = this.nodesBuilder.build(targetObjectIdToNodeId);

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/edge/EdgeBuilder.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/edge/EdgeBuilder.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.eclipse.sirius.components.diagrams.ArrowStyle;
@@ -37,7 +38,7 @@ import org.eclipse.sirius.components.diagrams.tests.builder.label.LabelBuilder;
 public final class EdgeBuilder {
     private TestLayoutDiagramBuilder diagramBuilder;
 
-    private Label centerLabel;
+    private Optional<Label> centerLabel;
 
     private EdgeEndBuilder sourceEdgeBuilder;
 
@@ -49,7 +50,13 @@ public final class EdgeBuilder {
 
     public EdgeBuilder(TestLayoutDiagramBuilder diagramBuilder, String edgeCenterLabel, Map<String, Integer> edgeIdPrefixToCount) {
         this.diagramBuilder = Objects.requireNonNull(diagramBuilder);
-        this.centerLabel = new LabelBuilder().basicLabel(edgeCenterLabel, LabelType.EDGE_CENTER);
+        this.centerLabel = Optional.of(new LabelBuilder().basicLabel(edgeCenterLabel, LabelType.EDGE_CENTER));
+        this.edgeIdPrefixToCount = edgeIdPrefixToCount;
+    }
+
+    public EdgeBuilder(TestLayoutDiagramBuilder diagramBuilder, Map<String, Integer> edgeIdPrefixToCount) {
+        this.diagramBuilder = Objects.requireNonNull(diagramBuilder);
+        this.centerLabel = Optional.empty();
         this.edgeIdPrefixToCount = edgeIdPrefixToCount;
     }
 
@@ -111,14 +118,14 @@ public final class EdgeBuilder {
                 .sourceAnchorRelativePosition(sourceEdgeEnd.getEndRatio())
                 .targetAnchorRelativePosition(targetEdgeEnd.getEndRatio())
                 .beginLabel(null)
-                .centerLabel(this.centerLabel)
+                .centerLabel(this.centerLabel.orElse(null))
                 .endLabel(null)
                 .descriptionId(TestLayoutDiagramBuilder.EDGE_DESCRIPTION_ID)
                 .routingPoints(this.routingPoints)
                 .style(edgeStyle)
                 .targetObjectId(sourceEdgeEnd.getEndId())
                 .targetObjectKind("") //$NON-NLS-1$
-                .targetObjectLabel(this.centerLabel.getText())
+                .targetObjectLabel(this.centerLabel.map(Label::getText).orElse("")) //$NON-NLS-1$
                 .build();
         // @formatter:on
     }


### PR DESCRIPTION
# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [x] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?

1. Import the project [Broken Egde Studio.zip](https://github.com/eclipse-sirius/sirius-components/files/9027734/Broken.Egde.Studio.zip)
2. Create a project, a model, and the root entity based on the `brokenEdge` domain
3. Create a new diagram based on the `Broken Edge Description`
4. Create three entities
5. Create an edge between two of them
6. Create another edge between two different entities
7. Try to move each entity separately

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?