### PR TITLE
[1346] Auto-save on blur/focus lost

### DIFF
--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/RichTextWidget.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/RichTextWidget.tsx
@@ -19,7 +19,6 @@ import FormatBoldIcon from '@material-ui/icons/FormatBold';
 import FormatItalicIcon from '@material-ui/icons/FormatItalic';
 import FormatListBulletedIcon from '@material-ui/icons/FormatListBulleted';
 import FormatListNumberedIcon from '@material-ui/icons/FormatListNumbered';
-import FormatUnderlinedIcon from '@material-ui/icons/FormatUnderlined';
 import StrikethroughSIcon from '@material-ui/icons/StrikethroughS';
 import SubjectIcon from '@material-ui/icons/Subject';
 import TitleIcon from '@material-ui/icons/Title';
@@ -135,9 +134,6 @@ export const RichTextWidget = ({ widget, selection }: RichTextWidgetProps) => {
             </ToggleButton>
             <ToggleButton classes={{ root: classes.button }} value={'italic'} key={'italic'}>
               <FormatItalicIcon fontSize="small" />
-            </ToggleButton>
-            <ToggleButton classes={{ root: classes.button }} disabled={false} value={'underline'} key={'underline'}>
-              <FormatUnderlinedIcon fontSize="small" />
             </ToggleButton>
             <ToggleButton classes={{ root: classes.button }} disabled={false} value={'code'} key={'code'}>
               <CodeIcon fontSize="small" />

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/RichTextWidget.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/RichTextWidget.tsx
@@ -20,7 +20,6 @@ import FormatItalicIcon from '@material-ui/icons/FormatItalic';
 import FormatListBulletedIcon from '@material-ui/icons/FormatListBulleted';
 import FormatListNumberedIcon from '@material-ui/icons/FormatListNumbered';
 import FormatUnderlinedIcon from '@material-ui/icons/FormatUnderlined';
-import SaveIcon from '@material-ui/icons/Save';
 import StrikethroughSIcon from '@material-ui/icons/StrikethroughS';
 import SubjectIcon from '@material-ui/icons/Subject';
 import TitleIcon from '@material-ui/icons/Title';
@@ -47,13 +46,7 @@ const useStyles = makeStyles((theme) => ({
   paper: {
     display: 'flex',
     flexDirection: 'row',
-    justifyContent: 'space-between',
     borderBottom: `1px solid ${theme.palette.divider}`,
-    flexWrap: 'wrap',
-  },
-  formattingActions: {
-    display: 'flex',
-    flexDirection: 'row',
     flexWrap: 'wrap',
   },
   divider: {
@@ -82,9 +75,7 @@ const StyledToggleButtonGroup = withStyles((theme) => ({
 
 export const RichTextWidget = ({ widget, selection }: RichTextWidgetProps) => {
   const classes = useStyles();
-
   const [selected, setSelected] = useState<boolean>(false);
-
   const ref = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -103,67 +94,60 @@ export const RichTextWidget = ({ widget, selection }: RichTextWidgetProps) => {
       </Typography>
       <div onFocus={() => setSelected(true)} onBlur={() => setSelected(false)} ref={ref} tabIndex={0}>
         <Paper elevation={0} className={classes.paper}>
-          <div className={classes.formattingActions}>
-            <StyledToggleButtonGroup size="small">
-              <ToggleButton
-                classes={{ root: classes.button }}
-                selected
-                disabled={false}
-                value={'paragraph'}
-                key={'paragraph'}>
-                <SubjectIcon fontSize="small" />
-              </ToggleButton>
-              <ToggleButton
-                classes={{ root: classes.button }}
-                selected={false}
-                disabled={false}
-                value={'header1'}
-                key={'header1'}>
-                <TitleIcon fontSize="small" />
-              </ToggleButton>
-              <ToggleButton
-                classes={{ root: classes.button }}
-                selected={false}
-                disabled={false}
-                value={'bullet-list'}
-                key={'bullet-list'}>
-                <FormatListBulletedIcon fontSize="small" />
-              </ToggleButton>
-              <ToggleButton
-                classes={{ root: classes.button }}
-                selected={false}
-                disabled={false}
-                value={'number-list'}
-                key={'number-list'}>
-                <FormatListNumberedIcon fontSize="small" />
-              </ToggleButton>
-            </StyledToggleButtonGroup>
-            <Divider flexItem orientation="vertical" className={classes.divider} />
-            <StyledToggleButtonGroup size="small">
-              <ToggleButton classes={{ root: classes.button }} disabled={false} value={'bold'} key={'bold'}>
-                <FormatBoldIcon fontSize="small" />
-              </ToggleButton>
-              <ToggleButton classes={{ root: classes.button }} value={'italic'} key={'italic'}>
-                <FormatItalicIcon fontSize="small" />
-              </ToggleButton>
-              <ToggleButton classes={{ root: classes.button }} disabled={false} value={'underline'} key={'underline'}>
-                <FormatUnderlinedIcon fontSize="small" />
-              </ToggleButton>
-              <ToggleButton classes={{ root: classes.button }} disabled={false} value={'code'} key={'code'}>
-                <CodeIcon fontSize="small" />
-              </ToggleButton>
-              <ToggleButton
-                classes={{ root: classes.button }}
-                disabled={false}
-                value={'strikethrough'}
-                key={'strikethrough'}>
-                <StrikethroughSIcon fontSize="small" />
-              </ToggleButton>
-            </StyledToggleButtonGroup>
-          </div>
           <StyledToggleButtonGroup size="small">
-            <ToggleButton classes={{ root: classes.button }} disabled={false} value={'save'} key={'save'}>
-              <SaveIcon fontSize="small" />
+            <ToggleButton
+              classes={{ root: classes.button }}
+              selected
+              disabled={false}
+              value={'paragraph'}
+              key={'paragraph'}>
+              <SubjectIcon fontSize="small" />
+            </ToggleButton>
+            <ToggleButton
+              classes={{ root: classes.button }}
+              selected={false}
+              disabled={false}
+              value={'header1'}
+              key={'header1'}>
+              <TitleIcon fontSize="small" />
+            </ToggleButton>
+            <ToggleButton
+              classes={{ root: classes.button }}
+              selected={false}
+              disabled={false}
+              value={'bullet-list'}
+              key={'bullet-list'}>
+              <FormatListBulletedIcon fontSize="small" />
+            </ToggleButton>
+            <ToggleButton
+              classes={{ root: classes.button }}
+              selected={false}
+              disabled={false}
+              value={'number-list'}
+              key={'number-list'}>
+              <FormatListNumberedIcon fontSize="small" />
+            </ToggleButton>
+          </StyledToggleButtonGroup>
+          <Divider flexItem orientation="vertical" className={classes.divider} />
+          <StyledToggleButtonGroup size="small">
+            <ToggleButton classes={{ root: classes.button }} disabled={false} value={'bold'} key={'bold'}>
+              <FormatBoldIcon fontSize="small" />
+            </ToggleButton>
+            <ToggleButton classes={{ root: classes.button }} value={'italic'} key={'italic'}>
+              <FormatItalicIcon fontSize="small" />
+            </ToggleButton>
+            <ToggleButton classes={{ root: classes.button }} disabled={false} value={'underline'} key={'underline'}>
+              <FormatUnderlinedIcon fontSize="small" />
+            </ToggleButton>
+            <ToggleButton classes={{ root: classes.button }} disabled={false} value={'code'} key={'code'}>
+              <CodeIcon fontSize="small" />
+            </ToggleButton>
+            <ToggleButton
+              classes={{ root: classes.button }}
+              disabled={false}
+              value={'strikethrough'}
+              key={'strikethrough'}>
+              <StrikethroughSIcon fontSize="small" />
             </ToggleButton>
           </StyledToggleButtonGroup>
         </Paper>

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/RichTextPropertySection.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/RichTextPropertySection.tsx
@@ -33,8 +33,6 @@ import {
   RichTextPropertySectionProps,
 } from './RichTextPropertySection.types';
 import {
-  ChangeValueEvent,
-  InitializeEvent,
   RichTextPropertySectionContext,
   RichTextPropertySectionEvent,
   RichTextPropertySectionMachine,
@@ -83,17 +81,7 @@ export const RichTextPropertySection = ({
     RichTextPropertySectionEvent
   >(RichTextPropertySectionMachine);
   const { toast } = schemaValue as SchemaValue;
-  const { value, message } = context;
-
-  useEffect(() => {
-    const initializeEvent: InitializeEvent = { type: 'INITIALIZE', value: widget.stringValue };
-    dispatch(initializeEvent);
-  }, [dispatch, widget.stringValue]);
-
-  const onChange = (newText: string) => {
-    const changeValueEvent: ChangeValueEvent = { type: 'CHANGE_VALUE', value: newText };
-    dispatch(changeValueEvent);
-  };
+  const { message } = context;
 
   const [editRichText, { loading: updateRichTextLoading, data: updateRichTextData, error: updateRichTextError }] =
     useMutation<GQLEditRichTextMutationData, GQLEditRichTextMutationVariables>(editRichTextMutation);
@@ -111,15 +99,12 @@ export const RichTextPropertySection = ({
 
   useEffect(() => {
     if (!updateRichTextLoading) {
-      let hasError = false;
       if (updateRichTextError) {
         const showToastEvent: ShowToastEvent = {
           type: 'SHOW_TOAST',
           message: 'An unexpected error has occurred, please refresh the page',
         };
         dispatch(showToastEvent);
-
-        hasError = true;
       }
       if (updateRichTextData) {
         const { editRichText } = updateRichTextData;
@@ -127,17 +112,10 @@ export const RichTextPropertySection = ({
           const { message } = editRichText;
           const showToastEvent: ShowToastEvent = { type: 'SHOW_TOAST', message };
           dispatch(showToastEvent);
-
-          hasError = true;
         }
       }
-
-      if (hasError) {
-        const initializeEvent: InitializeEvent = { type: 'INITIALIZE', value: widget.stringValue };
-        dispatch(initializeEvent);
-      }
     }
-  }, [updateRichTextLoading, updateRichTextData, updateRichTextError, widget, dispatch]);
+  }, [updateRichTextLoading, updateRichTextData, updateRichTextError, dispatch]);
 
   const [
     updateWidgetFocus,
@@ -178,9 +156,9 @@ export const RichTextPropertySection = ({
   }, [updateWidgetFocusLoading, updateWidgetFocusData, updateWidgetFocusError, dispatch]);
 
   const onFocus = () => sendUpdateWidgetFocus(true);
-  const onSave = (newValue: string) => {
+  const onBlur = (currentText: string) => {
     sendUpdateWidgetFocus(false);
-    sendEditedValue(newValue);
+    sendEditedValue(currentText);
   };
 
   return (
@@ -188,11 +166,10 @@ export const RichTextPropertySection = ({
       <PropertySectionLabel label={widget.label} subscribers={subscribers} />
       <div data-testid={widget.label}>
         <RichTextEditor
-          value={value}
+          value={widget.stringValue}
           placeholder={widget.label}
-          onChange={onChange}
           onFocus={onFocus}
-          onSave={onSave}
+          onBlur={onBlur}
           readOnly={readOnly}
         />
       </div>

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/RichTextPropertySectionMachine.ts
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/RichTextPropertySectionMachine.ts
@@ -20,31 +20,21 @@ export interface RichTextPropertySectionStateSchema {
         hidden: {};
       };
     };
-    richTextPropertySection: {
-      states: {
-        pristine: {};
-        edited: {};
-      };
-    };
   };
 }
 
 export type SchemaValue = {
   toast: 'visible' | 'hidden';
-  richTextPropertySection: 'pristine' | 'edited';
 };
 
 export interface RichTextPropertySectionContext {
-  value: string;
   message: string | null;
 }
 
 export type ShowToastEvent = { type: 'SHOW_TOAST'; message: string };
 export type HideToastEvent = { type: 'HIDE_TOAST' };
-export type InitializeEvent = { type: 'INITIALIZE'; value: string };
-export type ChangeValueEvent = { type: 'CHANGE_VALUE'; value: string };
 
-export type RichTextPropertySectionEvent = InitializeEvent | ChangeValueEvent | ShowToastEvent | HideToastEvent;
+export type RichTextPropertySectionEvent = ShowToastEvent | HideToastEvent;
 
 export const RichTextPropertySectionMachine = Machine<
   RichTextPropertySectionContext,
@@ -54,7 +44,6 @@ export const RichTextPropertySectionMachine = Machine<
   {
     type: 'parallel',
     context: {
-      value: '',
       message: null,
     },
     states: {
@@ -79,56 +68,10 @@ export const RichTextPropertySectionMachine = Machine<
           },
         },
       },
-      richTextPropertySection: {
-        initial: 'pristine',
-        states: {
-          pristine: {
-            on: {
-              INITIALIZE: {
-                target: 'pristine',
-                actions: 'updateValue',
-              },
-              CHANGE_VALUE: {
-                target: 'edited',
-                actions: 'updateValue',
-              },
-            },
-          },
-          edited: {
-            on: {
-              INITIALIZE: {
-                target: 'pristine',
-                actions: 'initializeValue',
-              },
-              CHANGE_VALUE: {
-                target: 'edited',
-                actions: 'updateValue',
-              },
-            },
-          },
-        },
-      },
     },
   },
   {
     actions: {
-      initializeValue: assign((context, event) => {
-        const { value } = event as InitializeEvent;
-        const { value: previousValue } = context;
-
-        if (value !== previousValue) {
-          // Similar issue as in EEFLifecycleManager, some update is coming from the server
-          // while we have started to enter some content locally. We are choosing here to drop
-          // the content entered locally but we will still log it.
-          console.trace(`The following content "${previousValue}" has been overwritten by "${value}"`);
-        }
-
-        return { value };
-      }),
-      updateValue: assign((_, event) => {
-        const { value } = event as ChangeValueEvent;
-        return { value };
-      }),
       setMessage: assign((_, event) => {
         const { message } = event as ShowToastEvent;
         return { message };

--- a/packages/forms/frontend/sirius-components-forms/src/richtexteditor/RichTextEditor.types.ts
+++ b/packages/forms/frontend/sirius-components-forms/src/richtexteditor/RichTextEditor.types.ts
@@ -11,11 +11,25 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
+import { ReactNode } from 'react';
+
 export interface RichTextEditorProps {
   value: string;
   placeholder: string;
-  onChange: (value: string) => void;
   onFocus: () => void;
-  onSave: (newValue) => void;
+  onBlur: (newValue: string) => void;
   readOnly: boolean;
+}
+
+export interface ToolbarPluginProps {
+  readOnly: boolean;
+}
+
+export interface UpdateValuePluginProps {
+  markdownText: string;
+}
+
+export interface OnBlurPluginProps {
+  onBlur: (markdownText: string) => void;
+  children: ReactNode;
 }

--- a/packages/forms/frontend/sirius-components-forms/src/richtexteditor/ToolbarPlugin.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/richtexteditor/ToolbarPlugin.tsx
@@ -29,7 +29,6 @@ import FormatBoldIcon from '@material-ui/icons/FormatBold';
 import FormatItalicIcon from '@material-ui/icons/FormatItalic';
 import FormatListBulletedIcon from '@material-ui/icons/FormatListBulleted';
 import FormatListNumberedIcon from '@material-ui/icons/FormatListNumbered';
-import FormatUnderlinedIcon from '@material-ui/icons/FormatUnderlined';
 import StrikethroughSIcon from '@material-ui/icons/StrikethroughS';
 import SubjectIcon from '@material-ui/icons/Subject';
 import TitleIcon from '@material-ui/icons/Title';
@@ -82,7 +81,6 @@ export const ToolbarPlugin = ({ readOnly }: ToolbarPluginProps) => {
 
   const [isBold, setIsBold] = useState<boolean>(false);
   const [isItalic, setIsItalic] = useState<boolean>(false);
-  const [isUnderline, setIsUnderline] = useState<boolean>(false);
   const [isStrikeTrough, setIsStrikeTrough] = useState<boolean>(false);
   const [isCode, setIsCode] = useState<boolean>(false);
   const [blockType, setBlockType] = useState('paragraph');
@@ -90,7 +88,6 @@ export const ToolbarPlugin = ({ readOnly }: ToolbarPluginProps) => {
   const updateButtons = (toggled) => {
     setIsBold(toggled.includes('bold'));
     setIsItalic(toggled.includes('italic'));
-    setIsUnderline(toggled.includes('underline'));
     setIsStrikeTrough(toggled.includes('strikethrough'));
     setIsCode(toggled.includes('code'));
     if (toggled.includes('paragraph')) {
@@ -118,7 +115,6 @@ export const ToolbarPlugin = ({ readOnly }: ToolbarPluginProps) => {
       if (elementDOM !== null) {
         setIsBold(selection.hasFormat('bold'));
         setIsItalic(selection.hasFormat('italic'));
-        setIsUnderline(selection.hasFormat('underline'));
         setIsStrikeTrough(selection.hasFormat('strikethrough'));
         setIsCode(selection.hasFormat('code'));
         if ($isListNode(element)) {
@@ -169,9 +165,6 @@ export const ToolbarPlugin = ({ readOnly }: ToolbarPluginProps) => {
   }
   if (isItalic) {
     toggled.push('italic');
-  }
-  if (isUnderline) {
-    toggled.push('underline');
   }
   if (isStrikeTrough) {
     toggled.push('strikethrough');
@@ -263,16 +256,6 @@ export const ToolbarPlugin = ({ readOnly }: ToolbarPluginProps) => {
             editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
           }}>
           <FormatItalicIcon fontSize="small" />
-        </ToggleButton>
-        <ToggleButton
-          classes={{ root: classes.button }}
-          disabled={readOnly}
-          value={'underline'}
-          key={'underline'}
-          onClick={() => {
-            editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
-          }}>
-          <FormatUnderlinedIcon fontSize="small" />
         </ToggleButton>
         <ToggleButton
           classes={{ root: classes.button }}

--- a/packages/forms/frontend/sirius-components-forms/src/richtexteditor/ToolbarPlugin.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/richtexteditor/ToolbarPlugin.tsx
@@ -17,7 +17,6 @@ import {
   ListNode,
   REMOVE_LIST_COMMAND,
 } from '@lexical/list';
-import { $convertToMarkdownString, TRANSFORMERS } from '@lexical/markdown';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { $createHeadingNode, $isHeadingNode } from '@lexical/rich-text';
 import { $wrapNodes } from '@lexical/selection';
@@ -31,7 +30,6 @@ import FormatItalicIcon from '@material-ui/icons/FormatItalic';
 import FormatListBulletedIcon from '@material-ui/icons/FormatListBulleted';
 import FormatListNumberedIcon from '@material-ui/icons/FormatListNumbered';
 import FormatUnderlinedIcon from '@material-ui/icons/FormatUnderlined';
-import SaveIcon from '@material-ui/icons/Save';
 import StrikethroughSIcon from '@material-ui/icons/StrikethroughS';
 import SubjectIcon from '@material-ui/icons/Subject';
 import TitleIcon from '@material-ui/icons/Title';
@@ -46,25 +44,13 @@ import {
   SELECTION_CHANGE_COMMAND,
 } from 'lexical';
 import { useCallback, useEffect, useState } from 'react';
-
-export interface ToolbarPluginProps {
-  readOnly: boolean;
-  pristine: boolean;
-  onEdited: () => void;
-  onSave: (newValue: string) => void;
-}
+import { ToolbarPluginProps } from './RichTextEditor.types';
 
 const useToolbarStyles = makeStyles((theme) => ({
   paper: {
     display: 'flex',
     flexDirection: 'row',
-    justifyContent: 'space-between',
     borderBottom: `1px solid ${theme.palette.divider}`,
-    flexWrap: 'wrap',
-  },
-  formattingActions: {
-    display: 'flex',
-    flexDirection: 'row',
     flexWrap: 'wrap',
   },
   divider: {
@@ -91,7 +77,7 @@ const StyledToggleButtonGroup = withStyles((theme) => ({
   },
 }))(ToggleButtonGroup);
 
-export const ToolbarPlugin = ({ readOnly, pristine, onEdited, onSave }: ToolbarPluginProps) => {
+export const ToolbarPlugin = ({ readOnly }: ToolbarPluginProps) => {
   const [editor] = useLexicalComposerContext();
 
   const [isBold, setIsBold] = useState<boolean>(false);
@@ -197,142 +183,116 @@ export const ToolbarPlugin = ({ readOnly, pristine, onEdited, onSave }: ToolbarP
   const classes = useToolbarStyles({});
   return (
     <Paper elevation={0} className={classes.paper}>
-      <div className={classes.formattingActions}>
-        <StyledToggleButtonGroup size="small" value={toggled} onChange={(_, newStyles) => updateButtons(newStyles)}>
-          <ToggleButton
-            classes={{ root: classes.button }}
-            disabled={readOnly}
-            value={'paragraph'}
-            key={'paragraph'}
-            onClick={() => {
-              editor.update(() => {
-                const selection = $getSelection();
-                if ($isRangeSelection(selection)) {
-                  $wrapNodes(selection, () => $createParagraphNode());
-                  onEdited();
-                }
-              });
-            }}>
-            <SubjectIcon fontSize="small" />
-          </ToggleButton>
-          <ToggleButton
-            classes={{ root: classes.button }}
-            disabled={readOnly}
-            value={'header1'}
-            key={'header1'}
-            onClick={() => {
-              editor.update(() => {
-                const selection = $getSelection();
-                if ($isRangeSelection(selection)) {
-                  $wrapNodes(selection, () => $createHeadingNode('h1'));
-                  onEdited();
-                }
-              });
-            }}>
-            <TitleIcon fontSize="small" />
-          </ToggleButton>
-          <ToggleButton
-            classes={{ root: classes.button }}
-            disabled={readOnly}
-            value={'bullet-list'}
-            key={'bullet-list'}
-            onClick={() => {
-              if (blockType !== 'ul') {
-                editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, null);
-              } else {
-                editor.dispatchCommand(REMOVE_LIST_COMMAND, null);
-              }
-              onEdited();
-            }}>
-            <FormatListBulletedIcon fontSize="small" />
-          </ToggleButton>
-          <ToggleButton
-            classes={{ root: classes.button }}
-            disabled={readOnly}
-            value={'number-list'}
-            key={'number-list'}
-            onClick={() => {
-              if (blockType !== 'ol') {
-                editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, null);
-              } else {
-                editor.dispatchCommand(REMOVE_LIST_COMMAND, null);
-              }
-              onEdited();
-            }}>
-            <FormatListNumberedIcon fontSize="small" />
-          </ToggleButton>
-        </StyledToggleButtonGroup>
-        <Divider flexItem orientation="vertical" className={classes.divider} />
-        <StyledToggleButtonGroup size="small" value={toggled} onChange={(_, newStyles) => updateButtons(newStyles)}>
-          <ToggleButton
-            classes={{ root: classes.button }}
-            disabled={readOnly}
-            value={'bold'}
-            key={'bold'}
-            onClick={() => {
-              editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
-              onEdited();
-            }}>
-            <FormatBoldIcon fontSize="small" />
-          </ToggleButton>
-          <ToggleButton
-            classes={{ root: classes.button }}
-            value={'italic'}
-            key={'italic'}
-            onClick={() => {
-              editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
-              onEdited();
-            }}>
-            <FormatItalicIcon fontSize="small" />
-          </ToggleButton>
-          <ToggleButton
-            classes={{ root: classes.button }}
-            disabled={readOnly}
-            value={'underline'}
-            key={'underline'}
-            onClick={() => {
-              editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
-              onEdited();
-            }}>
-            <FormatUnderlinedIcon fontSize="small" />
-          </ToggleButton>
-          <ToggleButton
-            classes={{ root: classes.button }}
-            disabled={readOnly}
-            value={'code'}
-            key={'code'}
-            onClick={() => {
-              editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
-              onEdited();
-            }}>
-            <CodeIcon fontSize="small" />
-          </ToggleButton>
-          <ToggleButton
-            classes={{ root: classes.button }}
-            disabled={readOnly}
-            value={'strikethrough'}
-            key={'strikethrough'}
-            onClick={() => {
-              editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
-              onEdited();
-            }}>
-            <StrikethroughSIcon fontSize="small" />
-          </ToggleButton>
-        </StyledToggleButtonGroup>
-      </div>
       <StyledToggleButtonGroup size="small" value={toggled} onChange={(_, newStyles) => updateButtons(newStyles)}>
         <ToggleButton
           classes={{ root: classes.button }}
-          disabled={readOnly || pristine}
-          value={'save'}
-          key={'save'}
+          disabled={readOnly}
+          value={'paragraph'}
+          key={'paragraph'}
           onClick={() => {
-            editor.getEditorState().read(() => {
-              const markdown = $convertToMarkdownString(TRANSFORMERS);
-              onSave(markdown);
+            editor.update(() => {
+              const selection = $getSelection();
+              if ($isRangeSelection(selection)) {
+                $wrapNodes(selection, () => $createParagraphNode());
+              }
             });
           }}>
-          <SaveIcon fontSize="small" color={pristine ? 'disabled' : 'primary'} />
+          <SubjectIcon fontSize="small" />
+        </ToggleButton>
+        <ToggleButton
+          classes={{ root: classes.button }}
+          disabled={readOnly}
+          value={'header1'}
+          key={'header1'}
+          onClick={() => {
+            editor.update(() => {
+              const selection = $getSelection();
+              if ($isRangeSelection(selection)) {
+                $wrapNodes(selection, () => $createHeadingNode('h1'));
+              }
+            });
+          }}>
+          <TitleIcon fontSize="small" />
+        </ToggleButton>
+        <ToggleButton
+          classes={{ root: classes.button }}
+          disabled={readOnly}
+          value={'bullet-list'}
+          key={'bullet-list'}
+          onClick={() => {
+            if (blockType !== 'ul') {
+              editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, null);
+            } else {
+              editor.dispatchCommand(REMOVE_LIST_COMMAND, null);
+            }
+          }}>
+          <FormatListBulletedIcon fontSize="small" />
+        </ToggleButton>
+        <ToggleButton
+          classes={{ root: classes.button }}
+          disabled={readOnly}
+          value={'number-list'}
+          key={'number-list'}
+          onClick={() => {
+            if (blockType !== 'ol') {
+              editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, null);
+            } else {
+              editor.dispatchCommand(REMOVE_LIST_COMMAND, null);
+            }
+          }}>
+          <FormatListNumberedIcon fontSize="small" />
+        </ToggleButton>
+      </StyledToggleButtonGroup>
+      <Divider flexItem orientation="vertical" className={classes.divider} />
+      <StyledToggleButtonGroup size="small" value={toggled} onChange={(_, newStyles) => updateButtons(newStyles)}>
+        <ToggleButton
+          classes={{ root: classes.button }}
+          disabled={readOnly}
+          value={'bold'}
+          key={'bold'}
+          onClick={() => {
+            editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
+          }}>
+          <FormatBoldIcon fontSize="small" />
+        </ToggleButton>
+        <ToggleButton
+          classes={{ root: classes.button }}
+          value={'italic'}
+          key={'italic'}
+          onClick={() => {
+            editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
+          }}>
+          <FormatItalicIcon fontSize="small" />
+        </ToggleButton>
+        <ToggleButton
+          classes={{ root: classes.button }}
+          disabled={readOnly}
+          value={'underline'}
+          key={'underline'}
+          onClick={() => {
+            editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
+          }}>
+          <FormatUnderlinedIcon fontSize="small" />
+        </ToggleButton>
+        <ToggleButton
+          classes={{ root: classes.button }}
+          disabled={readOnly}
+          value={'code'}
+          key={'code'}
+          onClick={() => {
+            editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
+          }}>
+          <CodeIcon fontSize="small" />
+        </ToggleButton>
+        <ToggleButton
+          classes={{ root: classes.button }}
+          disabled={readOnly}
+          value={'strikethrough'}
+          key={'strikethrough'}
+          onClick={() => {
+            editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
+          }}>
+          <StrikethroughSIcon fontSize="small" />
         </ToggleButton>
       </StyledToggleButtonGroup>
     </Paper>


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1346
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?