### PR TITLE
[cleanup] Make ArchUnit more quiet on sirius-components-charts

### DIFF
--- a/packages/charts/backend/sirius-components-charts/.classpath
+++ b/packages/charts/backend/sirius-components-charts/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/packages/charts/backend/sirius-components-charts/src/test/resources/logback-test.xml
+++ b/packages/charts/backend/sirius-components-charts/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>


### PR DESCRIPTION
Configure the `sirius-components-charts` backend module like the rest to avoid excessive `DEBUG` messages from ArchUnit during the build.
