### PR TITLE
[1583] Improve support for diagram nodes labels' auto-wrap

### DIFF
--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramCreationService.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramCreationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo and others.
+ * Copyright (c) 2019, 2023 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,8 @@ import org.eclipse.sirius.components.diagrams.layout.api.ILayoutService;
 import org.eclipse.sirius.components.diagrams.renderer.DiagramRenderer;
 import org.eclipse.sirius.components.representations.Element;
 import org.eclipse.sirius.components.representations.VariableManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -60,6 +62,8 @@ public class DiagramCreationService implements IDiagramCreationService {
     private final ILayoutService layoutService;
 
     private final Timer timer;
+
+    private final Logger logger = LoggerFactory.getLogger(DiagramCreationService.class);
 
     public DiagramCreationService(IRepresentationDescriptionSearchService representationDescriptionSearchService, IRepresentationPersistenceService representationPersistenceService,
             IObjectService objectService, ILayoutService layoutService, MeterRegistry meterRegistry) {
@@ -140,6 +144,8 @@ public class DiagramCreationService implements IDiagramCreationService {
 
         long end = System.currentTimeMillis();
         this.timer.record(end - start, TimeUnit.MILLISECONDS);
+        this.logger.trace("diagram refreshed in {}ms", end - start);
+
         return newDiagram;
     }
 

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/ELKDiagramConverter.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/ELKDiagramConverter.java
@@ -123,7 +123,7 @@ public class ELKDiagramConverter implements IELKDiagramConverter {
         String labelType = this.elkPropertiesService.getNodeLabelType(node, layoutConfigurator);
         if (labelType.startsWith("label:inside-v")) {
             double maxPadding = this.elkPropertiesService.getMaxPadding(node, layoutConfigurator);
-            textBounds = this.textBoundsService.getAutoWrapBounds(label, node.getSize().getWidth() - maxPadding);
+            textBounds = this.textBoundsService.getAutoWrapBounds(label, node.getSize().getWidth() - maxPadding * 2);
             elkNode.setDimensions(node.getSize().getWidth(), node.getSize().getHeight());
         } else {
             textBounds = this.textBoundsService.getBounds(label);

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/IncrementalLayoutDiagramConverter.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/IncrementalLayoutDiagramConverter.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.components.diagrams.ViewModifier;
 import org.eclipse.sirius.components.diagrams.components.LabelType;
 import org.eclipse.sirius.components.diagrams.layout.ELKPropertiesService;
 import org.eclipse.sirius.components.diagrams.layout.ISiriusWebLayoutConfigurator;
+import org.eclipse.sirius.components.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.components.diagrams.layout.incremental.data.DiagramLayoutData;
 import org.eclipse.sirius.components.diagrams.layout.incremental.data.EdgeLayoutData;
 import org.eclipse.sirius.components.diagrams.layout.incremental.data.IContainerLayoutData;
@@ -45,9 +46,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class IncrementalLayoutDiagramConverter {
 
+    private final TextBoundsService textBoundsService;
+
     private final ELKPropertiesService elkPropertiesService;
 
-    public IncrementalLayoutDiagramConverter(ELKPropertiesService elkPropertiesService) {
+    public IncrementalLayoutDiagramConverter(TextBoundsService textBoundsService, ELKPropertiesService elkPropertiesService) {
+        this.textBoundsService = Objects.requireNonNull(textBoundsService);
         this.elkPropertiesService = Objects.requireNonNull(elkPropertiesService);
     }
 
@@ -171,9 +175,10 @@ public class IncrementalLayoutDiagramConverter {
 
         TextBounds textBounds = null;
         if (labelType.startsWith("label:inside-v")) {
-            textBounds = new TextBoundsProvider().computeAutoWrapBounds(label.getStyle(), label.getText(), node.getSize().getWidth());
+            double maxPadding = this.elkPropertiesService.getMaxPadding(node, layoutConfigurator);
+            textBounds = this.textBoundsService.getAutoWrapBounds(label, node.getSize().getWidth() - maxPadding * 2);
         } else {
-            textBounds = new TextBoundsProvider().computeBounds(label.getStyle(), label.getText());
+            textBounds = this.textBoundsService.getBounds(label);
         }
         layoutData.setTextBounds(textBounds);
 

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/DiagramLayoutTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/DiagramLayoutTests.java
@@ -42,6 +42,7 @@ import org.eclipse.sirius.components.diagrams.layout.IELKDiagramConverter;
 import org.eclipse.sirius.components.diagrams.layout.ILayoutEngineHandlerSwitchProvider;
 import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
 import org.eclipse.sirius.components.diagrams.layout.LayoutService;
+import org.eclipse.sirius.components.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageNodeStyleSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodeSizeProvider;
@@ -73,6 +74,8 @@ public class DiagramLayoutTests {
     private TestLayoutObjectService objectService = new TestLayoutObjectService();
 
     private DefaultTestDiagramDescriptionProvider defaultTestDiagramDescriptionProvider = new DefaultTestDiagramDescriptionProvider(this.objectService);
+
+    private TextBoundsService textBoundsService = new TextBoundsService();
 
     private ELKPropertiesService elkPropertiesService = new ELKPropertiesService();
 
@@ -113,8 +116,9 @@ public class DiagramLayoutTests {
         ILayoutEngineHandlerSwitchProvider layoutEngineHandlerSwitchProvider = () -> new LayoutEngineHandlerSwitch(borderNodeLayoutEngine, List.of(), imageNodeStyleSizeProvider);
         IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(layoutEngineHandlerSwitchProvider);
 
-        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.elkPropertiesService), new LayoutConfiguratorRegistry(List.of()),
-                new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.textBoundsService, this.elkPropertiesService),
+                new LayoutConfiguratorRegistry(List.of()), new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(),
+                representationDescriptionSearchService, incrementalLayoutEngine);
 
         return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
     }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/EdgeLayoutTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/EdgeLayoutTests.java
@@ -34,6 +34,7 @@ import org.eclipse.sirius.components.diagrams.layout.IELKDiagramConverter;
 import org.eclipse.sirius.components.diagrams.layout.ILayoutEngineHandlerSwitchProvider;
 import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
 import org.eclipse.sirius.components.diagrams.layout.LayoutService;
+import org.eclipse.sirius.components.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageNodeStyleSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodeSizeProvider;
@@ -57,6 +58,8 @@ public class EdgeLayoutTests {
 
     private DefaultTestDiagramDescriptionProvider defaultTestDiagramDescriptionProvider = new DefaultTestDiagramDescriptionProvider(this.objectService);
 
+    private TextBoundsService textBoundsService = new TextBoundsService();
+
     private ELKPropertiesService elkPropertiesService = new ELKPropertiesService();
 
     private TestDiagramCreationService createDiagramCreationService(Diagram diagram) {
@@ -75,8 +78,9 @@ public class EdgeLayoutTests {
         ILayoutEngineHandlerSwitchProvider layoutEngineHandlerSwitchProvider = () -> new LayoutEngineHandlerSwitch(borderNodeLayoutEngine, List.of(), imageNodeStyleSizeProvider);
         IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(layoutEngineHandlerSwitchProvider);
 
-        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.elkPropertiesService), new LayoutConfiguratorRegistry(List.of()),
-                new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.textBoundsService, this.elkPropertiesService),
+                new LayoutConfiguratorRegistry(List.of()), new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(),
+                representationDescriptionSearchService, incrementalLayoutEngine);
 
         return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
     }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/IncrementalLayoutTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/IncrementalLayoutTests.java
@@ -43,6 +43,7 @@ import org.eclipse.sirius.components.diagrams.layout.IELKDiagramConverter;
 import org.eclipse.sirius.components.diagrams.layout.ILayoutEngineHandlerSwitchProvider;
 import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
 import org.eclipse.sirius.components.diagrams.layout.LayoutService;
+import org.eclipse.sirius.components.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageNodeStyleSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodeSizeProvider;
@@ -66,6 +67,8 @@ public class IncrementalLayoutTests {
     private TestLayoutObjectService objectService = new TestLayoutObjectService();
 
     private DefaultTestDiagramDescriptionProvider defaultTestDiagramDescriptionProvider = new DefaultTestDiagramDescriptionProvider(this.objectService);
+
+    private TextBoundsService textBoundsService = new TextBoundsService();
 
     private ELKPropertiesService elkPropertiesService = new ELKPropertiesService();
 
@@ -214,8 +217,9 @@ public class IncrementalLayoutTests {
         ILayoutEngineHandlerSwitchProvider layoutEngineHandlerSwitchProvider = () -> new LayoutEngineHandlerSwitch(borderNodeLayoutEngine, List.of(), imageNodeStyleSizeProvider);
         IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(layoutEngineHandlerSwitchProvider);
 
-        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.elkPropertiesService), new LayoutConfiguratorRegistry(List.of()),
-                new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.textBoundsService, this.elkPropertiesService),
+                new LayoutConfiguratorRegistry(List.of()), new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(),
+                representationDescriptionSearchService, incrementalLayoutEngine);
 
         return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
     }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeCollapseExpandTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeCollapseExpandTests.java
@@ -38,6 +38,7 @@ import org.eclipse.sirius.components.diagrams.layout.IELKDiagramConverter;
 import org.eclipse.sirius.components.diagrams.layout.ILayoutEngineHandlerSwitchProvider;
 import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
 import org.eclipse.sirius.components.diagrams.layout.LayoutService;
+import org.eclipse.sirius.components.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageNodeStyleSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodeSizeProvider;
@@ -95,8 +96,9 @@ public class NodeCollapseExpandTests {
         ILayoutEngineHandlerSwitchProvider layoutEngineHandlerSwitchProvider = () -> new LayoutEngineHandlerSwitch(borderNodeLayoutEngine, List.of(), imageNodeStyleSizeProvider);
         IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(layoutEngineHandlerSwitchProvider);
 
-        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(new ELKPropertiesService()), new LayoutConfiguratorRegistry(List.of()),
-                new ELKLayoutedDiagramProvider(List.of(), new ELKPropertiesService()), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(new TextBoundsService(), new ELKPropertiesService()),
+                new LayoutConfiguratorRegistry(List.of()), new ELKLayoutedDiagramProvider(List.of(), new ELKPropertiesService()), new IncrementalLayoutedDiagramProvider(),
+                representationDescriptionSearchService, incrementalLayoutEngine);
 
         return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
     }
@@ -140,7 +142,7 @@ public class NodeCollapseExpandTests {
         assertThat(laidOutDiagram.getNodes()).hasSize(2);
         Node laidOutContainer = laidOutDiagram.getNodes().get(1);
         assertThat(laidOutContainer.getPosition()).isEqualTo(Position.at(10, 10));
-        assertThat(laidOutContainer.getSize()).isEqualTo(Size.of(150, 70));
+        assertThat(laidOutContainer.getSize()).isEqualTo(Size.of(200, 70));
     }
 
     @Test
@@ -188,13 +190,13 @@ public class NodeCollapseExpandTests {
         assertThat(laidOutDiagram.getNodes()).hasSize(2);
         Node laidOutContainer = laidOutDiagram.getNodes().get(1);
         assertThat(laidOutContainer.getPosition()).isEqualTo(Position.at(10, 10));
-        assertThat(laidOutContainer.getSize().getWidth()).isEqualTo(174);
-        assertThat(laidOutContainer.getSize().getHeight()).isBetween(124.0, 125.0);
+        assertThat(laidOutContainer.getSize().getWidth()).isEqualTo(200);
+        assertThat(laidOutContainer.getSize().getHeight()).isBetween(118.0, 119.0);
         assertThat(laidOutContainer.getChildNodes()).hasSize(1);
 
         Node laidOutChild = laidOutContainer.getChildNodes().get(0);
         assertThat(laidOutChild.getPosition().getX()).isEqualTo(12);
-        assertThat(laidOutChild.getPosition().getY()).isBetween(42.0, 43.0);
+        assertThat(laidOutChild.getPosition().getY()).isBetween(36.0, 37.0);
         assertThat(laidOutChild.getSize()).isEqualTo(Size.of(150, 70));
 
         Edge laidOutEdge = laidOutDiagram.getEdges().get(0);

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeCreationTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeCreationTests.java
@@ -41,6 +41,7 @@ import org.eclipse.sirius.components.diagrams.layout.ILayoutEngineHandlerSwitchP
 import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
 import org.eclipse.sirius.components.diagrams.layout.LayoutOptionValues;
 import org.eclipse.sirius.components.diagrams.layout.LayoutService;
+import org.eclipse.sirius.components.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageNodeStyleSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodePositionProvider;
@@ -63,6 +64,8 @@ public class NodeCreationTests {
     private TestLayoutObjectService objectService = new TestLayoutObjectService();
 
     private DefaultTestDiagramDescriptionProvider defaultTestDiagramDescriptionProvider = new DefaultTestDiagramDescriptionProvider(this.objectService);
+
+    private TextBoundsService textBoundsService = new TextBoundsService();
 
     private ELKPropertiesService elkPropertiesService = new ELKPropertiesService();
 
@@ -286,8 +289,9 @@ public class NodeCreationTests {
         ILayoutEngineHandlerSwitchProvider layoutEngineHandlerSwitchProvider = () -> new LayoutEngineHandlerSwitch(borderNodeLayoutEngine, List.of(), imageNodeStyleSizeProvider);
         IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(layoutEngineHandlerSwitchProvider);
 
-        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.elkPropertiesService), new LayoutConfiguratorRegistry(List.of()),
-                new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.textBoundsService, this.elkPropertiesService),
+                new LayoutConfiguratorRegistry(List.of()), new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(),
+                representationDescriptionSearchService, incrementalLayoutEngine);
 
         return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
     }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeMoveTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeMoveTests.java
@@ -35,6 +35,7 @@ import org.eclipse.sirius.components.diagrams.layout.IELKDiagramConverter;
 import org.eclipse.sirius.components.diagrams.layout.ILayoutEngineHandlerSwitchProvider;
 import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
 import org.eclipse.sirius.components.diagrams.layout.LayoutService;
+import org.eclipse.sirius.components.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageNodeStyleSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodeSizeProvider;
@@ -55,6 +56,8 @@ public class NodeMoveTests {
     private TestLayoutObjectService objectService = new TestLayoutObjectService();
 
     private DefaultTestDiagramDescriptionProvider defaultTestDiagramDescriptionProvider = new DefaultTestDiagramDescriptionProvider(this.objectService);
+
+    private TextBoundsService textBoundsService = new TextBoundsService();
 
     private ELKPropertiesService elkPropertiesService = new ELKPropertiesService();
 
@@ -121,8 +124,9 @@ public class NodeMoveTests {
         ILayoutEngineHandlerSwitchProvider layoutEngineHandlerSwitchProvider = () -> new LayoutEngineHandlerSwitch(borderNodeLayoutEngine, List.of(), imageNodeStyleSizeProvider);
         IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(layoutEngineHandlerSwitchProvider);
 
-        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.elkPropertiesService), new LayoutConfiguratorRegistry(List.of()),
-                new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.textBoundsService, this.elkPropertiesService),
+                new LayoutConfiguratorRegistry(List.of()), new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(),
+                representationDescriptionSearchService, incrementalLayoutEngine);
 
         return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
     }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeResizeTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeResizeTests.java
@@ -38,6 +38,7 @@ import org.eclipse.sirius.components.diagrams.layout.IELKDiagramConverter;
 import org.eclipse.sirius.components.diagrams.layout.ILayoutEngineHandlerSwitchProvider;
 import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
 import org.eclipse.sirius.components.diagrams.layout.LayoutService;
+import org.eclipse.sirius.components.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageNodeStyleSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodeSizeProvider;
@@ -58,6 +59,8 @@ public class NodeResizeTests {
     private TestLayoutObjectService objectService = new TestLayoutObjectService();
 
     private DefaultTestDiagramDescriptionProvider defaultTestDiagramDescriptionProvider = new DefaultTestDiagramDescriptionProvider(this.objectService);
+
+    private TextBoundsService textBoundsService = new TextBoundsService();
 
     private ELKPropertiesService elkPropertiesService = new ELKPropertiesService();
 
@@ -233,8 +236,9 @@ public class NodeResizeTests {
         ILayoutEngineHandlerSwitchProvider layoutEngineHandlerSwitchProvider = () -> new LayoutEngineHandlerSwitch(borderNodeLayoutEngine, List.of(), imageNodeStyleSizeProvider);
         IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(layoutEngineHandlerSwitchProvider);
 
-        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.elkPropertiesService), new LayoutConfiguratorRegistry(List.of()),
-                new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.textBoundsService, this.elkPropertiesService),
+                new LayoutConfiguratorRegistry(List.of()), new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(),
+                representationDescriptionSearchService, incrementalLayoutEngine);
 
         return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
     }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/ReconnectEdgeTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/ReconnectEdgeTests.java
@@ -40,6 +40,7 @@ import org.eclipse.sirius.components.diagrams.layout.IELKDiagramConverter;
 import org.eclipse.sirius.components.diagrams.layout.ILayoutEngineHandlerSwitchProvider;
 import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
 import org.eclipse.sirius.components.diagrams.layout.LayoutService;
+import org.eclipse.sirius.components.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageNodeStyleSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
 import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodeSizeProvider;
@@ -74,6 +75,8 @@ public class ReconnectEdgeTests {
 
     private DefaultTestDiagramDescriptionProvider defaultTestDiagramDescriptionProvider = new DefaultTestDiagramDescriptionProvider(this.objectService);
 
+    private TextBoundsService textBoundsService = new TextBoundsService();
+
     private ELKPropertiesService elkPropertiesService = new ELKPropertiesService();
 
     private TestDiagramCreationService createDiagramCreationService(Diagram diagram) {
@@ -92,8 +95,9 @@ public class ReconnectEdgeTests {
         ILayoutEngineHandlerSwitchProvider layoutEngineHandlerSwitchProvider = () -> new LayoutEngineHandlerSwitch(borderNodeLayoutEngine, List.of(), imageNodeStyleSizeProvider);
         IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(layoutEngineHandlerSwitchProvider);
 
-        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.elkPropertiesService), new LayoutConfiguratorRegistry(List.of()),
-                new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(this.textBoundsService, this.elkPropertiesService),
+                new LayoutConfiguratorRegistry(List.of()), new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(),
+                representationDescriptionSearchService, incrementalLayoutEngine);
 
         return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
     }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/DiagramELKLayoutTest.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/DiagramELKLayoutTest.java
@@ -26,7 +26,6 @@ import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchSe
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.FreeFormLayoutStrategy;
 import org.eclipse.sirius.components.diagrams.Node;
-import org.eclipse.sirius.components.diagrams.Position;
 import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
 import org.eclipse.sirius.components.diagrams.layout.ELKDiagramConverter;
 import org.eclipse.sirius.components.diagrams.layout.ELKLayoutedDiagramProvider;
@@ -60,6 +59,8 @@ public class DiagramELKLayoutTest {
 
     private DefaultTestDiagramDescriptionProvider defaultTestDiagramDescriptionProvider = new DefaultTestDiagramDescriptionProvider(this.objectService);
 
+    private TextBoundsService textBoundsService = new TextBoundsService();
+
     private ELKPropertiesService elkPropertiesService = new ELKPropertiesService();
 
     private TestDiagramCreationService createDiagramCreationService(Diagram diagram) {
@@ -80,8 +81,8 @@ public class DiagramELKLayoutTest {
         IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(layoutEngineHandlerSwitchProvider);
 
         LayoutService layoutService = new LayoutService(new ELKDiagramConverter(new TextBoundsService(), new ImageSizeProvider(), this.elkPropertiesService),
-                new IncrementalLayoutDiagramConverter(this.elkPropertiesService), new LayoutConfiguratorRegistry(List.of()), new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService),
-                new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+                new IncrementalLayoutDiagramConverter(this.textBoundsService, this.elkPropertiesService), new LayoutConfiguratorRegistry(List.of()),
+                new ELKLayoutedDiagramProvider(List.of(), this.elkPropertiesService), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
 
         return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
     }
@@ -115,11 +116,13 @@ public class DiagramELKLayoutTest {
 
         // Check that the parent node and the label have the right size
         assertThat(firstParent.getLabel().getSize().getWidth()).isCloseTo(190.0, Offset.offset(5.0));
-        assertThat(firstParent.getLabel().getSize().getHeight()).isCloseTo(45.0, Offset.offset(5.0));
+        assertThat(firstParent.getLabel().getSize().getHeight()).isCloseTo(40.0, Offset.offset(5.0));
         assertThat(firstParent.getSize().getWidth()).isCloseTo(200.0, Offset.offset(5.0));
-        assertThat(firstParent.getSize().getHeight()).isCloseTo(185.0, Offset.offset(5.0));
+        assertThat(firstParent.getSize().getHeight()).isCloseTo(155.0, Offset.offset(5.0));
 
         // Check that the inner node is under the multi line label area
-        assertThat(firstParent.getChildNodes().get(0).getPosition()).isEqualTo(Position.at(12, 66));
+        assertThat(firstParent.getChildNodes().get(0).getPosition().getX()).isCloseTo(12, Offset.offset(0.1));
+        assertThat(firstParent.getChildNodes().get(0).getPosition().getY()).isCloseTo(55.8, Offset.offset(0.1));
+
     }
 }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/TextBoundsServiceTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/TextBoundsServiceTests.java
@@ -1,0 +1,293 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.layout.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.data.Offset;
+import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.LabelStyle;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
+import org.eclipse.sirius.components.diagrams.TextBounds;
+import org.eclipse.sirius.components.diagrams.layout.TextBoundsService;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests of the TextBoundsService.
+ *
+ * @author arichard
+ */
+public class TextBoundsServiceTests {
+
+    private static final String BLACK_COLOR = "black";
+
+    private static final String LABEL_ID = "label";
+
+    private static final String LABEL_TYPE = "labelType";
+
+    private static final String LOREM_IPSUM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+            + "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. "
+            + "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. "
+            + "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+    private static final String LOREM_IPSUM_WITH_NEW_LINE = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. \n"
+            + "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. "
+            + "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. "
+            + "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+    private final TextBoundsService textBoundsService = new TextBoundsService();
+
+    @Test
+    public void smallLabelWithSmallFont() {
+        // @formatter:off
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .color(BLACK_COLOR)
+                .fontSize(8)
+                .bold(false)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .iconURL("")
+                .build();
+
+        Label label = Label.newLabel(LABEL_ID)
+                .alignment(Position.at(0, 0))
+                .position(Position.at(0, 0))
+                .size(Size.of(0, 0))
+                .style(labelStyle)
+                .text("small font")
+                .type(LABEL_TYPE)
+                .build();
+        // @formatter:on
+        TextBounds labelBounds = this.textBoundsService.getAutoWrapBounds(label, 200);
+        assertThat(labelBounds.getSize().getWidth()).isEqualTo(200);
+        assertThat(labelBounds.getSize().getHeight()).isCloseTo(11.0, Offset.offset(1.0));
+    }
+
+    @Test
+    public void smallLabelWithNormalFont() {
+        // @formatter:off
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .color(BLACK_COLOR)
+                .fontSize(14)
+                .bold(false)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .iconURL("")
+                .build();
+
+        Label label = Label.newLabel(LABEL_ID)
+                .alignment(Position.at(0, 0))
+                .position(Position.at(0, 0))
+                .size(Size.of(0, 0))
+                .style(labelStyle)
+                .text("default font")
+                .type(LABEL_TYPE)
+                .build();
+        // @formatter:on
+        TextBounds labelBounds = this.textBoundsService.getAutoWrapBounds(label, 200);
+        assertThat(labelBounds.getSize().getWidth()).isEqualTo(200);
+        assertThat(labelBounds.getSize().getHeight()).isCloseTo(19.0, Offset.offset(1.0));
+    }
+
+    @Test
+    public void smallLabelWithBigFont() {
+        // @formatter:off
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .color(BLACK_COLOR)
+                .fontSize(26)
+                .bold(false)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .iconURL("big font")
+                .build();
+
+        Label label = Label.newLabel(LABEL_ID)
+                .alignment(Position.at(0, 0))
+                .position(Position.at(0, 0))
+                .size(Size.of(0, 0))
+                .style(labelStyle)
+                .text("Lorem ipsum")
+                .type(LABEL_TYPE)
+                .build();
+        // @formatter:on
+        TextBounds labelBounds = this.textBoundsService.getAutoWrapBounds(label, 200);
+        assertThat(labelBounds.getSize().getWidth()).isEqualTo(200);
+        assertThat(labelBounds.getSize().getHeight()).isCloseTo(36.0, Offset.offset(1.0));
+    }
+
+    @Test
+    public void labelGreaterThanContainerWithSmallFont() {
+        // @formatter:off
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .color(BLACK_COLOR)
+                .fontSize(8)
+                .bold(false)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .iconURL("")
+                .build();
+
+        Label label = Label.newLabel(LABEL_ID)
+                .alignment(Position.at(0, 0))
+                .position(Position.at(0, 0))
+                .size(Size.of(0, 0))
+                .style(labelStyle)
+                .text(LOREM_IPSUM)
+                .type(LABEL_TYPE)
+                .build();
+        // @formatter:on
+        TextBounds labelBounds = this.textBoundsService.getAutoWrapBounds(label, 400);
+        assertThat(labelBounds.getSize().getWidth()).isEqualTo(400);
+        assertThat(labelBounds.getSize().getHeight()).isCloseTo(59.0, Offset.offset(1.0));
+    }
+
+    @Test
+    public void labelGreaterThanContainerWithNormalFont() {
+        // @formatter:off
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .color(BLACK_COLOR)
+                .fontSize(14)
+                .bold(false)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .iconURL("")
+                .build();
+
+        Label label = Label.newLabel(LABEL_ID)
+                .alignment(Position.at(0, 0))
+                .position(Position.at(0, 0))
+                .size(Size.of(0, 0))
+                .style(labelStyle)
+                .text(LOREM_IPSUM)
+                .type(LABEL_TYPE)
+                .build();
+        // @formatter:on
+        TextBounds labelBounds = this.textBoundsService.getAutoWrapBounds(label, 400);
+        assertThat(labelBounds.getSize().getWidth()).isEqualTo(400);
+        assertThat(labelBounds.getSize().getHeight()).isCloseTo(155.0, Offset.offset(1.0));
+    }
+
+    @Test
+    public void labelGreaterThanContainerWithBigFont() {
+        // @formatter:off
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .color(BLACK_COLOR)
+                .fontSize(26)
+                .bold(false)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .iconURL("")
+                .build();
+
+        Label label = Label.newLabel(LABEL_ID)
+                .alignment(Position.at(0, 0))
+                .position(Position.at(0, 0))
+                .size(Size.of(0, 0))
+                .style(labelStyle)
+                .text(LOREM_IPSUM)
+                .type(LABEL_TYPE)
+                .build();
+        // @formatter:on
+        TextBounds labelBounds = this.textBoundsService.getAutoWrapBounds(label, 400);
+        assertThat(labelBounds.getSize().getWidth()).isEqualTo(400);
+        assertThat(labelBounds.getSize().getHeight()).isCloseTo(570.0, Offset.offset(1.0));
+    }
+
+    @Test
+    public void labelWithNewLineGreaterThanContainerWithSmallFont() {
+        // @formatter:off
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .color(BLACK_COLOR)
+                .fontSize(8)
+                .bold(false)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .iconURL("")
+                .build();
+
+        Label label = Label.newLabel(LABEL_ID)
+                .alignment(Position.at(0, 0))
+                .position(Position.at(0, 0))
+                .size(Size.of(0, 0))
+                .style(labelStyle)
+                .text(LOREM_IPSUM_WITH_NEW_LINE)
+                .type(LABEL_TYPE)
+                .build();
+        // @formatter:on
+        TextBounds labelBounds = this.textBoundsService.getAutoWrapBounds(label, 400);
+        assertThat(labelBounds.getSize().getWidth()).isEqualTo(400);
+        assertThat(labelBounds.getSize().getHeight()).isCloseTo(71.0, Offset.offset(1.0));
+    }
+
+    @Test
+    public void labelWithNewLineGreaterThanContainerWithNormalFont() {
+        // @formatter:off
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .color(BLACK_COLOR)
+                .fontSize(14)
+                .bold(false)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .iconURL("")
+                .build();
+
+        Label label = Label.newLabel(LABEL_ID)
+                .alignment(Position.at(0, 0))
+                .position(Position.at(0, 0))
+                .size(Size.of(0, 0))
+                .style(labelStyle)
+                .text(LOREM_IPSUM_WITH_NEW_LINE)
+                .type(LABEL_TYPE)
+                .build();
+        // @formatter:on
+        TextBounds labelBounds = this.textBoundsService.getAutoWrapBounds(label, 400);
+        assertThat(labelBounds.getSize().getWidth()).isEqualTo(400);
+        assertThat(labelBounds.getSize().getHeight()).isCloseTo(175.0, Offset.offset(1.0));
+    }
+
+    @Test
+    public void labelWithNewLineGreaterThanContainerWithBigFont() {
+        // @formatter:off
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .color(BLACK_COLOR)
+                .fontSize(26)
+                .bold(false)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .iconURL("")
+                .build();
+
+        Label label = Label.newLabel(LABEL_ID)
+                .alignment(Position.at(0, 0))
+                .position(Position.at(0, 0))
+                .size(Size.of(0, 0))
+                .style(labelStyle)
+                .text(LOREM_IPSUM_WITH_NEW_LINE)
+                .type(LABEL_TYPE)
+                .build();
+        // @formatter:on
+        TextBounds labelBounds = this.textBoundsService.getAutoWrapBounds(label, 400);
+        assertThat(labelBounds.getSize().getWidth()).isEqualTo(400);
+        assertThat(labelBounds.getSize().getHeight()).isCloseTo(570.0, Offset.offset(1.0));
+    }
+}

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/sprotty/views/InsideLabelView.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/sprotty/views/InsideLabelView.tsx
@@ -26,8 +26,8 @@ export class InsideLabelView extends SLabelView {
   render(label) {
     const { color, bold, underline, strikeThrough, italic, fontSize, iconURL, opacity } = label.style;
 
-    const width: number = label.parent.size.width - label.position.y * 2;
-    const height: number = label.parent.size.height - label.position.x * 2;
+    const width: number = label.parent.size.width - label.position.x * 2;
+    const height: number = label.parent.size.height - label.position.y * 2;
 
     // The font-family is hardcoded to match with the backend compute bounds algo.
     const textStyle = {
@@ -80,7 +80,7 @@ export class InsideLabelView extends SLabelView {
 
     const foreignObjectContents = (
       <div style={textStyle}>
-        {iconURL ? <img height="16" width="16" alt="" src={iconURL} /> : ''}
+        {iconURL ? <img height="16" width="16" alt="" style={{ marginRight: '4px' }} src={iconURL} /> : ''}
         {label.text}
       </div>
     );

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/main/resources/application-dev.properties
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/main/resources/application-dev.properties
@@ -20,8 +20,6 @@
 server.port=8080
 spring.mvc.pathmatch.matching-strategy=ant-path-matcher
 logging.level.org.eclipse.sirius.web.diagrams.layout.LayoutService=OFF
-logging.level.org.eclipse.sirius.components.collaborative.editingcontext=trace
-logging.level.org.eclipse.sirius.components.graphql.ws.handlers=trace
 
 org.eclipse.sirius.web.customImages.pattern=classpath:/icons/papaya/**
 


### PR DESCRIPTION
Fix some cases where size of the node can be changed multiple times by the arrange all.
Fix use case where icon is besides label.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/1583
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?