### PR TITLE
Add new (experimental) layout API, with an empty implementation for now

### DIFF
--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramCreationService.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramCreationService.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.components.collaborative.diagrams;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -34,7 +35,9 @@ import org.eclipse.sirius.components.diagrams.components.DiagramComponentProps.B
 import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
 import org.eclipse.sirius.components.diagrams.events.ArrangeAllEvent;
 import org.eclipse.sirius.components.diagrams.events.IDiagramEvent;
+import org.eclipse.sirius.components.diagrams.layout.api.IDiagramLayoutEngine;
 import org.eclipse.sirius.components.diagrams.layout.api.ILayoutService;
+import org.eclipse.sirius.components.diagrams.layoutdata.DiagramLayoutData;
 import org.eclipse.sirius.components.diagrams.renderer.DiagramRenderer;
 import org.eclipse.sirius.components.representations.Element;
 import org.eclipse.sirius.components.representations.IOperationValidator;
@@ -62,6 +65,8 @@ public class DiagramCreationService implements IDiagramCreationService {
 
     private final ILayoutService layoutService;
 
+    private final IDiagramLayoutEngine diagramLayoutEngine;
+
     private final IOperationValidator operationValidator;
 
     private final Timer timer;
@@ -69,11 +74,12 @@ public class DiagramCreationService implements IDiagramCreationService {
     private final Logger logger = LoggerFactory.getLogger(DiagramCreationService.class);
 
     public DiagramCreationService(IRepresentationDescriptionSearchService representationDescriptionSearchService, IRepresentationPersistenceService representationPersistenceService,
-            IObjectService objectService, ILayoutService layoutService, IOperationValidator operationValidator, MeterRegistry meterRegistry) {
+            IObjectService objectService, ILayoutService layoutService, IDiagramLayoutEngine diagramLayoutEngine, IOperationValidator operationValidator, MeterRegistry meterRegistry) {
         this.representationDescriptionSearchService = Objects.requireNonNull(representationDescriptionSearchService);
         this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
         this.objectService = Objects.requireNonNull(objectService);
         this.layoutService = Objects.requireNonNull(layoutService);
+        this.diagramLayoutEngine = Objects.requireNonNull(diagramLayoutEngine);
         this.operationValidator = Objects.requireNonNull(operationValidator);
         // @formatter:off
         this.timer = Timer.builder(Monitoring.REPRESENTATION_EVENT_PROCESSOR_REFRESH)
@@ -160,6 +166,15 @@ public class DiagramCreationService implements IDiagramCreationService {
             newDiagram = this.layoutService.layout(editingContext, newDiagram);
         } else if (optionalDiagramContext.isPresent()) {
             newDiagram = this.layoutService.incrementalLayout(editingContext, newDiagram, optionalDiagramElementEvent);
+        }
+
+        if (newDiagram.getLabel().endsWith("__EXPERIMENTAL")) {
+            DiagramLayoutData previousLayoutData = new DiagramLayoutData(Map.of(), Map.of(), Map.of());
+            if (!this.shouldPerformFullLayout(optionalDiagramContext, diagramDescription) && optionalPreviousDiagram.isPresent()) {
+                previousLayoutData = optionalPreviousDiagram.get().getLayoutData();
+            }
+            DiagramLayoutData newLayoutData = this.diagramLayoutEngine.layout(editingContext, newDiagram, previousLayoutData, optionalDiagramElementEvent);
+            newDiagram = Diagram.newDiagram(newDiagram).layoutData(newLayoutData).build();
         }
 
         this.representationPersistenceService.save(editingContext, newDiagram);

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/UpdateNodeBoundsEventHandler.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/UpdateNodeBoundsEventHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.Position;
 import org.eclipse.sirius.components.diagrams.Size;
 import org.eclipse.sirius.components.diagrams.events.ResizeEvent;
+import org.eclipse.sirius.components.diagrams.layoutdata.NodeLayoutData;
 import org.springframework.stereotype.Service;
 
 import io.micrometer.core.instrument.Counter;
@@ -100,6 +101,12 @@ public class UpdateNodeBoundsEventHandler implements IDiagramEventHandler {
 
         if (optionalNode.isPresent() && (optionalNode.get().isUserResizable() || newSize.equals(optionalNode.get().getSize()))) {
             Position oldPosition = optionalNode.get().getPosition();
+            if (diagramContext.getDiagram().getLabel().endsWith("__EXPERIMENTAL")) {
+                NodeLayoutData nodeLayoutData = diagramContext.getDiagram().getLayoutData().nodeLayoutData().get(optionalNode.get().getId());
+                if (nodeLayoutData != null) {
+                    oldPosition = Position.at(nodeLayoutData.position().x(), nodeLayoutData.position().y());
+                }
+            }
             //@formatter:off
             Position delta = Position.newPosition()
                     .x(oldPosition.getX() - newPosition.getX())

--- a/packages/diagrams/backend/sirius-components-diagrams-layout-api/src/main/java/org/eclipse/sirius/components/diagrams/layout/api/IDiagramLayoutEngine.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout-api/src/main/java/org/eclipse/sirius/components/diagrams/layout/api/IDiagramLayoutEngine.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.layout.api;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.events.IDiagramEvent;
+import org.eclipse.sirius.components.diagrams.layoutdata.DiagramLayoutData;
+
+/**
+ * Used to layout diagrams.
+ *
+ * @author pcdavid
+ */
+public interface IDiagramLayoutEngine {
+    /**
+     * Computes the new layout to be used for a diagram and its content.
+     *
+     * @param editingContext
+     *            the editing context.
+     * @param diagram
+     *            the diagram's structure (nodes, edges, etc.).
+     * @param previousLayoutData
+     *            the layout data from the previous version of the diagram. This may be empty for the initial layout or
+     *            for a "full" layout.
+     * @param optionalEvent
+     *            if the (incremental) layout was triggered by a user operation (e.g. the invocation of a tool at a
+     *            specific position) the corresponding event with the information relevant for the layout will be
+     *            available here.
+     * @return the layout information to be used for the new version of the diagram.
+     */
+    DiagramLayoutData layout(IEditingContext editingContext, Diagram diagram, DiagramLayoutData previousLayoutData, Optional<IDiagramEvent> optionalDiagramEvent);
+
+    /**
+     * Implementation which does nothing, used for mocks in unit tests.
+     *
+     * @author pcdavid
+     */
+    class NoOp implements IDiagramLayoutEngine {
+
+        @Override
+        public DiagramLayoutData layout(IEditingContext editingContext, Diagram diagram, DiagramLayoutData previousLayoutData, Optional<IDiagramEvent> optionalDiagramEvent) {
+            return Optional.ofNullable(previousLayoutData).orElse(new DiagramLayoutData(Map.of(), Map.of(), Map.of()));
+        }
+
+    }
+}

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/experimental/DiagramLayoutEngine.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/experimental/DiagramLayoutEngine.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.layout.experimental;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.events.IDiagramEvent;
+import org.eclipse.sirius.components.diagrams.layout.api.IDiagramLayoutEngine;
+import org.eclipse.sirius.components.diagrams.layoutdata.DiagramLayoutData;
+import org.springframework.stereotype.Service;
+
+/**
+ * The default {@link IDiagramLayoutEngine}. Empty/no-op for now.
+ *
+ * @author pcdavid
+ */
+@Service
+public class DiagramLayoutEngine implements IDiagramLayoutEngine {
+    @Override
+    public DiagramLayoutData layout(IEditingContext editingContext, Diagram diagram, DiagramLayoutData previousLayoutData, Optional<IDiagramEvent> optionalDiagramEvent) {
+        return new DiagramLayoutData(Map.of(), Map.of(), Map.of());
+    }
+}

--- a/packages/view/backend/sirius-components-view-emf/src/test/java/org/eclipse/sirius/components/view/emf/view/DynamicDiagramsTests.java
+++ b/packages/view/backend/sirius-components-view-emf/src/test/java/org/eclipse/sirius/components/view/emf/view/DynamicDiagramsTests.java
@@ -31,6 +31,7 @@ import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
 import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.layout.api.IDiagramLayoutEngine;
 import org.eclipse.sirius.components.diagrams.layout.api.ILayoutService;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
@@ -158,7 +159,7 @@ public class DynamicDiagramsTests {
         IObjectService objectService = new IObjectService.NoOp();
         ILayoutService layoutService = new ILayoutService.NoOp();
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
-        var diagramCreationService = new DiagramCreationService(representationDescriptionSearchService, new IRepresentationPersistenceService.NoOp(), objectService, layoutService, new IOperationValidator.NoOp(), meterRegistry);
+        var diagramCreationService = new DiagramCreationService(representationDescriptionSearchService, new IRepresentationPersistenceService.NoOp(), objectService, layoutService, new IDiagramLayoutEngine.NoOp(), new IOperationValidator.NoOp(), meterRegistry);
 
         IEditingContext editinContext = new IEditingContext.NoOp();
 


### PR DESCRIPTION
Add a new API for the future layout algorithm, based on the new `Diagram.getLayoutData()` introduced in https://github.com/eclipse-sirius/sirius-components/pull/1832.

Invoke the new API only for `__EXPERIMENTAL` diagrams which use the new layout data.
The initial implementation returns an empty layout data for now, so this does not change the curent behavior for these.