### PR TITLE
[1375] Resize the node to always display the full label

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/1368[#1368] [diagram] Do not render rectangle view children twice
 - https://github.com/eclipse-sirius/sirius-components/issues/931[#931] [layout] When the delete tool of an edge is used, the position of other edges are not affected.
 - https://github.com/eclipse-sirius/sirius-components/issues/1392[#1392] [core] Fix EditingContextCrossReferenceAdapter for derived references
+- https://github.com/eclipse-sirius/sirius-components/issues/1375[#1375] [diagram] Resize the node to always display the full label
 
 === Improvements
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components-parent",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components-parent",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0",
       "workspaces": [
         "./packages/*/frontend/*"
@@ -4564,7 +4564,7 @@
     },
     "packages/charts/frontend/sirius-components-charts": {
       "name": "@eclipse-sirius/sirius-components-charts",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0",
       "devDependencies": {
         "@eclipse-sirius/sirius-components-tsconfig": "~2022.9.0",
@@ -4584,7 +4584,7 @@
     },
     "packages/core/frontend/sirius-components-core": {
       "name": "@eclipse-sirius/sirius-components-core",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.6.9",
@@ -4619,7 +4619,7 @@
     },
     "packages/diagrams/frontend/sirius-components-diagrams": {
       "name": "@eclipse-sirius/sirius-components-diagrams",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.6.9",
@@ -4663,7 +4663,7 @@
     },
     "packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors": {
       "name": "@eclipse-sirius/sirius-components-formdescriptioneditors",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.6.9",
@@ -4705,7 +4705,7 @@
     },
     "packages/forms/frontend/sirius-components-forms": {
       "name": "@eclipse-sirius/sirius-components-forms",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.6.9",
@@ -4752,12 +4752,12 @@
     },
     "packages/releng/frontend/sirius-components-tsconfig": {
       "name": "@eclipse-sirius/sirius-components-tsconfig",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0"
     },
     "packages/selection/frontend/sirius-components-selection": {
       "name": "@eclipse-sirius/sirius-components-selection",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.6.9",
@@ -4791,7 +4791,7 @@
     },
     "packages/trees/frontend/sirius-components-trees": {
       "name": "@eclipse-sirius/sirius-components-trees",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.6.9",
@@ -4828,7 +4828,7 @@
     },
     "packages/validation/frontend/sirius-components-validation": {
       "name": "@eclipse-sirius/sirius-components-validation",
-      "version": "2022.9.2",
+      "version": "2022.9.3",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.6.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-parent",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/charts/backend/pom.xml
+++ b/packages/charts/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-charts-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-charts-parent</name>
 	<description>Sirius Components Charts Parent</description>

--- a/packages/charts/backend/sirius-components-charts/pom.xml
+++ b/packages/charts/backend/sirius-components-charts/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-charts</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-charts</name>
 	<description>Sirius Components Charts</description>
 
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/charts/backend/sirius-components-collaborative-charts/pom.xml
+++ b/packages/charts/backend/sirius-components-collaborative-charts/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-charts</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-collaborative-charts</name>
 	<description>Sirius Components Collaborative Charts</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/charts/frontend/sirius-components-charts/package.json
+++ b/packages/charts/frontend/sirius-components-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-charts",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/compatibility/backend/pom.xml
+++ b/packages/compatibility/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-compatibility-parent</name>
 	<description>Sirius Components Compatibility Parent</description>

--- a/packages/compatibility/backend/sirius-components-compatibility-emf/pom.xml
+++ b/packages/compatibility/backend/sirius-components-compatibility-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility-emf</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-compatibility-emf</name>
 	<description>Sirius Components Compatibility EMF</description>
 
@@ -58,22 +58,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -83,19 +83,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/compatibility/backend/sirius-components-compatibility/pom.xml
+++ b/packages/compatibility/backend/sirius-components-compatibility/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-compatibility</name>
 	<description>Sirius Components Compatibility</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -74,43 +74,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/packages/core/backend/pom.xml
+++ b/packages/core/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-core-parent</name>
 	<description>Sirius Components Core Parent</description>

--- a/packages/core/backend/sirius-components-annotations-spring/pom.xml
+++ b/packages/core/backend/sirius-components-annotations-spring/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations-spring</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-annotations-spring</name>
 	<description>Sirius Components Annotations Spring</description>
 

--- a/packages/core/backend/sirius-components-annotations/pom.xml
+++ b/packages/core/backend/sirius-components-annotations/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-annotations</name>
 	<description>Sirius Components Annotations</description>
 

--- a/packages/core/backend/sirius-components-collaborative/pom.xml
+++ b/packages/core/backend/sirius-components-collaborative/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-collaborative</name>
 	<description>Sirius Components Collaborative</description>
 
@@ -67,23 +67,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/core/backend/sirius-components-core/pom.xml
+++ b/packages/core/backend/sirius-components-core/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-core</name>
 	<description>Sirius Components Core</description>
 
@@ -52,17 +52,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/core/backend/sirius-components-graphql-api/pom.xml
+++ b/packages/core/backend/sirius-components-graphql-api/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-api</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-graphql-api</name>
 	<description>Sirius Components GraphQL API</description>
 
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/core/backend/sirius-components-representations/pom.xml
+++ b/packages/core/backend/sirius-components-representations/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-representations</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-representations</name>
 	<description>Sirius Components Representations</description>
 
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/core/frontend/sirius-components-core/package.json
+++ b/packages/core/frontend/sirius-components-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-core",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/diagrams/backend/pom.xml
+++ b/packages/diagrams/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-diagrams-parent</name>
 	<description>Sirius Components Diagrams Parent</description>

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/pom.xml
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-diagrams</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-collaborative-diagrams</name>
 	<description>Sirius Components Collaborative Diagrams</description>
 
@@ -51,34 +51,34 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-graphql</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-diagrams-graphql</name>
 	<description>Sirius Components Diagrams GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/diagrams/backend/sirius-components-diagrams-layout-api/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout-api/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout-api</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-diagrams-layout-api</name>
 	<description>Sirius Components Diagrams Layout API</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-diagrams-layout</name>
 	<description>Sirius Components Diagrams layout</description>
 
@@ -66,17 +66,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -128,18 +128,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/updater/ContainmentUpdater.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/updater/ContainmentUpdater.java
@@ -86,15 +86,27 @@ public class ContainmentUpdater {
 
     private boolean shouldUpdate(IContainerLayoutData container) {
         boolean shouldUpdate = true;
+        boolean isLabelContained = this.isLabelContained(container);
+        if (!(isLabelContained && this.isLabelLargerThanNode(container))) {
+            if (container instanceof NodeLayoutData) {
+                NodeLayoutData nodeLayoutData = (NodeLayoutData) container;
+                shouldUpdate = !(nodeLayoutData.isResizedByUser() && this.hasEveryChildWithinItsBounds(nodeLayoutData));
+            }
 
-        if (container instanceof NodeLayoutData) {
-            NodeLayoutData nodeLayoutData = (NodeLayoutData) container;
-            shouldUpdate = !(nodeLayoutData.isResizedByUser() && this.hasEveryChildWithinItsBounds(nodeLayoutData));
+            shouldUpdate = shouldUpdate && (!container.getChildrenNodes().isEmpty() || isLabelContained);
         }
 
-        shouldUpdate = shouldUpdate && (!container.getChildrenNodes().isEmpty() || this.isLabelContained(container));
-
         return shouldUpdate;
+    }
+
+    private boolean isLabelLargerThanNode(IContainerLayoutData container) {
+        if (container instanceof NodeLayoutData) {
+            NodeLayoutData nodeLayoutData = (NodeLayoutData) container;
+            double labelWidth = nodeLayoutData.getLabel().getTextBounds().getSize().getWidth() + DEFAULT_NODE_LABELS_PADDING;
+            double nodeWidth = nodeLayoutData.getSize().getWidth();
+            return labelWidth > nodeWidth;
+        }
+        return false;
     }
 
     private boolean hasEveryChildWithinItsBounds(NodeLayoutData nodeLayoutData) {

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-tests</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-diagrams-tests</name>
 	<description>Sirius Components Diagrams Tests</description>
 
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/packages/diagrams/backend/sirius-components-diagrams/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-diagrams</name>
 	<description>Sirius Components Diagrams</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/diagrams/frontend/sirius-components-diagrams/package.json
+++ b/packages/diagrams/frontend/sirius-components-diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-diagrams",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/domain/backend/pom.xml
+++ b/packages/domain/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-domain-parent</name>
 	<description>Sirius Components Domain Parent</description>

--- a/packages/domain/backend/sirius-components-domain-design/pom.xml
+++ b/packages/domain/backend/sirius-components-domain-design/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-design</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-domain-design</name>
 	<description>Sirius Components Domain Definition DSL - Graphical Modeler Definition</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/domain/backend/sirius-components-domain-edit/pom.xml
+++ b/packages/domain/backend/sirius-components-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-edit</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-domain-edit</name>
 	<description>Sirius Components Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/domain/backend/sirius-components-domain-emf/pom.xml
+++ b/packages/domain/backend/sirius-components-domain-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-emf</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-domain-emf</name>
 	<description>Sirius Components Domain EMF</description>
 
@@ -54,12 +54,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -69,13 +69,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/domain/backend/sirius-components-domain/pom.xml
+++ b/packages/domain/backend/sirius-components-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-domain</name>
 	<description>Sirius Components Domain Definition DSL</description>
 

--- a/packages/emf/backend/pom.xml
+++ b/packages/emf/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-emf-parent</name>
 	<description>Sirius Components EMF Parent</description>

--- a/packages/emf/backend/sirius-components-emf/pom.xml
+++ b/packages/emf/backend/sirius-components-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-emf</name>
 	<description>Sirius Components EMF</description>
 
@@ -58,17 +58,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -117,19 +117,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/emf/backend/sirius-components-interpreter/pom.xml
+++ b/packages/emf/backend/sirius-components-interpreter/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-interpreter</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-interpreter</name>
 	<description>Sirius Components Intepreter</description>
 

--- a/packages/formdescriptioneditors/backend/pom.xml
+++ b/packages/formdescriptioneditors/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-formdescriptioneditors-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-formdescriptioneditors-parent</name>
 	<description>Sirius Components FormDescription Editors Parent</description>

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-collaborative-formdescriptioneditors</name>
 	<description>Sirius Components Collaborative FormDescriptionEditors</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors-graphql/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-formdescriptioneditors-graphql</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-formdescriptioneditors-graphql</name>
 	<description>Sirius Components FormDescription Editors GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-formdescriptioneditors</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-formdescriptioneditors</name>
 	<description>Sirius Components FormDescriptionEditors</description>
 
@@ -47,22 +47,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/package.json
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-formdescriptioneditors",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/forms/backend/pom.xml
+++ b/packages/forms/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-forms-parent</name>
 	<description>Sirius Components Forms Parent</description>

--- a/packages/forms/backend/sirius-components-collaborative-forms/pom.xml
+++ b/packages/forms/backend/sirius-components-collaborative-forms/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-forms</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-collaborative-forms</name>
 	<description>Sirius Components Collaborative Forms</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/backend/sirius-components-forms-graphql/pom.xml
+++ b/packages/forms/backend/sirius-components-forms-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-graphql</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-forms-graphql</name>
 	<description>Sirius Components Forms GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/backend/sirius-components-forms-tests/pom.xml
+++ b/packages/forms/backend/sirius-components-forms-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-tests</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-forms-tests</name>
 	<description>Sirius Components Forms Tests</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/packages/forms/backend/sirius-components-forms/pom.xml
+++ b/packages/forms/backend/sirius-components-forms/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-forms</name>
 	<description>Sirius Components Forms</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/frontend/sirius-components-forms/package.json
+++ b/packages/forms/frontend/sirius-components-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-forms",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/pom.xml
+++ b/packages/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/packages/releng/backend/pom.xml
+++ b/packages/releng/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-releng-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-releng-parent</name>
 	<description>Sirius Components Releng Parent</description>

--- a/packages/releng/backend/sirius-components-test-coverage/pom.xml
+++ b/packages/releng/backend/sirius-components-test-coverage/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-test-coverage</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-test-coverage-aggregation</name>
 	<description>Sirius Components Test Coverage Aggregation</description>
 
@@ -43,232 +43,232 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-design</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-charts</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-persistence</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-graphql-schema</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-sample-application</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/releng/frontend/sirius-components-tsconfig/package.json
+++ b/packages/releng/frontend/sirius-components-tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-tsconfig",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/selection/backend/pom.xml
+++ b/packages/selection/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-selection-parent</name>
 	<description>Sirius Components Selection Parent</description>

--- a/packages/selection/backend/sirius-components-collaborative-selection/pom.xml
+++ b/packages/selection/backend/sirius-components-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-selection</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-collaborative-selection</name>
 	<description>Sirius Components Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,18 +56,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/selection/backend/sirius-components-selection-graphql/pom.xml
+++ b/packages/selection/backend/sirius-components-selection-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection-graphql</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-selection-graphql</name>
 	<description>Sirius Components Selection GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/selection/backend/sirius-components-selection/pom.xml
+++ b/packages/selection/backend/sirius-components-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-selection</name>
 	<description>Sirius Components Selection</description>
 
@@ -43,17 +43,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/selection/frontend/sirius-components-selection/package.json
+++ b/packages/selection/frontend/sirius-components-selection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-selection",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/sirius-web/backend/pom.xml
+++ b/packages/sirius-web/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-web-parent</name>
 	<description>Sirius Web Parent</description>

--- a/packages/sirius-web/backend/sirius-web-frontend/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-frontend/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-frontend</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-web-frontend</name>
 	<description>Sirius Web Frontend</description>
 

--- a/packages/sirius-web/backend/sirius-web-graphql-schema/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-graphql-schema/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-graphql-schema</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-web-graphql-schema</name>
 	<description>Sirius Web GraphQL Schema</description>
 
@@ -47,32 +47,32 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -82,13 +82,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/sirius-web/backend/sirius-web-graphql/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-graphql</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-web-graphql</name>
 	<description>Sirius Web GraphQL</description>
 
@@ -43,62 +43,62 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-graphql-schema</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -108,13 +108,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/sirius-web/backend/sirius-web-persistence/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-persistence/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-persistence</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-web-persistence</name>
 	<description>Sirius Web Persistence</description>
 
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -70,13 +70,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/sirius-web/backend/sirius-web-sample-application/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-sample-application/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-sample-application</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-web-sample-application</name>
 	<description>Sirius Web Sample Application</description>
 
@@ -96,52 +96,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-starter</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-frontend</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphiql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-voyager</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-design</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.obeo.dsl.designer.sample.flow</groupId>

--- a/packages/sirius-web/backend/sirius-web-services-api/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-services-api/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-services-api</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-web-services-api</name>
 	<description>Sirius Web Services API</description>
 
@@ -47,22 +47,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/sirius-web/backend/sirius-web-services/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-services/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-services</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-web-services</name>
 	<description>Sirius Web Services</description>
 
@@ -51,37 +51,37 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-persistence</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/sirius-web/backend/sirius-web-spring/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-spring/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-spring</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-web-spring</name>
 	<description>Sirius Web Spring</description>
 
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -71,13 +71,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/starters/backend/pom.xml
+++ b/packages/starters/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-starter-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-starter-parent</name>
 	<description>Sirius Components Starter Parent</description>

--- a/packages/starters/backend/sirius-components-starter/pom.xml
+++ b/packages/starters/backend/sirius-components-starter/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-starter</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-starter</name>
 	<description>Sirius Components Starter</description>
 
@@ -63,112 +63,112 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-web</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-charts</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation-graphql</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/tests/backend/pom.xml
+++ b/packages/tests/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-tests-parent</name>
 	<description>Sirius Components Tests Parent</description>

--- a/packages/tests/backend/sirius-components-spring-tests/pom.xml
+++ b/packages/tests/backend/sirius-components-spring-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-spring-tests</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-spring-tests</name>
 	<description>Sirius Components Spring Tests</description>
 
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/packages/tests/backend/sirius-components-tests/pom.xml
+++ b/packages/tests/backend/sirius-components-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-tests</name>
 	<description>Sirius Components Tests</description>
 
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/tools/backend/pom.xml
+++ b/packages/tools/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tools-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-tools-parent</name>
 	<description>Sirius Components Tools Parent</description>

--- a/packages/tools/backend/sirius-components-graphiql/pom.xml
+++ b/packages/tools/backend/sirius-components-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphiql</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-graphiql</name>
 	<description>Sirius Components Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/packages/tools/backend/sirius-components-graphql-voyager/pom.xml
+++ b/packages/tools/backend/sirius-components-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-voyager</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-graphql-voyager</name>
 	<description>Sirius Components Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/packages/trees/backend/pom.xml
+++ b/packages/trees/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-trees-parent</name>
 	<description>Sirius Components Trees Parent</description>

--- a/packages/trees/backend/sirius-components-collaborative-trees/pom.xml
+++ b/packages/trees/backend/sirius-components-collaborative-trees/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-trees</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-collaborative-trees</name>
 	<description>Sirius Components Collaborative Trees</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -65,13 +65,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/trees/backend/sirius-components-trees-graphql/pom.xml
+++ b/packages/trees/backend/sirius-components-trees-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees-graphql</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-trees-graphql</name>
 	<description>Sirius Components Trees GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/trees/backend/sirius-components-trees/pom.xml
+++ b/packages/trees/backend/sirius-components-trees/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-trees</name>
 	<description>Sirius Components Trees</description>
 
@@ -43,17 +43,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/trees/frontend/sirius-components-trees/package.json
+++ b/packages/trees/frontend/sirius-components-trees/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-trees",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/validation/backend/pom.xml
+++ b/packages/validation/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-validation-parent</name>
 	<description>Sirius Components Validation Parent</description>

--- a/packages/validation/backend/sirius-components-collaborative-validation/pom.xml
+++ b/packages/validation/backend/sirius-components-collaborative-validation/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-validation</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-collaborative-validation</name>
 	<description>Sirius Components Collaborative Validation</description>
 
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -62,13 +62,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/validation/backend/sirius-components-validation-graphql/pom.xml
+++ b/packages/validation/backend/sirius-components-validation-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation-graphql</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-validation-graphql</name>
 	<description>Sirius Components Validation GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/validation/backend/sirius-components-validation/pom.xml
+++ b/packages/validation/backend/sirius-components-validation/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-validation</name>
 	<description>Sirius Components Validation</description>
 
@@ -48,12 +48,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/validation/frontend/sirius-components-validation/package.json
+++ b/packages/validation/frontend/sirius-components-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-validation",
-  "version": "2022.9.2",
+  "version": "2022.9.3",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/view/backend/pom.xml
+++ b/packages/view/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-view-parent</name>
 	<description>Sirius Components View Parent</description>

--- a/packages/view/backend/sirius-components-view-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-edit</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-view-edit</name>
 	<description>Sirius Components View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-emf/pom.xml
+++ b/packages/view/backend/sirius-components-view-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-emf</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-view-emf</name>
 	<description>Sirius Components View EMF</description>
 
@@ -54,27 +54,27 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility-emf</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -84,19 +84,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/view/backend/sirius-components-view/pom.xml
+++ b/packages/view/backend/sirius-components-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-view</name>
 	<description>Sirius Components View Definition DSL</description>
 

--- a/packages/web/backend/pom.xml
+++ b/packages/web/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-web-parent</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 
 	<name>sirius-components-web-parent</name>
 	<description>Sirius Components Web Parent</description>

--- a/packages/web/backend/sirius-components-graphql/pom.xml
+++ b/packages/web/backend/sirius-components-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-graphql</name>
 	<description>Sirius Components GraphQL</description>
 
@@ -63,23 +63,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/web/backend/sirius-components-web/pom.xml
+++ b/packages/web/backend/sirius-components-web/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-web</artifactId>
-	<version>2022.9.2</version>
+	<version>2022.9.3</version>
 	<name>sirius-components-web</name>
 	<description>Sirius Components Web</description>
 
@@ -47,18 +47,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.9.2</version>
+			<version>2022.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Even if the node has been manually resized, if the label is an inner label, when the label is changed, the node will have the minimum width to fully display its label.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/1375
Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [X] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?