### PR TITLE
[1482] Allow CustomImageLoader to get images from the bundled projects

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -34,6 +34,10 @@
 - [diagram] When clicking on a node in a diagram, the creation tools list is now always in the same order
 - https://github.com/eclipse-sirius/sirius-components/issues/1485[#1485] [diagram] Select the relevant edge reconnection tools
 
+=== Improvements
+
+- https://github.com/eclipse-sirius/sirius-components/issues/1482[#1482] [core] Allow CustomImageLoader to get images from packaged projects. To import images from local files on startup, set `-Dorg.eclipse.sirius.web.customImages.pattern="file:///local/path/to/folder/with/files/**"`. To import images from a folder inside a packaged JAR, use `-Dorg.eclipse.sirius.web.customImages.pattern="classpath:path/in/jar/**"`. The syntax supports Ant-style path patterns.
+
 === New Features
 
 - https://github.com/eclipse-sirius/sirius-components/issues/1453[#1453] [diagram] Add new arrow styles Circle, FillCircle and CrossedCircle
@@ -44,7 +48,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/1428[#1428] [layout] Add support for List layout compartment. We rely on the layout strategy engine handler switch and the layout engine handler switch to dispatch to the correct behavior depending on how children should be laid out and the type of the node. This kind of architecture has already been implemented for model operation for the View DSL. Nothing has changed if nodes have to be laid out freely.
 - https://github.com/eclipse-sirius/sirius-components/issues/1439[#1439] [form] Add support for toolbar actions in Form/FormDescriptionEditor
 - https://github.com/eclipse-sirius/sirius-components/issues/1437[#1437] [form] Add support for styles preview in FormDescriptionEditor
-- https://github.com/eclipse-sirius/sirius-components/issues/1494[#1494] [form] Add width and height attributes to BarChart
+`- https://github.com/eclipse-sirius/sirius-components/issues/1494[#1494] [form] Add width and height attributes to BarChart
 - https://github.com/eclipse-sirius/sirius-components/issues/1510[#1510] [form] Add support for multi-groups in Form/FormDescriptionEditor
 - https://github.com/eclipse-sirius/sirius-components/issues/1504[#1504] [releng] Add Cypress-based integration tests
 - https://github.com/eclipse-sirius/sirius-components/issues/1446[#1446] [diagram] Add support for hidden and faded edges


### PR DESCRIPTION
A spring property is used instead of a system property to get the path from which find the images.

https://github.com/eclipse-sirius/sirius-components/issues/1482
Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] Improvement
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [X] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?