### PR TITLE
[doc] Contribute the shapes of the view creation API

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,10 @@
 
 - Filter tree based representations
 - Add pages to form in the view DSL
+- Simplify the programmatic creation of view models
+- Add the ability to convert an odesign to a view model
+- Provide a view-based version of Flow
+- Add support for the features of the compatibility layer not supported in the view DSL
 
 === Architectural decision records
 

--- a/doc/iterations/2023.6/shapes/add_missing_features_in_the_view_support.adoc
+++ b/doc/iterations/2023.6/shapes/add_missing_features_in_the_view_support.adoc
@@ -1,0 +1,34 @@
+= (M) Add support for the features of the compatibility layer not supported in the view DSL
+
+== Problem
+
+Some odesign concepts are not implemented in View (like selection dialogs or icons support). 
+
+== Key Result
+
+Each new feature works and can be used by the end user, the new flow version is updated to use those features, integration tests of those features are available
+
+== Solution
+
+For each concepts we should provide an adrs that will explain the solution if more details.
+
+We should also provide some mock ui in these adrs.
+
+=== Scenario
+
+An user will be able to use the newly implemented concept that was available in odesign models in updated views.
+
+=== Breadboarding
+
+Futurs ui changes will be discussed in their respective adrs.
+
+=== Cutting backs
+
+Some concepts may be challenging to implement. We will discuss it further in specific adrs.
+
+== Rabbit holes
+
+Some concepts may be challenging to implement. We will discuss it further in specific adrs.
+
+== No-gos
+

--- a/doc/iterations/2023.6/shapes/odesign_to_view_converter_api.adoc
+++ b/doc/iterations/2023.6/shapes/odesign_to_view_converter_api.adoc
@@ -1,0 +1,48 @@
+= (M) Add the ability to convert an odesign to a view model
+
+== Problem
+
+We can create representations descriptions programmatically, with the view model and with the compatibility layer that converts to odesign files in representation descriptions.
+It will be more efficient to concentrate our efforts in the creation of representation description programmatically and with the view model.
+As such the odesign will be converted to a view.
+Using plain old Java code, we should be able to transform an odesign model into a view model while converting the diagram and form descriptions. 
+
+== Key Result
+
+A first version of flow, simplified, is available (potentially behind a flag), integration tests are available to validate the result.
+
+== Solution
+
+This code should be provided in a dedicated project named `sirius-components-odesign-converter`.
+
+```
+package org.eclipse.sirius.components.odesign.converter;
+
+import org.eclipse.sirius.viewpoint.description.Group;
+import org.eclipse.sirius.components.view.View;
+
+public interface IOdesignConverter {
+    Optional<View> convert(Group group);
+}
+```
+
+The implementation will use an iterative transformation approach meaning that the API should be decomposed in smaller APIS that convert specific entities and that it should be possible to add more entities to be converted in the future.
+The implementation will use the the soon to be introduced view creation API.
+
+=== Scenario
+
+A user will be able to use the new interface IOdesignConverter to convert an odesign file to a view model.
+
+=== Breadboarding
+
+No ui changes
+
+=== Cutting backs
+
+We will be able to support more concepts of the odesign model in the view model in a near future
+
+== Rabbit holes
+
+== No-gos
+
+

--- a/doc/iterations/2023.6/shapes/provide_a_view_based_version_of_flow.adoc
+++ b/doc/iterations/2023.6/shapes/provide_a_view_based_version_of_flow.adoc
@@ -1,0 +1,38 @@
+= (M) Provide a view-based version of Flow
+
+== Problem
+
+In order to include a test which covers the odesign to view transformation, we will migrate the existing flow model.
+
+== Key Result
+
+The new view-based version of flow is fully equivalent to the previous odesign based version, all integrations tests of the odesign version of flow are working on the new version
+
+== Solution
+
+We will use the same maven package flow's dependencies.
+We will offer an interface that if implemented will convert the odesign from their path to Views.
+
+=== Scenario
+
+The end user will open Sirius Web and not see any single change at all.
+
+Everything will work as before including our Cypress integration tests.
+
+=== Breadboarding
+
+no ui changes
+
+=== Cutting backs
+
+Some concepts might not be available in the first implementation of the odesign converter.
+They will be added back progressively
+
+== Rabbit holes
+
+== No-gos
+
+
+
+
+

--- a/doc/iterations/2023.6/shapes/simplify_the_programmatic_creation_of_view_models.adoc
+++ b/doc/iterations/2023.6/shapes/simplify_the_programmatic_creation_of_view_models.adoc
@@ -1,0 +1,49 @@
+= (L) Simplify the programmatic creation of view models
+
+== Problem
+
+We can create representations descriptions programmatically, with the view model and with the compatibility layer that converts odesign files in representation descriptions.
+Another use case is to create view models programmatically but we don't have an API to create complex models easily.
+
+
+== Key Result
+
+The Papaya View will be created with this new API and offer the same functionalities than before this implementation.
+All the tests will still work.
+
+
+== Solution
+
+In a project `sirius-components-view-builder`, depending only on `sirius-components-view`, we should provide utility classes to help the creation of view based models.
+We will need to synthesize how other applications using Sirius Web implements some parts of the future API.
+The detailed ADR will gather some feedback first.
+
+
+=== Scenario
+
+Some features that the API will offer are :
+
+* Helpers for creating diagrams, nodes and edges
+* Helpers for creating element's style and conditional style
+* Helpers for creating unsynchronized nodes (including unsynchronized children or recursively with reused node description)
+* Easy access to previously declared elements to use them as reference to other elements (for example an edge description will need some node description)
+* Helpers for creating tools (node & edge creation, delete, direct edit, drag & drop, simple or complex tools)
+* Helpers for creating and reusing AQL expressions that will be used in previous scenarios.
+
+
+=== Breadboarding
+
+no ui changes
+
+=== Cutting backs
+
+The AQL expressions API could be reused for scenarios other than diagram, tool, node and edge creation.
+
+As such, it will probably need specific ADR and might be too large to implement completely in this scope.
+
+== Rabbit holes
+
+== No-gos
+
+The API will not generate a complete diagram description from a metamodel, we want to explicitly control what's created.
+


### PR DESCRIPTION
[doc] Contribute the shapes of the view creation API

- Simplify the programmatic creation of view models
- Add the ability to convert an odesign to a view model
- Convert the flow example to the view DSL
- Add support for the features of the compatibility layer not supported in the view DSL

