### PR TITLE
[1346] Change the Save icon for rich text editor

### DIFF
--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/RichTextWidget.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/RichTextWidget.tsx
@@ -20,7 +20,7 @@ import FormatItalicIcon from '@material-ui/icons/FormatItalic';
 import FormatListBulletedIcon from '@material-ui/icons/FormatListBulleted';
 import FormatListNumberedIcon from '@material-ui/icons/FormatListNumbered';
 import FormatUnderlinedIcon from '@material-ui/icons/FormatUnderlined';
-import SaveAltIcon from '@material-ui/icons/SaveAlt';
+import SaveIcon from '@material-ui/icons/Save';
 import StrikethroughSIcon from '@material-ui/icons/StrikethroughS';
 import SubjectIcon from '@material-ui/icons/Subject';
 import TitleIcon from '@material-ui/icons/Title';
@@ -46,7 +46,14 @@ const useStyles = makeStyles((theme) => ({
   },
   paper: {
     display: 'flex',
-    border: `1px solid ${theme.palette.divider}`,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    flexWrap: 'wrap',
+  },
+  formattingActions: {
+    display: 'flex',
+    flexDirection: 'row',
     flexWrap: 'wrap',
   },
   divider: {
@@ -96,63 +103,67 @@ export const RichTextWidget = ({ widget, selection }: RichTextWidgetProps) => {
       </Typography>
       <div onFocus={() => setSelected(true)} onBlur={() => setSelected(false)} ref={ref} tabIndex={0}>
         <Paper elevation={0} className={classes.paper}>
+          <div className={classes.formattingActions}>
+            <StyledToggleButtonGroup size="small">
+              <ToggleButton
+                classes={{ root: classes.button }}
+                selected
+                disabled={false}
+                value={'paragraph'}
+                key={'paragraph'}>
+                <SubjectIcon fontSize="small" />
+              </ToggleButton>
+              <ToggleButton
+                classes={{ root: classes.button }}
+                selected={false}
+                disabled={false}
+                value={'header1'}
+                key={'header1'}>
+                <TitleIcon fontSize="small" />
+              </ToggleButton>
+              <ToggleButton
+                classes={{ root: classes.button }}
+                selected={false}
+                disabled={false}
+                value={'bullet-list'}
+                key={'bullet-list'}>
+                <FormatListBulletedIcon fontSize="small" />
+              </ToggleButton>
+              <ToggleButton
+                classes={{ root: classes.button }}
+                selected={false}
+                disabled={false}
+                value={'number-list'}
+                key={'number-list'}>
+                <FormatListNumberedIcon fontSize="small" />
+              </ToggleButton>
+            </StyledToggleButtonGroup>
+            <Divider flexItem orientation="vertical" className={classes.divider} />
+            <StyledToggleButtonGroup size="small">
+              <ToggleButton classes={{ root: classes.button }} disabled={false} value={'bold'} key={'bold'}>
+                <FormatBoldIcon fontSize="small" />
+              </ToggleButton>
+              <ToggleButton classes={{ root: classes.button }} value={'italic'} key={'italic'}>
+                <FormatItalicIcon fontSize="small" />
+              </ToggleButton>
+              <ToggleButton classes={{ root: classes.button }} disabled={false} value={'underline'} key={'underline'}>
+                <FormatUnderlinedIcon fontSize="small" />
+              </ToggleButton>
+              <ToggleButton classes={{ root: classes.button }} disabled={false} value={'code'} key={'code'}>
+                <CodeIcon fontSize="small" />
+              </ToggleButton>
+              <ToggleButton
+                classes={{ root: classes.button }}
+                disabled={false}
+                value={'strikethrough'}
+                key={'strikethrough'}>
+                <StrikethroughSIcon fontSize="small" />
+              </ToggleButton>
+            </StyledToggleButtonGroup>
+          </div>
           <StyledToggleButtonGroup size="small">
-            <ToggleButton
-              classes={{ root: classes.button }}
-              selected
-              disabled={false}
-              value={'paragraph'}
-              key={'paragraph'}>
-              <SubjectIcon fontSize="small" />
-            </ToggleButton>
-            <ToggleButton
-              classes={{ root: classes.button }}
-              selected={false}
-              disabled={false}
-              value={'header1'}
-              key={'header1'}>
-              <TitleIcon fontSize="small" />
-            </ToggleButton>
-            <ToggleButton
-              classes={{ root: classes.button }}
-              selected={false}
-              disabled={false}
-              value={'bullet-list'}
-              key={'bullet-list'}>
-              <FormatListBulletedIcon fontSize="small" />
-            </ToggleButton>
-            <ToggleButton
-              classes={{ root: classes.button }}
-              selected={false}
-              disabled={false}
-              value={'number-list'}
-              key={'number-list'}>
-              <FormatListNumberedIcon fontSize="small" />
-            </ToggleButton>
-          </StyledToggleButtonGroup>
-          <Divider flexItem orientation="vertical" className={classes.divider} />
-          <StyledToggleButtonGroup size="small">
-            <ToggleButton classes={{ root: classes.button }} disabled={false} value={'bold'} key={'bold'}>
-              <FormatBoldIcon fontSize="small" />
-            </ToggleButton>
-            <ToggleButton classes={{ root: classes.button }} value={'italic'} key={'italic'}>
-              <FormatItalicIcon fontSize="small" />
-            </ToggleButton>
-            <ToggleButton classes={{ root: classes.button }} disabled={false} value={'underline'} key={'underline'}>
-              <FormatUnderlinedIcon fontSize="small" />
-            </ToggleButton>
-            <ToggleButton classes={{ root: classes.button }} disabled={false} value={'code'} key={'code'}>
-              <CodeIcon fontSize="small" />
-            </ToggleButton>
-            <ToggleButton
-              classes={{ root: classes.button }}
-              disabled={false}
-              value={'strikethrough'}
-              key={'strikethrough'}>
-              <StrikethroughSIcon fontSize="small" />
-            </ToggleButton>
             <ToggleButton classes={{ root: classes.button }} disabled={false} value={'save'} key={'save'}>
-              <SaveAltIcon fontSize="small" />
+              <SaveIcon fontSize="small" />
             </ToggleButton>
           </StyledToggleButtonGroup>
         </Paper>

--- a/packages/forms/frontend/sirius-components-forms/src/richtexteditor/ToolbarPlugin.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/richtexteditor/ToolbarPlugin.tsx
@@ -31,7 +31,7 @@ import FormatItalicIcon from '@material-ui/icons/FormatItalic';
 import FormatListBulletedIcon from '@material-ui/icons/FormatListBulleted';
 import FormatListNumberedIcon from '@material-ui/icons/FormatListNumbered';
 import FormatUnderlinedIcon from '@material-ui/icons/FormatUnderlined';
-import SaveAltIcon from '@material-ui/icons/SaveAlt';
+import SaveIcon from '@material-ui/icons/Save';
 import StrikethroughSIcon from '@material-ui/icons/StrikethroughS';
 import SubjectIcon from '@material-ui/icons/Subject';
 import TitleIcon from '@material-ui/icons/Title';
@@ -332,7 +332,7 @@ export const ToolbarPlugin = ({ readOnly, pristine, onEdited, onSave }: ToolbarP
               onSave(markdown);
             });
           }}>
-          <SaveAltIcon fontSize="small" color={pristine ? 'disabled' : 'primary'} />
+          <SaveIcon fontSize="small" color={pristine ? 'disabled' : 'primary'} />
         </ToggleButton>
       </StyledToggleButtonGroup>
     </Paper>


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1346
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?