### PR TITLE
[1851] Fix an issue where the explorer could be expanded while not synchronized

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -60,6 +60,7 @@ The result returned and captured in this variable name will not be the real node
 - https://github.com/eclipse-sirius/sirius-components/issues/1838[#1838] [diagram] Collapsing and expanding a node with unsynchronized child nodes will now properly restore the child nodes
 - https://github.com/eclipse-sirius/sirius-components/issues/1775[#1775] [core] Handle representation/document/project label length in UI (by adding ellipsis) and in sirius-web SQL schema (up to 1024 characters)
 - https://github.com/eclipse-sirius/sirius-components/issues/1829[#1829] [diagram] Node descriptions from the view DSL can now reference concepts outside of their containing diagram description
+- https://github.com/eclipse-sirius/sirius-components/issues/1851[#1851] Fix an issue where the explorer could be expanded while not synchronized
 
 === New Features
 
@@ -77,6 +78,7 @@ This will allow us to easily compare the current layout algorithm and the new on
 This has no visible effect at the moment, but will allow better documentation, validation and configuration later.
 - [studio] Add a project template for the Papaya domains and view
 - https://github.com/eclipse-sirius/sirius-components/issues/1667[#1667] [diagram] Make the contextual palette self contained 
+
 
 == v2023.3.0
 

--- a/integration-tests/cypress/integration/project/edit/explorer-toolbar_spec.js
+++ b/integration-tests/cypress/integration/project/edit/explorer-toolbar_spec.js
@@ -56,7 +56,7 @@ describe('/projects/:projectId/edit - Tree toolbar', () => {
     // 6. Activate the synchronisation mode
     cy.getByTestId('tree-synchronise').click();
 
-    // 5. CHECK that the 'GPU' node is visible and selected
+    // 5. CHECK that the 'DSP' node is visible and selected
     cy.getByTestId('DSP').should('exist');
     cy.getByTestId('selected').findByTestId('DSP').should('exist');
   });

--- a/packages/trees/frontend/sirius-components-trees/src/toolbar/TreeToolBar.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/toolbar/TreeToolBar.tsx
@@ -52,7 +52,7 @@ export const TreeToolBar = ({ editingContextId, onSynchronizedClick, synchronize
           color="inherit"
           aria-label="New model"
           title="New model"
-          onClick={() => openNewDocumentModal()}
+          onClick={openNewDocumentModal}
           data-testid="new-model">
           <AddIcon />
         </IconButton>
@@ -62,7 +62,7 @@ export const TreeToolBar = ({ editingContextId, onSynchronizedClick, synchronize
           color="inherit"
           aria-label="Upload model"
           title="Upload model"
-          onClick={() => openUploadDocumentModal()}
+          onClick={openUploadDocumentModal}
           data-testid="upload-document">
           <PublishIcon />
         </IconButton>
@@ -71,7 +71,7 @@ export const TreeToolBar = ({ editingContextId, onSynchronizedClick, synchronize
           size="small"
           aria-label={preferenceButtonSynchroniseTitle}
           title={preferenceButtonSynchroniseTitle}
-          onClick={() => onSynchronizedClick()}
+          onClick={onSynchronizedClick}
           data-testid="tree-synchronise">
           <SwapHorizIcon color={synchronized ? 'inherit' : 'disabled'} />
         </IconButton>


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1851
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?