### PR TITLE
[1647] Restore the same behavior in the computation of the text bounds…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -78,6 +78,7 @@ This has no visible effect at the moment, but will allow better documentation, v
 It was not actually used, as tools have long been found in `DiagramDescription.getToolSections()` instead.
 - https://github.com/eclipse-sirius/sirius-components/issues/1588[#1588] [project] Moved the action "New Model" and "Upload model" in a new tree toolbar
 - https://github.com/eclipse-sirius/sirius-components/issues/1614[#1614] [graphql] Add a SuccessPayload to replace most basic payloads, add GQLWidgetOperationPayload to replace most basic Operation
+- https://github.com/eclipse-sirius/sirius-components/issues/1647[#1647] [layout] Restore the same behavior in the computation of the text bounds between the frontend and backend
 
 === Dependency update
 

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/TextBoundsService.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/TextBoundsService.java
@@ -20,6 +20,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
 import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.LabelBoundsProvider;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.Position;
 import org.eclipse.sirius.components.diagrams.Size;
@@ -87,11 +88,15 @@ public class TextBoundsService {
     }
 
     public TextBounds getBounds(Label label) {
-        return this.textBoundsProvider.computeBounds(label.getStyle(), label.getText());
+        Position alignment =  Position.newPosition().x(0).y(0).build();
+        Size size = LabelBoundsProvider.getLabelBounds(label.getStyle(), label.getText());
+        return new TextBounds(size, alignment);
     }
 
     public TextBounds getAutoWrapBounds(Label label, double maxWidth) {
-        return this.textBoundsProvider.computeAutoWrapBounds(label.getStyle(), label.getText(), maxWidth);
+        Position alignment =  Position.newPosition().x(0).y(0).build();
+        Size size = LabelBoundsProvider.getLabelBoundsWrapped(label.getStyle(), label.getText(), maxWidth);
+        return new TextBounds(size, alignment);
     }
 
 }

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/LabelBoundsProvider.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/LabelBoundsProvider.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams;
+
+import java.awt.Font;
+import java.awt.GraphicsEnvironment;
+import java.awt.font.FontRenderContext;
+import java.awt.geom.AffineTransform;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/**
+ * Provides the TextBounds of a given text applied to a LabelStyle.
+ * @author mcharfadi
+ */
+public class LabelBoundsProvider {
+    private static final String DEFAULT_LABEL_FONT_NAME = "Arial";
+    private static final String FALLBACK_LABEL_FONT_NAME = "Liberation Sans";
+    private static final AffineTransform AFFINE_TRANSFORM = new AffineTransform();
+    private static final FontRenderContext FONT_RENDER_CONTEXT = new FontRenderContext(AFFINE_TRANSFORM, true, true);
+    private static String fontName;
+
+    public static Size getLabelBounds(LabelStyle labelStyle, String text) {
+        Font font = getFont(labelStyle);
+
+        String maxGlyphHeight = "Éç";
+        Double maxFontHeight = font.getStringBounds(maxGlyphHeight, FONT_RENDER_CONTEXT).getHeight();
+        Double totalHeight = maxFontHeight * text.lines().count();
+
+        String longestLine = text.lines().max(Comparator.comparingInt(String::length)).get();
+        Double maxWidthValue = font.getStringBounds(longestLine, FONT_RENDER_CONTEXT).getWidth();
+
+        return Size.of(Math.round(maxWidthValue), Math.round(totalHeight));
+    }
+
+    private static int round(double d) {
+        double dAbs = Math.abs(d);
+        int i = (int) dAbs;
+        if (d < 0) {
+            return -(i + 1);
+        }
+        else {
+            return i + 1;
+        }
+    }
+
+    public static Size getLabelBoundsWrapped(LabelStyle labelStyle, String text, double containerMaxWidth) {
+        Font font = getFont(labelStyle);
+        String maxGlyphHeight = "Éç";
+        Double maxFontHeight = font.getStringBounds(maxGlyphHeight, FONT_RENDER_CONTEXT).getHeight();
+
+        float maxWidth = 0;
+        if (containerMaxWidth < 0) {
+            maxWidth = 1000;
+        } else {
+            maxWidth = (float) containerMaxWidth;
+        }
+
+        Stream<String> lines = text.lines();
+        int nbTotalLignes = 0;
+        for (String line : lines.toList()) {
+            Double textWidth = font.getStringBounds(line, FONT_RENDER_CONTEXT).getWidth();
+            Double nbLigne = textWidth / maxWidth;
+            nbTotalLignes += round(nbLigne);
+        }
+
+        Double totalHeight = (maxFontHeight * nbTotalLignes) -  maxFontHeight;
+        return Size.of(containerMaxWidth, Math.round(totalHeight));
+    }
+
+    private static Font getFont(LabelStyle labelStyle) {
+        int fontStyle = Font.PLAIN;
+        if (labelStyle.isBold()) {
+            fontStyle = fontStyle | Font.BOLD;
+        }
+        if (labelStyle.isItalic()) {
+            fontStyle = fontStyle | Font.ITALIC;
+        }
+        return new Font(getFontName(), fontStyle, labelStyle.getFontSize());
+    }
+
+    private static String getFontName() {
+        if (fontName == null) {
+            if (isDefaultFontAvailable()) {
+                fontName = DEFAULT_LABEL_FONT_NAME;
+            } else {
+                fontName = FALLBACK_LABEL_FONT_NAME;
+            }
+        }
+        return fontName;
+    }
+
+    private static boolean isDefaultFontAvailable() {
+        GraphicsEnvironment e = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        for (String currentFont : e.getAvailableFontFamilyNames()) {
+            if (DEFAULT_LABEL_FONT_NAME.equals(currentFont)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/sprotty/views/InsideLabelView.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/sprotty/views/InsideLabelView.tsx
@@ -26,8 +26,8 @@ export class InsideLabelView extends SLabelView {
   render(label) {
     const { color, bold, underline, strikeThrough, italic, fontSize, iconURL, opacity } = label.style;
 
-    const width: number = label.parent.size.width - label.position.x * 2;
-    const height: number = label.parent.size.height - label.position.y * 2;
+    const width: number = label.size.width;
+    const height: number = label.size.height;
 
     // The font-family is hardcoded to match with the backend compute bounds algo.
     const textStyle = {
@@ -41,6 +41,8 @@ export class InsideLabelView extends SLabelView {
       'font-style': 'normal',
       'overflow-wrap': 'anywhere',
       'white-space': 'break-spaces',
+      'letter-spacing': 'normal',
+      'line-height': '1',
       display: 'flex',
       'flex-wrap': 'no-wrap',
     };


### PR DESCRIPTION
… between the frontend and backend

Bug: https://github.com/eclipse-sirius/sirius-components/issues/1647

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?