### PR TITLE
[1946] Enable child extenders in the View DSL implementation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -42,17 +42,19 @@ In the _styleDescription_, the definition of a color are now a select list of al
 
 === New Features
 
-- https://github.com/eclipse-sirius/sirius-components/issues/1883[#1883] [sirius-web] Add the possibility to programmatically set some metadate such as specifics natures to a project.
+- https://github.com/eclipse-sirius/sirius-components/issues/1883[#1883] [sirius-web] Add the possibility to programmatically set some metadata such as specifics natures to a project.
 These natures can be used later to enable or not some capabilities on a project.
 This work will start by adding the ability to filter the project's domains.
 A large set of features will have to be updated in order to stop considering the list of metamodels available in an editing context as a certainty.
+- https://github.com/eclipse-sirius/sirius-components/issues/1946[1#946] Enabled child extenders in the View DSL implementation.
+This allows downstream projects and applications to provide their own sub-types of the DSL types (e.g. new WidgetDescriptions).
+In addition to registering the extension metadmodel itself, users must provide a `ChildExtenderProvider` bean for their extensions to be properly integrated.
 
 === Improvements
 
 - https://github.com/eclipse-sirius/sirius-components/issues/1869[#1869] [tree] Navigate to the first child with the right arrow if a node is expanded.
 Navigate to the parent with the left arrow if a node is collapsed
 - https://github.com/eclipse-sirius/sirius-components/issues/1621[#1621] [project] Migrate the onboard area to Material-UI
-
 
 == v2023.4.0
 

--- a/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/configuration/ChildExtenderProvider.java
+++ b/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/configuration/ChildExtenderProvider.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.emf.configuration;
+
+import java.util.function.Supplier;
+
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
+
+/**
+ * Used to extend EMF's global IChildCreationExtender.Descriptor.Registry with new IChildCreationExtender.
+ * Corresponds to the {@code org.eclipse.emf.edit.childCreationExtenders} extension point configuration.
+ *
+ * @author pcdavid
+ */
+public record ChildExtenderProvider(String nsURI, Supplier<IChildCreationExtender> childExtenderProvider) {
+}

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/ConditionalItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/ConditionalItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -142,7 +143,7 @@ public class ConditionalItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/DiagramElementDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/DiagramElementDescriptionItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -216,7 +217,7 @@ public class DiagramElementDescriptionItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/DiagramPaletteItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/DiagramPaletteItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -165,7 +166,7 @@ public class DiagramPaletteItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/EdgePaletteItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/EdgePaletteItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -203,7 +204,7 @@ public class EdgePaletteItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/FreeFormLayoutStrategyDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/FreeFormLayoutStrategyDescriptionItemProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Obeo.
+ * Copyright (c) 2021, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -118,7 +119,7 @@ public class FreeFormLayoutStrategyDescriptionItemProvider extends ItemProviderA
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/GroupDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/GroupDescriptionItemProvider.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -320,7 +321,7 @@ public class GroupDescriptionItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/LabelStyleItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/LabelStyleItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -194,7 +195,7 @@ public class LabelStyleItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/ListLayoutStrategyDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/ListLayoutStrategyDescriptionItemProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Obeo.
+ * Copyright (c) 2021, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -118,7 +119,7 @@ public class ListLayoutStrategyDescriptionItemProvider extends ItemProviderAdapt
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/NodePaletteItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/NodePaletteItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -170,7 +171,7 @@ public class NodePaletteItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/OperationItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/OperationItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -163,7 +164,7 @@ public class OperationItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/RepresentationDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/RepresentationDescriptionItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -186,7 +187,7 @@ public class RepresentationDescriptionItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/StyleItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/StyleItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -139,7 +140,7 @@ public class StyleItemProvider extends ItemProviderAdapter implements IEditingDo
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/ToolItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/ToolItemProvider.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -180,7 +181,7 @@ public class ToolItemProvider extends ItemProviderAdapter implements IEditingDom
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/ViewItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/ViewItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -180,7 +181,7 @@ public class ViewItemProvider extends ItemProviderAdapter implements IEditingDom
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/ViewItemProviderAdapterFactory.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/ViewItemProviderAdapterFactory.java
@@ -14,14 +14,19 @@ package org.eclipse.sirius.components.view.provider;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.Notifier;
+import org.eclipse.emf.common.util.ResourceLocator;
+import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.edit.provider.ChangeNotifier;
+import org.eclipse.emf.edit.provider.ChildCreationExtenderManager;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.emf.edit.provider.IChangeNotifier;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IDisposable;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
@@ -29,6 +34,7 @@ import org.eclipse.emf.edit.provider.IItemPropertySource;
 import org.eclipse.emf.edit.provider.INotifyChangedListener;
 import org.eclipse.emf.edit.provider.IStructuredItemContentProvider;
 import org.eclipse.emf.edit.provider.ITreeItemContentProvider;
+import org.eclipse.sirius.components.view.ViewPackage;
 import org.eclipse.sirius.components.view.util.ViewAdapterFactory;
 
 /**
@@ -39,7 +45,7 @@ import org.eclipse.sirius.components.view.util.ViewAdapterFactory;
  *
  * @generated
  */
-public class ViewItemProviderAdapterFactory extends ViewAdapterFactory implements ComposeableAdapterFactory, IChangeNotifier, IDisposable {
+public class ViewItemProviderAdapterFactory extends ViewAdapterFactory implements ComposeableAdapterFactory, IChangeNotifier, IDisposable, IChildCreationExtender {
     /**
      * This keeps track of the root adapter factory that delegates to this adapter factory. <!-- begin-user-doc --> <!--
      * end-user-doc -->
@@ -55,6 +61,13 @@ public class ViewItemProviderAdapterFactory extends ViewAdapterFactory implement
      * @generated
      */
     protected IChangeNotifier changeNotifier = new ChangeNotifier();
+
+    /**
+     * This helps manage the child creation extenders. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    protected ChildCreationExtenderManager childCreationExtenderManager = new ChildCreationExtenderManager(ViewEditPlugin.INSTANCE, ViewPackage.eNS_URI);
 
     /**
      * This keeps track of all the supported types checked by {@link #isFactoryForType isFactoryForType}. <!--
@@ -1818,6 +1831,35 @@ public class ViewItemProviderAdapterFactory extends ViewAdapterFactory implement
         }
 
         return null;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    public List<IChildCreationExtender> getChildCreationExtenders() {
+        return this.childCreationExtenderManager.getChildCreationExtenders();
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public Collection<?> getNewChildDescriptors(Object object, EditingDomain editingDomain) {
+        return this.childCreationExtenderManager.getNewChildDescriptors(object, editingDomain);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public ResourceLocator getResourceLocator() {
+        return this.childCreationExtenderManager;
     }
 
     /**

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/WidgetDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/WidgetDescriptionItemProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -146,7 +147,7 @@ public class WidgetDescriptionItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/WidgetDescriptionStyleItemProvider.java
+++ b/packages/view/backend/sirius-components-view-edit/src/main/java/org/eclipse/sirius/components/view/provider/WidgetDescriptionStyleItemProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Obeo.
+ * Copyright (c) 2021, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
+import org.eclipse.emf.edit.provider.IChildCreationExtender;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
@@ -108,7 +109,7 @@ public class WidgetDescriptionStyleItemProvider extends ItemProviderAdapter
      */
     @Override
     public ResourceLocator getResourceLocator() {
-        return ViewEditPlugin.INSTANCE;
+        return ((IChildCreationExtender) this.adapterFactory).getResourceLocator();
     }
 
 }

--- a/packages/view/backend/sirius-components-view/src/main/resources/model/view.genmodel
+++ b/packages/view/backend/sirius-components-view/src/main/resources/model/view.genmodel
@@ -11,7 +11,7 @@
   <foreignModel>view.ecore</foreignModel>
   <testsDirectory xsi:nil="true"/>
   <genPackages prefix="View" basePackage="org.eclipse.sirius.components" disposableProviderFactory="true"
-      ecorePackage="view.ecore#/">
+      extensibleProviderFactory="true" childCreationExtenders="true" ecorePackage="view.ecore#/">
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="view.ecore#//LayoutDirection">
       <genEnumLiterals ecoreEnumLiteral="view.ecore#//LayoutDirection/Column"/>
     </genEnums>


### PR DESCRIPTION
This allows downstream projects and applications to provide their own
sub-types of the DSL types (e.g. new WidgetDescriptions) and they will
be correctly detected and handled (provided they are properly
registered).

Bug: https://github.com/eclipse-sirius/sirius-components/issues/1946
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?