### PR TITLE
[1615] Remove the unused DiagramDescription.getTools()

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -42,6 +42,8 @@ This contribution also ensures that the local context is configured as necessary
 +
 On top of that, creating more complex subscriptions involving the representation description could trigger a deadlock since the subcription on the reactive `Flux` emitting the payloads was performed in the thread of the `EditingContextEventProcessor`.
 The scheduling policy of our various `IRepresentationEventProcessor` will thus be updated in order to ensure that the subscription will be performed in another thread.
+- https://github.com/eclipse-sirius/sirius-components/issues/1615[#1615] [diagram] `DiagramDescription.getTools()` has been removed.
+It was not actually used, as tools have long been found in `DiagramDescription.getToolSections()` instead.
 
 === Dependency update
 

--- a/packages/compatibility/backend/sirius-components-compatibility-emf/src/test/java/org/eclipse/sirius/components/compatibility/emf/compatibility/operations/CreateViewOperationHandlerTests.java
+++ b/packages/compatibility/backend/sirius-components-compatibility-emf/src/test/java/org/eclipse/sirius/components/compatibility/emf/compatibility/operations/CreateViewOperationHandlerTests.java
@@ -85,7 +85,6 @@ public class CreateViewOperationHandlerTests {
                 .canCreatePredicate(variableManager -> true)
                 .labelProvider(variableManager -> "Diagram")
                 .toolSections(List.of())
-                .tools(List.of())
                 .nodeDescriptions(List.of(this.getNodeDescription(UUID.randomUUID())))
                 .edgeDescriptions(List.of())
                 .dropHandler(variableManager -> new Failure(""))

--- a/packages/compatibility/backend/sirius-components-compatibility-emf/src/test/java/org/eclipse/sirius/components/compatibility/emf/compatibility/operations/DeleteViewOperationHandlerTests.java
+++ b/packages/compatibility/backend/sirius-components-compatibility-emf/src/test/java/org/eclipse/sirius/components/compatibility/emf/compatibility/operations/DeleteViewOperationHandlerTests.java
@@ -86,7 +86,6 @@ public class DeleteViewOperationHandlerTests {
                 .canCreatePredicate(variableManager -> true)
                 .labelProvider(variableManager -> "Diagram")
                 .toolSections(List.of())
-                .tools(List.of())
                 .nodeDescriptions(List.of(this.getNodeDescription(UUID.randomUUID())))
                 .edgeDescriptions(List.of())
                 .dropHandler(variableManager -> new Failure(""))

--- a/packages/compatibility/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/DiagramDescriptionNodeAndEdgeDescriptionsPopulator.java
+++ b/packages/compatibility/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/DiagramDescriptionNodeAndEdgeDescriptionsPopulator.java
@@ -124,10 +124,7 @@ public class DiagramDescriptionNodeAndEdgeDescriptionsPopulator implements IDiag
         return builder.nodeDescriptions(allNodeDescriptions)
                 .edgeDescriptions(edgeDescriptions)
                 .dropHandler(dropHandler)
-                .toolSections(this.toolProvider.getToolSections(id2NodeDescriptions, edgeDescriptions, siriusDiagramDescription, layers))
-                // We don't care about populating tools here, there are executed on the fly from the compatibility reconnection tool executor.
-                // We must add it here to support the conversion from the View MM which is not able to execute tool on the fly.
-                .tools(List.of());
+                .toolSections(this.toolProvider.getToolSections(id2NodeDescriptions, edgeDescriptions, siriusDiagramDescription, layers));
         // @formatter:on
     }
 

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/CreateDiagramEventHandlerTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/CreateDiagramEventHandlerTests.java
@@ -61,7 +61,6 @@ public class CreateDiagramEventHandlerTests {
                         .edgeDescriptions(new ArrayList<>())
                         .labelProvider(variableManager -> "label")
                         .toolSections(List.of())
-                        .tools(List.of())
                         .nodeDescriptions(new ArrayList<>())
                         .targetObjectIdProvider(variableManager -> "targetObjectId")
                         .dropHandler(variableManager -> new Failure(""))

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/GetConnectorToolsEventHandlerTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/GetConnectorToolsEventHandlerTests.java
@@ -167,7 +167,6 @@ public class GetConnectorToolsEventHandlerTests {
                 .nodeDescriptions(List.of(nodeDescription))
                 .edgeDescriptions(new ArrayList<>())
                 .toolSections(List.of(toolSection))
-                .tools(List.of())
                 .dropHandler(variableManager -> new Failure(""))
                 .build();
         //@formatter:on

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/DefaultTestDiagramDescriptionProvider.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/DefaultTestDiagramDescriptionProvider.java
@@ -301,7 +301,6 @@ public class DefaultTestDiagramDescriptionProvider {
                  .canCreatePredicate(variableManager -> false)
                  .labelProvider(variableManager -> variableManager.get(DiagramDescription.LABEL, String.class).orElse(""))
                  .toolSections(List.of())
-                 .tools(List.of())
                  .nodeDescriptions(List.of(nodeDescription))
                  .edgeDescriptions(List.of(edgeDescription))
                  .dropHandler(variableManager -> new Failure(""))

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/TestDiagramDescriptionBuilder.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/TestDiagramDescriptionBuilder.java
@@ -52,7 +52,6 @@ public class TestDiagramDescriptionBuilder {
             .nodeDescriptions(nodeDescriptions)
             .edgeDescriptions(edgeDescriptions)
             .toolSections(toolSections)
-            .tools(List.of())
             .dropHandler(variableManager -> new Failure(""))
             .build();
         // @formatter:on

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/description/DiagramDescription.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/description/DiagramDescription.java
@@ -19,7 +19,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.eclipse.sirius.components.annotations.Immutable;
-import org.eclipse.sirius.components.diagrams.tools.ITool;
 import org.eclipse.sirius.components.diagrams.tools.ToolSection;
 import org.eclipse.sirius.components.representations.IRepresentationDescription;
 import org.eclipse.sirius.components.representations.IStatus;
@@ -59,8 +58,6 @@ public final class DiagramDescription implements IRepresentationDescription {
     private List<NodeDescription> nodeDescriptions;
 
     private List<EdgeDescription> edgeDescriptions;
-
-    private List<ITool> tools;
 
     private Function<VariableManager, IStatus> dropHandler;
 
@@ -107,10 +104,6 @@ public final class DiagramDescription implements IRepresentationDescription {
         return this.edgeDescriptions;
     }
 
-    public List<ITool> getTools() {
-        return this.tools;
-    }
-
     public Function<VariableManager, IStatus> getDropHandler() {
         return this.dropHandler;
     }
@@ -154,8 +147,6 @@ public final class DiagramDescription implements IRepresentationDescription {
 
         private List<EdgeDescription> edgeDescriptions;
 
-        private List<ITool> tools;
-
         private Function<VariableManager, IStatus> dropHandler;
 
         private Builder(String id) {
@@ -172,7 +163,6 @@ public final class DiagramDescription implements IRepresentationDescription {
             this.toolSections = diagramDescription.getToolSections();
             this.nodeDescriptions = diagramDescription.getNodeDescriptions();
             this.edgeDescriptions = diagramDescription.getEdgeDescriptions();
-            this.tools = diagramDescription.getTools();
             this.dropHandler = diagramDescription.getDropHandler();
         }
 
@@ -216,11 +206,6 @@ public final class DiagramDescription implements IRepresentationDescription {
             return this;
         }
 
-        public Builder tools(List<ITool> tools) {
-            this.tools = Objects.requireNonNull(tools);
-            return this;
-        }
-
         public Builder dropHandler(Function<VariableManager, IStatus> dropHandler) {
             this.dropHandler = Objects.requireNonNull(dropHandler);
             return this;
@@ -237,7 +222,6 @@ public final class DiagramDescription implements IRepresentationDescription {
             diagramDescription.toolSections = Objects.requireNonNull(this.toolSections);
             diagramDescription.nodeDescriptions = Objects.requireNonNull(this.nodeDescriptions);
             diagramDescription.edgeDescriptions = Objects.requireNonNull(this.edgeDescriptions);
-            diagramDescription.tools = Objects.requireNonNull(this.tools);
             diagramDescription.dropHandler = Objects.requireNonNull(this.dropHandler);
             return diagramDescription;
         }

--- a/packages/diagrams/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/DiagramElementChangeVisibilityTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/DiagramElementChangeVisibilityTests.java
@@ -195,7 +195,6 @@ public class DiagramElementChangeVisibilityTests {
                 .nodeDescriptions(nodeDescriptions)
                 .edgeDescriptions(edgeDescriptions)
                 .toolSections(List.of())
-                .tools(List.of())
                 .dropHandler(variableManager -> new Failure(""))
                 .build();
 

--- a/packages/diagrams/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/DiagramRendererEdgeTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/DiagramRendererEdgeTests.java
@@ -144,7 +144,6 @@ public class DiagramRendererEdgeTests {
                 .nodeDescriptions(nodeDescriptions)
                 .edgeDescriptions(edgeDescriptions)
                 .toolSections(List.of())
-                .tools(List.of())
                 .dropHandler(variableManager -> new Failure(""))
                 .build();
         // @formatter:on

--- a/packages/diagrams/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/DiagramRendererNodeTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/DiagramRendererNodeTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo and others.
+ * Copyright (c) 2019, 2023 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -278,7 +278,6 @@ public class DiagramRendererNodeTests {
                 .nodeDescriptions(List.of(nodeDescription))
                 .edgeDescriptions(new ArrayList<>())
                 .toolSections(List.of())
-                .tools(List.of())
                 .dropHandler(variableManager -> new Failure(""))
                 .build();
         // @formatter:on

--- a/packages/diagrams/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/UnsynchronizedDiagramTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/UnsynchronizedDiagramTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo and others.
+ * Copyright (c) 2019, 2023 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -354,7 +354,6 @@ public class UnsynchronizedDiagramTests {
                 .nodeDescriptions(List.of(unsynchronizedNodeDescription, synchronizedNodeDescription))
                 .edgeDescriptions(List.of())
                 .toolSections(List.of())
-                .tools(List.of())
                 .dropHandler(variableManager -> new Failure(""))
                 .build();
         // @formatter:on

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewDiagramDescriptionConverter.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewDiagramDescriptionConverter.java
@@ -56,9 +56,7 @@ import org.eclipse.sirius.components.diagrams.description.LabelStyleDescription;
 import org.eclipse.sirius.components.diagrams.description.NodeDescription;
 import org.eclipse.sirius.components.diagrams.description.SynchronizationPolicy;
 import org.eclipse.sirius.components.diagrams.elements.NodeElementProps;
-import org.eclipse.sirius.components.diagrams.events.ReconnectEdgeKind;
 import org.eclipse.sirius.components.diagrams.renderer.DiagramRenderingCache;
-import org.eclipse.sirius.components.diagrams.tools.EdgeReconnectionTool;
 import org.eclipse.sirius.components.diagrams.tools.ITool;
 import org.eclipse.sirius.components.diagrams.tools.SingleClickOnDiagramElementTool;
 import org.eclipse.sirius.components.diagrams.tools.SingleClickOnTwoDiagramElementsCandidate;
@@ -84,8 +82,6 @@ import org.eclipse.sirius.components.view.ListLayoutStrategyDescription;
 import org.eclipse.sirius.components.view.NodeStyleDescription;
 import org.eclipse.sirius.components.view.NodeTool;
 import org.eclipse.sirius.components.view.RepresentationDescription;
-import org.eclipse.sirius.components.view.SourceEdgeEndReconnectionTool;
-import org.eclipse.sirius.components.view.TargetEdgeEndReconnectionTool;
 import org.eclipse.sirius.components.view.ViewPackage;
 import org.eclipse.sirius.components.view.emf.IRepresentationDescriptionConverter;
 import org.eclipse.sirius.components.view.emf.diagram.providers.api.IViewToolImageProvider;
@@ -159,7 +155,6 @@ public class ViewDiagramDescriptionConverter implements IRepresentationDescripti
                 .nodeDescriptions(nodeDescriptions)
                 .edgeDescriptions(edgeDescriptions)
                 .toolSections(this.createToolSections(converterContext))
-                .tools(this.createTools(converterContext))
                 .dropHandler(this.createDiagramDropHandler(viewDiagramDescription, converterContext))
                 .build();
         // @formatter:on
@@ -412,31 +407,6 @@ public class ViewDiagramDescriptionConverter implements IRepresentationDescripti
             }
         }
         return allTargetDescriptions;
-    }
-
-    private List<ITool> createTools(ViewDiagramDescriptionConverterContext converterContext) {
-        var capturedConvertedNodes = Map.copyOf(converterContext.getConvertedNodes());
-        List<ITool> tools = new ArrayList<>();
-        int i = 0;
-        for (var edgeDescription : converterContext.getConvertedEdges().keySet()) {
-            for (org.eclipse.sirius.components.view.EdgeReconnectionTool edgeReconnectionTool : edgeDescription.getReconnectEdgeTools()) {
-                // @formatter:off
-                EdgeReconnectionTool.Builder reconnectionToolBuilder = EdgeReconnectionTool.newEdgeReconnectionTool(this.getToolId(edgeDescription, i++))
-                        .label(edgeReconnectionTool.getName())
-                        .handler(variableManager -> new DiagramOperationInterpreter(converterContext.getInterpreter(), this.objectService, this.editService, this.getDiagramContext(variableManager), capturedConvertedNodes).executeTool(edgeReconnectionTool, variableManager));
-                // @formatter:on
-
-                if (edgeReconnectionTool instanceof SourceEdgeEndReconnectionTool) {
-                    reconnectionToolBuilder.kind(ReconnectEdgeKind.SOURCE);
-                } else if (edgeReconnectionTool instanceof TargetEdgeEndReconnectionTool) {
-                    reconnectionToolBuilder.kind(ReconnectEdgeKind.TARGET);
-                }
-
-                tools.add(reconnectionToolBuilder.build());
-            }
-        }
-
-        return tools;
     }
 
     private LabelDescription getLabelDescription(org.eclipse.sirius.components.view.NodeDescription viewNodeDescription, AQLInterpreter interpreter) {


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1615
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [x] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [x] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?