### PR TITLE
[releng] Upgrade to Batik 1.16

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,12 @@
 = Changelog
 
+== v2023.1.0 (unreleased)
+
+=== Dependency update
+
+- [backenđ] Upgrade to Apache Batik 1.16.0 (from 1.14.0)
+
+
 == v2022.11.0
 
 === Architectural decision records
@@ -19,7 +26,7 @@
 
 === Dependency update
 
-- [backend] Switch to EMFJson 2.3.2-SNAPSHOT. It contains better management of proxy resolution in case of intermodel references.
+- [backend] Switch to EMFJson 2.3.2-SNAPSHOT. It contains better management of proxy resolution in case of intermodel references
 
 === Bug fixes
 

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/pom.xml
@@ -145,7 +145,7 @@
 		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>batik-bridge</artifactId>
-			<version>1.14</version>
+			<version>1.16</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Batik 1.15 and 1.16 fix several CVEs. From https://github.com/apache/xmlgraphics-batik/blob/trunk/CHANGES:

```
1.16
----

Java 8 or later is minimum runtime required

BATIK-1338: Block loading jar inside svg
BATIK-1345: Restrict what java classes can be run thru rhino

1.14 -> 1.15
------------

BATIK-1260: Java 11 module error
BATIK-1321: Remove Xerces
BATIK-1299: Batik-all jar has all classes so should not pull other jars also
BATIK-1329: Remove xalan
BATIK-1331: Jar url should be blocked by DefaultExternalResourceSecurity
BATIK-1333: Block external resource before calling fop
BATIK-1335: Jar url should be blocked by DefaultScriptSecurity
```