### PR TITLE
[1596] Add sample parametric SVG images to Sirius Web

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -46,6 +46,8 @@ image:doc/images/View_edit_begin_label_in_action.png[width=550,height=234]
 - https://github.com/eclipse-sirius/sirius-components/issues/1574[#1574] [diagram] Single click tools can now be executed on Edges in addition to Nodes
 - https://github.com/eclipse-sirius/sirius-components/issues/1569[#1569] [view] Only delegate semantic deletion to the element's _Delete Tool_
 - https://github.com/eclipse-sirius/sirius-components/issues/1562[#1562] [view] The default/canonical behaviors for diagram elements can now be invoked explicitly from AQL expressions. See `org.eclipse.sirius.components.view.emf.CanonicalServices`. This feature will be used only for internal for now. There will be breaking changes on this topic soon.
+- https://github.com/eclipse-sirius/sirius-components/issues/1596[#1596] [diagram] Sirius Web now includes two example parametric SVG images named "Package" and "Class".
+They can be used as any custom image (e.g. in a View-based diagram), but their precise shape is partially computed on the backend, in this case to adjust the size of the label compartment to the actual label's width.
 
 == v2023.1.0
 

--- a/packages/sirius-web/backend/sirius-web-services/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-services/pom.xml
@@ -55,6 +55,21 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
+			<artifactId>sirius-components-diagrams-layout</artifactId>
+			<version>2023.1.1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>xml-apis</groupId>
+					<artifactId>xml-apis</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>xml-apis</groupId>
+					<artifactId>xml-apis-ext</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
 			<version>2023.1.1</version>
 		</dependency>

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/diagram/ParametricSVGImageFactory.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/diagram/ParametricSVGImageFactory.java
@@ -1,0 +1,212 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.services.diagram;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerFactoryConfigurationError;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.eclipse.sirius.components.collaborative.diagrams.api.IParametricSVGImageFactory;
+import org.eclipse.sirius.components.collaborative.diagrams.api.IParametricSVGImageRegistry;
+import org.eclipse.sirius.components.collaborative.diagrams.api.ParametricSVGImage;
+import org.eclipse.sirius.components.collaborative.diagrams.api.SVGAttribute;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Implementation of {@link IParametricSVGImageFactory}.
+ *
+ * @author lfasani
+ */
+@Service
+public class ParametricSVGImageFactory implements IParametricSVGImageFactory {
+
+    private static final String HEIGHT = "height";
+
+    private static final String WIDTH = "width";
+
+    private static final String RECTANGLE_ELEMENT_LABEL_ID = "labelRectangle";
+
+    private static final String RECTANGLE_ELEMENT_MAIN_ID = "mainRectangle";
+
+    private static final Integer PADDING = 5;
+
+    private final Logger logger = LoggerFactory.getLogger(ParametricSVGImageFactory.class);
+
+    private final List<IParametricSVGImageRegistry> parametricSVGImageServices;
+
+    public ParametricSVGImageFactory(List<IParametricSVGImageRegistry> parametricSVGImageServices) {
+        this.parametricSVGImageServices = parametricSVGImageServices;
+    }
+
+    @Override
+    public Optional<byte[]> createSvg(String svgName, EnumMap<SVGAttribute, String> attributesValues) {
+
+        // @formatter:off
+        Optional<ParametricSVGImage> svgImageOpt = this.parametricSVGImageServices.stream()
+            .flatMap(service-> service.getImages().stream())
+            .filter(image -> {
+                return svgName.equals(image.getId().toString());
+            })
+            .findFirst();
+        // @formatter:on
+
+        if (svgImageOpt.isPresent()) {
+            ClassPathResource classPathResource = new ClassPathResource(svgImageOpt.get().getPath());
+            try (InputStream inputStream = classPathResource.getInputStream()) {
+                DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                Document document = factory.newDocumentBuilder().parse(inputStream);
+                XPath xpath = XPathFactory.newInstance().newXPath();
+
+                // change the global size
+                // @formatter:off
+                Node svgNode = Optional.of(xpath.evaluate("/svg", document, XPathConstants.NODESET))
+                        .filter(NodeList.class::isInstance)
+                        .map(NodeList.class::cast)
+                        .filter(nodeList -> nodeList.getLength() > 0)
+                        .map(nodeList -> nodeList.item(0))
+                        .orElse(null);
+                // @formatter:on
+
+                if (svgNode instanceof Element element) {
+                    Double halfBorderSize = Double.valueOf(attributesValues.get(SVGAttribute.BORDERSIZE)) * 0.5d;
+                    String realWidth = String.valueOf(Double.valueOf(attributesValues.get(SVGAttribute.WIDTH)) + halfBorderSize * 2);
+                    String realHeight = String.valueOf(Double.valueOf(attributesValues.get(SVGAttribute.HEIGHT)) + halfBorderSize * 2);
+                    String viewBox = String.format(Locale.US, "-%f -%f %s %s", halfBorderSize, halfBorderSize, realWidth, realHeight);
+                    element.setAttribute(WIDTH, realWidth);
+                    element.setAttribute(HEIGHT, realHeight);
+                    element.setAttribute("viewBox", viewBox);
+
+                }
+
+                String expr = String.format("//*[contains(@id, '%s')]|//*[contains(@id, '%s')]", RECTANGLE_ELEMENT_LABEL_ID, RECTANGLE_ELEMENT_MAIN_ID);
+
+                // @formatter:off
+                Optional.of(xpath.evaluate(expr, document, XPathConstants.NODESET))
+                        .filter(NodeList.class::isInstance)
+                        .map(NodeList.class::cast)
+                        .ifPresent(nodes-> {
+                            for (int i = 0; i < nodes.getLength(); i++) {
+                                Element node = (Element) nodes.item(i);
+                                this.updateNode(attributesValues, node, svgImageOpt.get());
+                            }
+                        });
+                // @formatter:on
+
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                Source xmlSource = new DOMSource(document);
+                Result outputTarget = new StreamResult(outputStream);
+                try {
+                    TransformerFactory.newInstance().newTransformer().transform(xmlSource, outputTarget);
+                } catch (TransformerException | TransformerFactoryConfigurationError e) {
+                    this.logger.warn(e.getMessage());
+                }
+
+                InputStream documentInputStream = new ByteArrayInputStream(outputStream.toByteArray());
+                return Optional.of(documentInputStream.readAllBytes());
+            } catch (IOException | ParserConfigurationException | XPathExpressionException | SAXException e) {
+                this.logger.warn(e.getMessage());
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private void updateNode(EnumMap<SVGAttribute, String> attributesValues, Element node, ParametricSVGImage parametricSVGImage) {
+        String idValue = node.getAttributes().getNamedItem("id").getNodeValue();
+        Node styleNode = node.getAttributes().getNamedItem("style");
+        if (styleNode != null) {
+            String style = styleNode.getNodeValue();
+            for (SVGAttribute svgAttribute : attributesValues.keySet()) {
+                String styleProperty = null;
+                if (SVGAttribute.COLOR.equals(svgAttribute)) {
+                    styleProperty = "fill";
+                } else if (SVGAttribute.BORDERCOLOR.equals(svgAttribute)) {
+                    styleProperty = "stroke";
+                } else if (SVGAttribute.BORDERSIZE.equals(svgAttribute)) {
+                    styleProperty = "stroke-width";
+                } else if (SVGAttribute.BORDERSTYLE.equals(svgAttribute)) {
+                    styleProperty = "stroke-dasharray";
+                }
+                if (styleProperty != null) {
+                    style = this.updateStyleValue(style, styleProperty, attributesValues.get(svgAttribute));
+                }
+            }
+            node.setAttribute("style", style);
+        }
+        if (RECTANGLE_ELEMENT_LABEL_ID.equals(idValue)) {
+            // TODO we should use ICustomNodeLabelPositionProvider
+            if (parametricSVGImage.getLabel().equals("Class")) {
+                // The label is centered so the label area is the same size than the container
+                node.setAttribute(WIDTH, attributesValues.get(SVGAttribute.WIDTH));
+            } else {
+                // The label is left aligned
+                node.setAttribute(WIDTH, String.valueOf(Double.valueOf(attributesValues.get(SVGAttribute.LABELWIDTH)) + 2 * PADDING));
+            }
+            node.setAttribute(HEIGHT, String.valueOf(Double.valueOf(attributesValues.get(SVGAttribute.LABELHEIGHT)) + 2 * PADDING));
+        } else if (RECTANGLE_ELEMENT_MAIN_ID.equals(idValue)) {
+            Double globalHeight = 100.;
+            Double labelHeight = 10.;
+            try {
+                globalHeight = Double.valueOf(attributesValues.get(SVGAttribute.HEIGHT));
+                labelHeight = Double.valueOf(Double.valueOf(attributesValues.get(SVGAttribute.LABELHEIGHT)) + 2 * PADDING);
+            } catch (NumberFormatException e) {
+                this.logger.error(e.getMessage());
+            }
+            Double mainRectangleYPosition = labelHeight;
+            Double mainRectangleHeight = globalHeight - labelHeight;
+            node.setAttribute("y", mainRectangleYPosition.toString());
+            node.setAttribute(HEIGHT, mainRectangleHeight.toString());
+            node.setAttribute(WIDTH, attributesValues.get(SVGAttribute.WIDTH));
+        }
+    }
+
+    private String updateStyleValue(String style, String styleProperty, String newValue) {
+        String updatedStyle = style;
+        if (style.contains(styleProperty)) {
+            updatedStyle = style.replaceFirst(styleProperty + ":(.*?)([;\"])", styleProperty + ":" + newValue + "$2");
+        } else {
+            updatedStyle = styleProperty + ":" + newValue + ";" + updatedStyle;
+        }
+        return updatedStyle;
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/diagram/ParametricSVGImageRegistry.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/diagram/ParametricSVGImageRegistry.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.services.diagram;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.collaborative.diagrams.api.IParametricSVGImageRegistry;
+import org.eclipse.sirius.components.collaborative.diagrams.api.ParametricSVGImage;
+import org.springframework.stereotype.Service;
+
+/**
+ * Provide a IParametricSVGImageRegistry.
+ *
+ * @author lfasani
+ */
+@Service
+public class ParametricSVGImageRegistry implements IParametricSVGImageRegistry {
+    @Override
+    public List<ParametricSVGImage> getImages() {
+        return List.of(new ParametricSVGImage(UUID.nameUUIDFromBytes("Package".getBytes()), "Package", "parametricSVGs/package.svg"),
+                new ParametricSVGImage(UUID.nameUUIDFromBytes("Class".getBytes()), "Class", "parametricSVGs/class.svg"));
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/diagram/ParametricSVGNodeStyleLabelPositionProvider.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/diagram/ParametricSVGNodeStyleLabelPositionProvider.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.services.diagram;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.elk.core.math.ElkPadding;
+import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.sirius.components.diagrams.INodeStyle;
+import org.eclipse.sirius.components.diagrams.ParametricSVGNodeStyle;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
+import org.eclipse.sirius.components.diagrams.layout.ISiriusWebLayoutConfigurator;
+import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ICustomNodeLabelPositionProvider;
+import org.springframework.stereotype.Service;
+
+/**
+ * Customize the label position for parametric SVG node styled nodes.
+ *
+ * @author lfasani
+ */
+@Service
+public class ParametricSVGNodeStyleLabelPositionProvider implements ICustomNodeLabelPositionProvider {
+
+    @Override
+    public Optional<Position> getLabelPosition(ISiriusWebLayoutConfigurator layoutConfigurator, Size initialLabelSize, Size nodeSize, String nodeType, INodeStyle nodeStyle) {
+        Optional<Position> positionOpt = Optional.empty();
+        if (nodeStyle instanceof ParametricSVGNodeStyle parametricNodeStyle) {
+            String svgURL = parametricNodeStyle.getSvgURL();
+            if (svgURL.contains(UUID.nameUUIDFromBytes("Class".getBytes()).toString())) {
+                // horizontally centered
+                ElkPadding labelPadding = layoutConfigurator.configureByType(nodeType).getProperty(CoreOptions.NODE_LABELS_PADDING);
+                positionOpt = Optional.of(Position.at(nodeSize.getWidth() / 2 - initialLabelSize.getWidth() / 2, labelPadding.getTop()));
+            } else {
+                // horizontally left
+                ElkPadding labelPadding = layoutConfigurator.configureByType(nodeType).getProperty(CoreOptions.NODE_LABELS_PADDING);
+                positionOpt = Optional.of(Position.at(labelPadding.getLeft(), labelPadding.getTop()));
+            }
+        }
+        return positionOpt;
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-services/src/main/resources/parametricSVGs/class.svg
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/resources/parametricSVGs/class.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="100.3825"
+   height="50.3825"
+   viewBox="0 0 100.3825 50.3825"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   sodipodi:docname="package.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="4"
+     inkscape:cx="105.75"
+     inkscape:cy="138.25"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="662"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid253"
+       originx="0.94488182"
+       originy="-110.23623" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0.25,0.25)">
+    <rect
+       style="fill:#ffffff;stroke:#ff6600;stroke-width:0.5;stroke-dasharray:0.5, 0.5;stroke-dashoffset:0;stroke-opacity:1;padding-left: 5px;padding-right: 5px"
+       id="labelRectangle"
+       width="50"
+       height="10"
+       x="0"
+       y="0" />
+    <rect
+       id="mainRectangle"
+       width="100"
+       height="40"
+       x="0"
+       y="10"
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.265;stroke-dasharray:0.265, 0.265;stroke-dashoffset:0;stroke-opacity:1;padding-left: 5px;padding-right: 5px" />
+  </g>
+</svg>

--- a/packages/sirius-web/backend/sirius-web-services/src/main/resources/parametricSVGs/package.svg
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/resources/parametricSVGs/package.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="100.3825"
+   height="50.3825"
+   viewBox="0 0 100.3825 50.3825"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   sodipodi:docname="package.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="4"
+     inkscape:cx="105.75"
+     inkscape:cy="138.25"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="662"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid253"
+       originx="0.94488182"
+       originy="-110.23623" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0.25,0.25)">
+    <rect
+       style="fill:#ffffff;stroke:#ff6600;stroke-width:0.5;stroke-dasharray:0.5, 0.5;stroke-dashoffset:0;stroke-opacity:1;padding-left: 5px;padding-right: 5px"
+       id="labelRectangle"
+       width="50"
+       height="10"
+       x="0"
+       y="0" />
+    <rect
+       id="mainRectangle"
+       width="100"
+       height="40"
+       x="0"
+       y="10"
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.265;stroke-dasharray:0.265, 0.265;stroke-dashoffset:0;stroke-opacity:1;padding-left: 5px;padding-right: 5px" />
+  </g>
+</svg>


### PR DESCRIPTION
Generic support for them was added in v2022.11.0 with #1316, but there
are no concrete examples in Sirius Web which makes it difficult to
test for.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/1596
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?