### PR TITLE
[1426] Add missing data type on initialDirectEditLabelExpression

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,7 @@
 
 - https://github.com/eclipse-sirius/sirius-components/issues/1559[#1559] [view] It is now possible to specify the (computed) width and height separately for a _Node Style_ (instead of a single size before, which always resulted in square shapes).
 - https://github.com/eclipse-sirius/sirius-components/issues/1560[#1560] Remove unused `EditingContextCompletionProposalsDataFetcher`
+- https://github.com/eclipse-sirius/sirius-components/issues/1426[#1426] [view] Add missing data type on initialDirectEditLabelExpression
 
 
 == v2023.1.0

--- a/packages/view/backend/sirius-components-view-edit/src/main/resources/plugin.properties
+++ b/packages/view/backend/sirius-components-view-edit/src/main/resources/plugin.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022 Obeo.
+# Copyright (c) 2021, 2023 Obeo.
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
@@ -151,7 +151,8 @@ _UI_BorderStyle_borderSize_feature = Border Size
 _UI_BorderStyle_borderLineStyle_feature = Border Line Style
 _UI_Style_color_feature = Color
 _UI_NodeStyleDescription_labelColor_feature = Label Color
-_UI_NodeStyleDescription_sizeComputationExpression_feature = Size Computation Expression
+_UI_NodeStyleDescription_widthComputationExpression_feature = Width Computation Expression
+_UI_NodeStyleDescription_heightComputationExpression_feature = Height Computation Expression
 _UI_NodeStyleDescription_showIcon_feature = Show Icon
 _UI_RectangularNodeStyleDescription_withHeader_feature = With Header
 _UI_ImageNodeStyleDescription_shape_feature = Shape

--- a/packages/view/backend/sirius-components-view/src/main/java/org/eclipse/sirius/components/view/LabelEditTool.java
+++ b/packages/view/backend/sirius-components-view/src/main/java/org/eclipse/sirius/components/view/LabelEditTool.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Obeo.
+ * Copyright (c) 2021, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ public interface LabelEditTool extends Tool {
      * @return the value of the '<em>Initial Direct Edit Label Expression</em>' attribute.
      * @see #setInitialDirectEditLabelExpression(String)
      * @see org.eclipse.sirius.components.view.ViewPackage#getLabelEditTool_InitialDirectEditLabelExpression()
-     * @model
+     * @model dataType="org.eclipse.sirius.components.view.InterpretedExpression"
      * @generated
      */
     String getInitialDirectEditLabelExpression();

--- a/packages/view/backend/sirius-components-view/src/main/java/org/eclipse/sirius/components/view/impl/ViewPackageImpl.java
+++ b/packages/view/backend/sirius-components-view/src/main/java/org/eclipse/sirius/components/view/impl/ViewPackageImpl.java
@@ -3988,7 +3988,7 @@ public class ViewPackageImpl extends EPackageImpl implements ViewPackage {
                 !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.labelEditToolEClass, LabelEditTool.class, "LabelEditTool", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        this.initEAttribute(this.getLabelEditTool_InitialDirectEditLabelExpression(), this.ecorePackage.getEString(), "initialDirectEditLabelExpression", null, 0, 1, LabelEditTool.class,
+        this.initEAttribute(this.getLabelEditTool_InitialDirectEditLabelExpression(), this.getInterpretedExpression(), "initialDirectEditLabelExpression", null, 0, 1, LabelEditTool.class,
                 !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.deleteToolEClass, DeleteTool.class, "DeleteTool", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);

--- a/packages/view/backend/sirius-components-view/src/main/resources/model/view.ecore
+++ b/packages/view/backend/sirius-components-view/src/main/resources/model/view.ecore
@@ -172,7 +172,7 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="LabelEditTool" eSuperTypes="#//Tool">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="initialDirectEditLabelExpression"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+        eType="#//InterpretedExpression"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="DeleteTool" eSuperTypes="#//Tool"/>
   <eClassifiers xsi:type="ecore:EClass" name="NodeTool" eSuperTypes="#//Tool"/>


### PR DESCRIPTION
Most of the generated code is reformatted because the removal of
NON-NLS markers changes (in 4d42d9675a51a16d76f83bcbb188a8acf42aefdd)
increased the line length available for actual code and the code was
not reformatted at the time.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/1426
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?