### PR TITLE
[1778] Reduce the animation when opening a representation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,7 +27,7 @@
 === Improvements
 
 - https://github.com/eclipse-sirius/sirius-components/issues/593[#593] [domain] Add support for referencing and extending other custom domains
-
+- https://github.com/eclipse-sirius/sirius-components/issues/1778[#1778] [diagram] Opening a diagram is no longer animated and thus faster.
 
 == v2023.3.0
 

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/sprotty/DiagramServer.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/sprotty/DiagramServer.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo and others.
+ * Copyright (c) 2019, 2023 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -306,7 +306,7 @@ export class DiagramServer extends ModelSource {
 
   handleInitializeCanvasBoundsAction(_: InitializeCanvasBoundsAction) {
     if (this.firstOpen && this.currentRoot.id !== INITIAL_ROOT.id) {
-      this.actionDispatcher.dispatch(FitToScreenAction.create([], { padding: 20, maxZoom: 1 }));
+      this.actionDispatcher.dispatch(FitToScreenAction.create([], { padding: 20, maxZoom: 1, animate: false }));
       this.firstOpen = false;
     }
   }
@@ -408,7 +408,7 @@ export class DiagramServer extends ModelSource {
         this.actionDispatcher.dispatchAll(actionsToDispatch);
       });
     } else {
-      this.actionDispatcher.dispatch(UpdateModelAction.create(INITIAL_ROOT));
+      this.actionDispatcher.dispatch(UpdateModelAction.create(INITIAL_ROOT, { animate: false }));
     }
   }
 


### PR DESCRIPTION
Draft for now as I was not yet able to get rid of a visible frame where the diagram is visible in the top-left corner before it gets centered.