### PR TITLE
[1982] Make the node label non required

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -50,6 +50,7 @@ Note that double-clicking no longer triggers a direct edit.
 - https://github.com/eclipse-sirius/sirius-web/issues/2264[#2264] [diagram] Add feedback for edge reconnection with React Flow.
 - https://github.com/eclipse-sirius/sirius-web/issues/288[#288] [diagram] Add support for drag and drop of nodes inside diagrams.
 The behavior is controlled by the new _Drop Node_ tools defined on the target element, which can be either a node or the diagram itself (when dropping on the diagram's background).
+- https://github.com/eclipse-sirius/sirius-components/issues/1982[#1982] [diagram] Make the node label non required
 
 === Improvements
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ A new parameter `rootDomainsOnly: Boolean` has been added, allowing to remove do
 For example, Diagram & Form domains are not root domains because `DiagramDescription` and `FormDescription` are not root objects valid candidates.
 - https://github.com/eclipse-sirius/sirius-web/issues/1712[#1712] [diagram] The GraphQL type `Node` must now implement `isLabelEditable` boolean field.
 - https://github.com/eclipse-sirius/sirius-web/issues/2456[#2456] [sirius-web] The GraphQL field `CreateChildSuccessPayload` now expects to have a list of messages.
+- https://github.com/eclipse-sirius/sirius-web/issues/1982[#1982] [diagram] Change the diagram structure. The Node's 'label' attribute has been renamed into 'insideLabel' and its type changed from `Label` to `InsideLabel` (which is currently identical to `Label` except for the name).
 
 === Dependency update
 
@@ -50,7 +51,7 @@ Note that double-clicking no longer triggers a direct edit.
 - https://github.com/eclipse-sirius/sirius-web/issues/2264[#2264] [diagram] Add feedback for edge reconnection with React Flow.
 - https://github.com/eclipse-sirius/sirius-web/issues/288[#288] [diagram] Add support for drag and drop of nodes inside diagrams.
 The behavior is controlled by the new _Drop Node_ tools defined on the target element, which can be either a node or the diagram itself (when dropping on the diagram's background).
-- https://github.com/eclipse-sirius/sirius-components/issues/1982[#1982] [diagram] Make the node label non required
+- https://github.com/eclipse-sirius/sirius-web/issues/1982[#1982] [diagram] Make the node label non required
 
 === Improvements
 

--- a/packages/compatibility/backend/sirius-components-compatibility-emf/src/test/java/org/eclipse/sirius/components/compatibility/emf/compatibility/operations/DeleteViewOperationHandlerTests.java
+++ b/packages/compatibility/backend/sirius-components-compatibility-emf/src/test/java/org/eclipse/sirius/components/compatibility/emf/compatibility/operations/DeleteViewOperationHandlerTests.java
@@ -32,7 +32,7 @@ import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.FreeFormLayoutStrategy;
 import org.eclipse.sirius.components.diagrams.INodeStyle;
 import org.eclipse.sirius.components.diagrams.ImageNodeStyle;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.LineStyle;
 import org.eclipse.sirius.components.diagrams.Node;
@@ -98,7 +98,7 @@ public class DeleteViewOperationHandlerTests {
                 .targetObjectId(UUID.randomUUID().toString())
                 .targetObjectKind("ecore::EPackage")
                 .targetObjectLabel(OperationTestContext.ROOT_PACKAGE_NAME)
-                .label(Label.newLabel(UUID.randomUUID().toString())
+                .insideLabel(InsideLabel.newLabel(UUID.randomUUID().toString())
                         .type("Label")
                         .text(OperationTestContext.ROOT_PACKAGE_NAME)
                         .position(Position.at(0, 0))

--- a/packages/compatibility/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/CompatibilityInitialDirectEditElementLabelProvider.java
+++ b/packages/compatibility/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/CompatibilityInitialDirectEditElementLabelProvider.java
@@ -46,7 +46,7 @@ public class CompatibilityInitialDirectEditElementLabelProvider implements IInit
     public String getInitialDirectEditElementLabel(Object diagramElement, String labelId, Diagram diagram, IEditingContext editingContext) {
         String label = "";
         if (diagramElement instanceof Node node) {
-            label = node.getLabel().getText();
+            label = node.getInsideLabel().getText();
         } else if (diagramElement instanceof Edge edge) {
             if (edge.getBeginLabel() != null && edge.getBeginLabel().getId().equals(labelId)) {
                 label = edge.getBeginLabel().getText();

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramQueryService.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramQueryService.java
@@ -38,7 +38,7 @@ public class DiagramQueryService implements IDiagramQueryService {
 
     @Override
     public Optional<Node> findNodeByLabelId(Diagram diagram, String labelId) {
-        return this.findNode(node -> Objects.equals(node.getLabel().getId(), labelId), diagram.getNodes());
+        return this.findNode(node -> Objects.equals(node.getInsideLabel().getId(), labelId), diagram.getNodes());
     }
 
     private Optional<Node> findNode(Predicate<Node> condition, List<Node> candidates) {

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramElementExportService.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramElementExportService.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.eclipse.sirius.components.collaborative.diagrams.export.api.IImageRegistry;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.LineStyle;
@@ -40,10 +41,14 @@ public class DiagramElementExportService {
     }
 
     public StringBuilder exportLabel(Label label, float opacity, Node node) {
-        if (label.getType().startsWith("label:inside-v")) {
-            return this.exportLabelAsForeignObject(label, opacity, node);
-        }
         return this.exportLabelAsText(label, opacity);
+    }
+
+    public StringBuilder exportInsideLabel(InsideLabel insideLabel, float opacity, Node node) {
+        if (insideLabel.getType().startsWith("label:inside-v")) {
+            return this.exportInsideLabelAsForeignObject(insideLabel, opacity, node);
+        }
+        return this.exportInsideLabelAsText(insideLabel, opacity);
     }
 
     public StringBuilder exportLabelAsText(Label label, float opacity) {
@@ -70,19 +75,46 @@ public class DiagramElementExportService {
         return labelExport.append("</g>");
     }
 
-    public StringBuilder exportLabelAsForeignObject(Label label, float opacity, Node node) {
+
+    public StringBuilder exportInsideLabelAsText(InsideLabel insideLabel, float opacity) {
         StringBuilder labelExport = new StringBuilder();
-        double width = node.getSize().getWidth() - label.getPosition().getX() * 2;
-        double height = node.getSize().getHeight() - label.getPosition().getY() * 2;
+        Position position = insideLabel.getPosition();
+        Position alignment = insideLabel.getAlignment();
+        LabelStyle style = insideLabel.getStyle();
+        String text = insideLabel.getText();
+        String type = insideLabel.getType();
+
+        labelExport.append("<g ");
+        labelExport.append("transform=\"");
+        labelExport.append("translate(" + position.getX() + ", " + position.getY() + ") ");
+        labelExport.append("translate(" + alignment.getX() + ", " + alignment.getY() + ")\" ");
+        labelExport.append("style=\"");
+        labelExport.append("opacity: " + opacity + ";");
+        labelExport.append("\" ");
+        labelExport.append(">");
+
+        if (!(style.getIconURL().isEmpty())) {
+            labelExport.append(this.exportImageElement(style.getIconURL(), -20, -12, Optional.empty(), 1));
+        }
+
+        labelExport.append(this.exportTextElement(text, type, style));
+
+        return labelExport.append("</g>");
+    }
+
+    public StringBuilder exportInsideLabelAsForeignObject(InsideLabel insideLabel, float opacity, Node node) {
+        StringBuilder labelExport = new StringBuilder();
+        double width = node.getSize().getWidth() - insideLabel.getPosition().getX() * 2;
+        double height = node.getSize().getHeight() - insideLabel.getPosition().getY() * 2;
         labelExport.append("<foreignObject ");
         labelExport.append("requiredFeatures=\"http://www.w3.org/TR/SVG11/feature#Extensibility\" ");
         labelExport.append("width=\"").append(width).append("\" ");
         labelExport.append("height=\"").append(height).append("\" ");
-        labelExport.append("transform=\"translate(").append(label.getPosition().getX()).append(", ").append(label.getPosition().getY()).append(")\" ");
+        labelExport.append("transform=\"translate(").append(insideLabel.getPosition().getX()).append(", ").append(insideLabel.getPosition().getY()).append(")\" ");
         labelExport.append("style=\"pointer-events: none;\"");
         labelExport.append(">");
 
-        labelExport.append(this.exportTextElementAsDiv(label.getText(), label.getType(), label.getStyle(), opacity, width, height));
+        labelExport.append(this.exportTextElementAsDiv(insideLabel.getText(), insideLabel.getType(), insideLabel.getStyle(), opacity, width, height));
 
         return labelExport.append("</foreignObject>");
     }

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramExportService.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramExportService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Obeo.
+ * Copyright (c) 2022, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import java.util.Objects;
 import org.eclipse.sirius.components.collaborative.diagrams.export.api.IImageRegistry;
 import org.eclipse.sirius.components.collaborative.diagrams.export.api.ISVGDiagramExportService;
 import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.Position;
@@ -143,10 +144,10 @@ public class DiagramExportService implements ISVGDiagramExportService {
 
     private void computeElementsCoordinates(Diagram diagram) {
         diagram.getNodes().forEach(node -> {
-            this.addElementPositions(node.getPosition(), node.getSize(), node.getLabel(), Position.at(0, 0));
+            this.addElementPositions(node.getPosition(), node.getSize(), node.getInsideLabel(), Position.at(0, 0));
 
             node.getBorderNodes().forEach(border -> {
-                this.addElementPositions(border.getPosition(), border.getSize(), border.getLabel(), node.getPosition());
+                this.addElementPositions(border.getPosition(), border.getSize(), border.getInsideLabel(), node.getPosition());
             });
         });
 
@@ -170,14 +171,29 @@ public class DiagramExportService implements ISVGDiagramExportService {
         });
     }
 
-    private void addElementPositions(Position elementPosition, Size elementSize, Label elementLabel, Position parentPosition) {
+    private void addElementPositions(Position elementPosition, Size elementSize, InsideLabel elementLabel, Position parentPosition) {
         double nodeX = parentPosition.getX() + elementPosition.getX();
         double nodeY = parentPosition.getY() + elementPosition.getY();
         this.xBeginPositions.add(nodeX);
         this.yBeginPositions.add(nodeY);
         this.xEndPositions.add(nodeX + elementSize.getWidth());
         this.yEndPositions.add(nodeY + elementSize.getHeight());
-        this.addAbsoluteLabelPosition(elementLabel, elementPosition);
+        this.addAbsoluteInsideLabelPosition(elementLabel, elementPosition);
+    }
+
+    private void addAbsoluteInsideLabelPosition(InsideLabel insideLabel, Position parentPosition) {
+        double xOffest = parentPosition.getX();
+        double yOffest = parentPosition.getY();
+        Position labelPosition = insideLabel.getPosition();
+        Position labelAlignment = insideLabel.getAlignment();
+        Size labelSize = insideLabel.getSize();
+
+        double xLabel = xOffest + labelPosition.getX() + labelAlignment.getX();
+        double yLabel = yOffest + labelPosition.getY() + labelAlignment.getY();
+        this.xBeginPositions.add(xLabel);
+        this.yBeginPositions.add(yLabel);
+        this.xEndPositions.add(xLabel + labelSize.getWidth());
+        this.yEndPositions.add(yLabel + labelSize.getHeight());
     }
 
     private void addAbsoluteLabelPosition(Label label, Position parentPosition) {

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/NodeExportService.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/NodeExportService.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 import org.eclipse.sirius.components.diagrams.INodeStyle;
 import org.eclipse.sirius.components.diagrams.IconLabelNodeStyle;
 import org.eclipse.sirius.components.diagrams.ImageNodeStyle;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.Position;
 import org.eclipse.sirius.components.diagrams.RectangularNodeStyle;
@@ -81,7 +81,7 @@ public class NodeExportService {
     private StringBuilder exportImage(Node node, ImageNodeStyle style, Map<String, NodeAndContainerId> id2NodeHierarchy, float nodeOpacity) {
         StringBuilder imageExport = new StringBuilder();
         Size size = node.getSize();
-        Label label = node.getLabel();
+        InsideLabel insideLabel = node.getInsideLabel();
 
         // @formatter:off
         var rectangleStyle = RectangleStyle.newRectangleStyle()
@@ -99,13 +99,13 @@ public class NodeExportService {
         Position position = Position.at(-style.getBorderSize() / 2., -style.getBorderSize() / 2.);
         imageExport.append(this.elementExport.exportRectangleElement(imageSize, position, rectangleStyle));
         imageExport.append(this.elementExport.exportImageElement(style.getImageURL(), 0, 0, Optional.of(size), nodeOpacity));
-        imageExport.append(this.elementExport.exportLabel(label, nodeOpacity, node));
+        imageExport.append(this.elementExport.exportInsideLabel(insideLabel, nodeOpacity, node));
         imageExport.append(this.exportChildren(node, id2NodeHierarchy));
 
         return imageExport.append("</g>");
     }
 
-    private StringBuilder exportHeaderSeparator(Node node, Label label, RectangularNodeStyle nodeStyle, float opacity) {
+    private StringBuilder exportHeaderSeparator(Node node, InsideLabel label, RectangularNodeStyle nodeStyle, float opacity) {
         StringBuilder headerExport = new StringBuilder();
         // The label y position indicates the padding top, we suppose the same padding is applied to the bottom.
         double headerLabelPadding = label.getPosition().getY();
@@ -137,7 +137,7 @@ public class NodeExportService {
 
         rectangleExport.append(this.elementExport.exportGNodeElement(node));
         rectangleExport.append(this.elementExport.exportRectangleElement(node.getSize(), Position.at(0, 0), rectangleStyle));
-        rectangleExport.append(this.elementExport.exportLabel(node.getLabel(), nodeOpacity, node));
+        rectangleExport.append(this.elementExport.exportInsideLabel(node.getInsideLabel(), nodeOpacity, node));
         rectangleExport.append(this.exportChildren(node, id2NodeHierarchy));
 
         return rectangleExport.append("</g>");
@@ -159,9 +159,9 @@ public class NodeExportService {
 
         rectangleExport.append(this.elementExport.exportGNodeElement(node));
         rectangleExport.append(this.elementExport.exportRectangleElement(node.getSize(), Position.at(0, 0), rectangleStyle));
-        rectangleExport.append(this.elementExport.exportLabel(node.getLabel(), nodeOpacity, node));
+        rectangleExport.append(this.elementExport.exportInsideLabel(node.getInsideLabel(), nodeOpacity, node));
         if (style.isWithHeader()) {
-            rectangleExport.append(this.exportHeaderSeparator(node, node.getLabel(), style, nodeOpacity));
+            rectangleExport.append(this.exportHeaderSeparator(node, node.getInsideLabel(), style, nodeOpacity));
         }
         rectangleExport.append(this.exportChildren(node, id2NodeHierarchy));
 

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/resources/schema/diagram.graphqls
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/resources/schema/diagram.graphqls
@@ -33,7 +33,7 @@ enum ViewModifier {
 
 type Node {
   id: ID!
-  label: Label!
+  insideLabel: InsideLabel
   descriptionId: ID!
   type: String!
   targetObjectId: String!
@@ -61,6 +61,16 @@ type ListLayoutStrategy {
 union ILayoutStrategy = FreeFormLayoutStrategy | ListLayoutStrategy
 
 type Label {
+  id: ID!
+  text: String!
+  type: String!
+  style: LabelStyle!
+  alignment: Position!
+  position: Position!
+  size: Size!
+}
+
+type InsideLabel {
   id: ID!
   text: String!
   type: String!

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/ChangeVisibilityEventHandlerTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/ChangeVisibilityEventHandlerTests.java
@@ -58,7 +58,7 @@ public class ChangeVisibilityEventHandlerTests {
     private final IDiagramQueryService diagramQueryService = new IDiagramQueryService.NoOp() {
         @Override
         public Optional<Node> findNodeById(Diagram diagram, String nodeId) {
-            return Optional.of(new TestDiagramBuilder().getNode(NODE_ID));
+            return Optional.of(new TestDiagramBuilder().getNode(NODE_ID, true));
         }
 
         @Override

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/DeleteFromDiagramEventHandlerTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/DeleteFromDiagramEventHandlerTests.java
@@ -71,7 +71,7 @@ public class DeleteFromDiagramEventHandlerTests {
     private final IDiagramQueryService diagramQueryService = new IDiagramQueryService.NoOp() {
         @Override
         public Optional<Node> findNodeById(Diagram diagram, String nodeId) {
-            return Optional.of(new TestDiagramBuilder().getNode(NODE_ID));
+            return Optional.of(new TestDiagramBuilder().getNode(NODE_ID, true));
         }
 
         @Override

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/GetConnectorToolsEventHandlerTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/GetConnectorToolsEventHandlerTests.java
@@ -33,7 +33,7 @@ import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchSe
 import org.eclipse.sirius.components.diagrams.CollapsingState;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.FreeFormLayoutStrategy;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.NodeType;
@@ -100,7 +100,7 @@ public class GetConnectorToolsEventHandlerTests {
                 .fontSize(16)
                 .iconURL("")
                 .build();
-        Label label = Label.newLabel(UUID.randomUUID().toString())
+        InsideLabel insdieLabel = InsideLabel.newLabel(UUID.randomUUID().toString())
                 .type("labelType")
                 .text("text")
                 .position(Position.UNDEFINED)
@@ -115,7 +115,7 @@ public class GetConnectorToolsEventHandlerTests {
                 .targetObjectKind("")
                 .targetObjectLabel("")
                 .descriptionId(NODE_DESCRIPTION_ID)
-                .label(label)
+                .insideLabel(insdieLabel)
                 .style(new TestDiagramBuilder().getRectangularNodeStyle())
                 .childrenLayoutStrategy(new FreeFormLayoutStrategy())
                 .position(Position.UNDEFINED)

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/InitialDirectEditElementLabelEventHandlerTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/InitialDirectEditElementLabelEventHandlerTests.java
@@ -76,8 +76,8 @@ public class InitialDirectEditElementLabelEventHandlerTests {
             }
         };
 
-        Node node = new TestDiagramBuilder().getNode(UUID.randomUUID().toString());
-        String labelId = node.getLabel().getId();
+        Node node = new TestDiagramBuilder().getNode(UUID.randomUUID().toString(), true);
+        String labelId = node.getInsideLabel().getId();
         Diagram diagram = Diagram.newDiagram(new TestDiagramBuilder().getDiagram(UUID.randomUUID().toString())).nodes(List.of(node)).build();
 
         var handler = new InitialDirectEditElementLabelEventHandler(representationDescriptionSearchService, new DiagramQueryService(), List.of(initialDirectEditElementLabelProvider),

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/InvokeSingleClickOnDiagramElementToolEventHandlerTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/InvokeSingleClickOnDiagramElementToolEventHandlerTests.java
@@ -40,6 +40,7 @@ import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
 import org.eclipse.sirius.components.diagrams.EdgeStyle;
 import org.eclipse.sirius.components.diagrams.FreeFormLayoutStrategy;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.LineStyle;
@@ -382,7 +383,7 @@ public class InvokeSingleClickOnDiagramElementToolEventHandlerTests {
                 .fontSize(16)
                 .iconURL("")
                 .build();
-        var label = Label.newLabel(UUID.randomUUID().toString())
+        var label = InsideLabel.newLabel(UUID.randomUUID().toString())
                 .type("labelType")
                 .text("text")
                 .position(Position.UNDEFINED)
@@ -397,7 +398,7 @@ public class InvokeSingleClickOnDiagramElementToolEventHandlerTests {
                 .targetObjectKind("")
                 .targetObjectLabel("")
                 .descriptionId(nodeDescriptionId)
-                .label(label)
+                .insideLabel(label)
                 .style(new TestDiagramBuilder().getRectangularNodeStyle())
                 .childrenLayoutStrategy(new FreeFormLayoutStrategy())
                 .position(Position.UNDEFINED)

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/ReconnectEdgeEventHandlerTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/ReconnectEdgeEventHandlerTests.java
@@ -67,9 +67,9 @@ public class ReconnectEdgeEventHandlerTests {
         String previousEdgeEndId = UUID.randomUUID().toString();
         String newEdgeEndId = UUID.randomUUID().toString();
         Edge edge = new TestDiagramBuilder().getEdge(edgeId, sourceEdgeEndId, previousEdgeEndId);
-        Node sourceEdgeEnd = new TestDiagramBuilder().getNode(sourceEdgeEndId);
-        Node previousEdgeEnd = new TestDiagramBuilder().getNode(previousEdgeEndId);
-        Node newEdgeEnd = new TestDiagramBuilder().getNode(newEdgeEndId);
+        Node sourceEdgeEnd = new TestDiagramBuilder().getNode(sourceEdgeEndId, true);
+        Node previousEdgeEnd = new TestDiagramBuilder().getNode(previousEdgeEndId, true);
+        Node newEdgeEnd = new TestDiagramBuilder().getNode(newEdgeEndId, true);
 
         Diagram initialDiagram = new TestDiagramBuilder().getDiagram(UUID.randomUUID().toString());
 

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/UpdateCollapsingStateEventHandlerTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/UpdateCollapsingStateEventHandlerTests.java
@@ -49,7 +49,7 @@ public class UpdateCollapsingStateEventHandlerTests {
     @Test
     public void testCollapseExpandDiagramElement() {
         String nodeId = UUID.randomUUID().toString();
-        Node node = new TestDiagramBuilder().getNode(nodeId);
+        Node node = new TestDiagramBuilder().getNode(nodeId, true);
 
         IDiagramQueryService diagramQueryService = new IDiagramQueryService.NoOp() {
             @Override

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/ELKLayoutedDiagramProvider.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/ELKLayoutedDiagramProvider.java
@@ -31,6 +31,7 @@ import org.eclipse.sirius.components.diagrams.CustomizableProperties;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
 import org.eclipse.sirius.components.diagrams.ImageNodeStyle;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.ParametricSVGNodeStyle;
@@ -93,7 +94,7 @@ public class ELKLayoutedDiagramProvider {
         Size size = Size.of(elkConnectableShape.getWidth(), elkConnectableShape.getHeight());
         Position position = Position.at(elkConnectableShape.getX(), elkConnectableShape.getY());
 
-        Label label = this.getNodeLayoutedLabel(node, id2ElkGraphElements, layoutConfigurator);
+        InsideLabel label = this.getNodeLayoutedLabel(node, id2ElkGraphElements, layoutConfigurator);
 
         List<Node> childNodes = this.getLayoutedNodes(node.getChildNodes(), id2ElkGraphElements, layoutConfigurator);
         List<Node> borderNodes = this.getLayoutedNodes(node.getBorderNodes(), id2ElkGraphElements, layoutConfigurator);
@@ -104,7 +105,7 @@ public class ELKLayoutedDiagramProvider {
         }
         // @formatter:off
         return Node.newNode(node)
-                .label(label)
+                .insideLabel(label)
                 .size(size)
                 .position(position)
                 .childNodes(childNodes)
@@ -245,9 +246,9 @@ public class ELKLayoutedDiagramProvider {
         return layoutedLabel;
     }
 
-    private Label getNodeLayoutedLabel(Node node, Map<String, ElkGraphElement> id2ElkGraphElements, ISiriusWebLayoutConfigurator layoutConfigurator) {
-        Label layoutedLabel = node.getLabel();
-        var optionalElkLabel = Optional.of(id2ElkGraphElements.get(layoutedLabel.getId().toString())).filter(ElkLabel.class::isInstance).map(ElkLabel.class::cast);
+    private InsideLabel getNodeLayoutedLabel(Node node, Map<String, ElkGraphElement> id2ElkGraphElements, ISiriusWebLayoutConfigurator layoutConfigurator) {
+        InsideLabel layoutedInsideLabel = node.getInsideLabel();
+        var optionalElkLabel = Optional.of(id2ElkGraphElements.get(layoutedInsideLabel.getId().toString())).filter(ElkLabel.class::isInstance).map(ElkLabel.class::cast);
         if (optionalElkLabel.isPresent()) {
             ElkLabel elkLabel = optionalElkLabel.get();
 
@@ -287,7 +288,7 @@ public class ELKLayoutedDiagramProvider {
                     .findFirst()
                     .orElse(Position.UNDEFINED);
 
-            layoutedLabel = Label.newLabel(node.getLabel())
+            layoutedInsideLabel = InsideLabel.newInsideLabel(node.getInsideLabel())
                     .type(nodeLabelType)
                     .size(size)
                     .position(position)
@@ -295,7 +296,7 @@ public class ELKLayoutedDiagramProvider {
                     .build();
             // @formatter:on
         }
-        return layoutedLabel;
+        return layoutedInsideLabel;
     }
 
     private Position getAbsolutePosition(ElkNode node) {

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/TextBoundsService.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/TextBoundsService.java
@@ -16,9 +16,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
-
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.Position;
@@ -28,6 +26,9 @@ import org.eclipse.sirius.components.diagrams.TextBoundsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 
 /**
  * Utility class used to compute the size of a piece of text.
@@ -90,8 +91,16 @@ public class TextBoundsService {
         return this.textBoundsProvider.computeBounds(label.getStyle(), label.getText());
     }
 
+    public TextBounds getBounds(InsideLabel insideLabel) {
+        return this.textBoundsProvider.computeBounds(insideLabel.getStyle(), insideLabel.getText());
+    }
+
     public TextBounds getAutoWrapBounds(Label label, double maxWidth) {
         return this.textBoundsProvider.computeAutoWrapBounds(label.getStyle(), label.getText(), maxWidth);
+    }
+
+    public TextBounds getAutoWrapBounds(InsideLabel insideLabel, double maxWidth) {
+        return this.textBoundsProvider.computeAutoWrapBounds(insideLabel.getStyle(), insideLabel.getText(), maxWidth);
     }
 
 }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/experimental/DiagramLayoutConfigurationProvider.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/experimental/DiagramLayoutConfigurationProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
 import org.eclipse.sirius.components.diagrams.INodeStyle;
 import org.eclipse.sirius.components.diagrams.ImageNodeStyle;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.ListLayoutStrategy;
 import org.eclipse.sirius.components.diagrams.Node;
@@ -94,7 +95,7 @@ public class DiagramLayoutConfigurationProvider implements IDiagramLayoutConfigu
         if (node.isBorderNode()) {
             containmentKind = "border";
         }
-        var nodeLabel = Optional.ofNullable(node.getLabel()).map(Label::getText).orElse("nolabel");
+        var nodeLabel = Optional.ofNullable(node.getInsideLabel()).map(InsideLabel::getText).orElse("nolabel");
         var displayName = String.format("%s > [%s node] %s", parentLayoutConfiguration.displayName(), containmentKind, nodeLabel);
 
         var builder = NodeLayoutConfiguration.newNodeLayoutConfiguration(node.getId())
@@ -106,7 +107,7 @@ public class DiagramLayoutConfigurationProvider implements IDiagramLayoutConfigu
                 .minimumSize(new Size(150, 70))
                 .layoutStrategy(this.getLayoutStrategy(node));
 
-        Optional.ofNullable(node.getLabel()).map(this::convertLabel).ifPresent(builder::labelLayoutConfiguration);
+        Optional.ofNullable(node.getInsideLabel()).map(this::convertInsideLabel).ifPresent(builder::labelLayoutConfiguration);
 
         var nodeLayoutConfiguration = builder.build();
 
@@ -163,6 +164,20 @@ public class DiagramLayoutConfigurationProvider implements IDiagramLayoutConfigu
         var fontStyle = new FontStyle(labelStyle.isBold(), labelStyle.isItalic(), labelStyle.isUnderline(), labelStyle.isStrikeThrough());
         return LabelLayoutConfiguration.newLabelLayoutConfiguration(label.getId())
                 .text(label.getText())
+                .fontSize(labelStyle.getFontSize())
+                .fontStyle(fontStyle)
+                .border(Offsets.empty())
+                .padding(Offsets.of(5.0))
+                .margin(Offsets.of(5.0))
+                .iconLayoutConfiguration(new IconLayoutConfiguration(new Size(16, 16), 10.0))
+                .build();
+    }
+
+    public LabelLayoutConfiguration convertInsideLabel(InsideLabel insidelabel) {
+        var labelStyle = insidelabel.getStyle();
+        var fontStyle = new FontStyle(labelStyle.isBold(), labelStyle.isItalic(), labelStyle.isUnderline(), labelStyle.isStrikeThrough());
+        return LabelLayoutConfiguration.newLabelLayoutConfiguration(insidelabel.getId())
+                .text(insidelabel.getText())
                 .fontSize(labelStyle.getFontSize())
                 .fontStyle(fontStyle)
                 .border(Offsets.empty())

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/experimental/DiagramLayoutConfigurationProvider.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/experimental/DiagramLayoutConfigurationProvider.java
@@ -94,19 +94,21 @@ public class DiagramLayoutConfigurationProvider implements IDiagramLayoutConfigu
         if (node.isBorderNode()) {
             containmentKind = "border";
         }
-        var nodeLabel = node.getLabel().getText();
+        var nodeLabel = Optional.ofNullable(node.getLabel()).map(Label::getText).orElse("nolabel");
         var displayName = String.format("%s > [%s node] %s", parentLayoutConfiguration.displayName(), containmentKind, nodeLabel);
 
-        var nodeLayoutConfiguration = NodeLayoutConfiguration.newNodeLayoutConfiguration(node.getId())
+        var builder = NodeLayoutConfiguration.newNodeLayoutConfiguration(node.getId())
                 .displayName(displayName)
-                .labelLayoutConfiguration(this.convertLabel(node.getLabel()))
                 .parentLayoutConfiguration(parentLayoutConfiguration)
                 .border(this.getBorderSize(node.getStyle()))
                 .padding(Offsets.of(12.0))
                 .margin(Offsets.of(25.0))
                 .minimumSize(new Size(150, 70))
-                .layoutStrategy(this.getLayoutStrategy(node))
-                .build();
+                .layoutStrategy(this.getLayoutStrategy(node));
+
+        Optional.ofNullable(node.getLabel()).map(this::convertLabel).ifPresent(builder::labelLayoutConfiguration);
+
+        var nodeLayoutConfiguration = builder.build();
 
         node.getChildNodes().stream()
             .map(childNode -> this.convertNode(nodeLayoutConfiguration, childNode))

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/IncrementalLayoutDiagramConverter.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/IncrementalLayoutDiagramConverter.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import org.eclipse.sirius.components.diagrams.CustomizableProperties;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.TextBounds;
@@ -164,12 +165,12 @@ public class IncrementalLayoutDiagramConverter {
 
     private LabelLayoutData convertNodeLabel(Node node, Map<String, ILayoutData> id2LayoutData, ISiriusWebLayoutConfigurator layoutConfigurator) {
         LabelLayoutData layoutData = new LabelLayoutData();
-        Label label = node.getLabel();
-        String id = label.getId();
+        InsideLabel insideLabel = node.getInsideLabel();
+        String id = insideLabel.getId();
         layoutData.setId(id);
         id2LayoutData.put(id, layoutData);
 
-        layoutData.setPosition(label.getPosition());
+        layoutData.setPosition(insideLabel.getPosition());
         String labelType;
         if (node.isBorderNode()) {
             labelType = this.elkPropertiesService.getBorderNodeLabelType(node, layoutConfigurator);
@@ -181,9 +182,9 @@ public class IncrementalLayoutDiagramConverter {
         TextBounds textBounds = null;
         if (labelType.startsWith("label:inside-v")) {
             double maxPadding = this.elkPropertiesService.getMaxPadding(node, layoutConfigurator);
-            textBounds = this.textBoundsService.getAutoWrapBounds(label, node.getSize().getWidth() - maxPadding * 2);
+            textBounds = this.textBoundsService.getAutoWrapBounds(insideLabel, node.getSize().getWidth() - maxPadding * 2);
         } else {
-            textBounds = this.textBoundsService.getBounds(label);
+            textBounds = this.textBoundsService.getBounds(insideLabel);
         }
         layoutData.setTextBounds(textBounds);
 

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/IncrementalLayoutedDiagramProvider.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/IncrementalLayoutedDiagramProvider.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import org.eclipse.sirius.components.diagrams.CustomizableProperties;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.layout.incremental.data.DiagramLayoutData;
@@ -67,7 +68,7 @@ public class IncrementalLayoutedDiagramProvider {
     }
 
     private Node getLayoutedNode(Node node, NodeLayoutData nodeLayoutData, Map<String, ILayoutData> id2LayoutData) {
-        Label label = this.getLayoutedLabel(node.getLabel(), id2LayoutData);
+        InsideLabel insideLabel = this.getLayoutedInsideLabel(node.getInsideLabel(), id2LayoutData);
 
         List<Node> childNodes = this.getLayoutedNodes(node.getChildNodes(), id2LayoutData);
         List<Node> borderNodes = this.getLayoutedNodes(node.getBorderNodes(), id2LayoutData);
@@ -80,7 +81,7 @@ public class IncrementalLayoutedDiagramProvider {
         }
         // @formatter:off
         return Node.newNode(node)
-                .label(label)
+                .insideLabel(insideLabel)
                 .size(nodeLayoutData.getSize())
                 .userResizable(nodeLayoutData.isUserResizable())
                 .position(nodeLayoutData.getPosition())
@@ -143,6 +144,22 @@ public class IncrementalLayoutedDiagramProvider {
                     .type(labelLayoutData.getLabelType())
                     .build();
             // @formatter:on
+        }
+        return layoutedLabel;
+    }
+
+    private InsideLabel getLayoutedInsideLabel(InsideLabel insideLabel, Map<String, ILayoutData> id2LayoutData) {
+        InsideLabel layoutedLabel = insideLabel;
+        var optionalLabelLayoutData = Optional.of(id2LayoutData.get(insideLabel.getId())).filter(LabelLayoutData.class::isInstance).map(LabelLayoutData.class::cast);
+        if (optionalLabelLayoutData.isPresent()) {
+            LabelLayoutData labelLayoutData = optionalLabelLayoutData.get();
+
+            layoutedLabel = InsideLabel.newInsideLabel(insideLabel)
+                    .size(labelLayoutData.getTextBounds().getSize())
+                    .position(labelLayoutData.getPosition())
+                    .alignment(labelLayoutData.getTextBounds().getAlignment())
+                    .type(labelLayoutData.getLabelType())
+                    .build();
         }
         return layoutedLabel;
     }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeCreationTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeCreationTests.java
@@ -27,7 +27,7 @@ import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
 import org.eclipse.sirius.components.diagrams.CustomizableProperties;
 import org.eclipse.sirius.components.diagrams.Diagram;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.Position;
 import org.eclipse.sirius.components.diagrams.Size;
@@ -210,11 +210,11 @@ public class NodeCreationTests {
         double labelPaddings = 0;
         if (this.isLabelOfType(parent, "inside")) {
             // We consider here the label is also on TOP of the node
-            double parentLabelHeight = parent.getLabel().getSize().getHeight();
+            double parentLabelHeight = parent.getInsideLabel().getSize().getHeight();
             labelPaddings += defaultLabelPadding + parentLabelHeight + defaultYPosition;
         }
         if (this.isLabelOfType(child, "outside")) {
-            double nodeLabelHeight = child.getLabel().getSize().getHeight();
+            double nodeLabelHeight = child.getInsideLabel().getSize().getHeight();
             labelPaddings += nodeLabelHeight + defaultLabelPadding;
         }
         double yPosition = Math.max(labelPaddings, defaultYPosition);
@@ -223,9 +223,9 @@ public class NodeCreationTests {
     }
 
     private boolean isLabelOfType(Node node, String labelType) {
-        Label label = node.getLabel();
-        if (label != null) {
-            return label.getType().contains(labelType);
+        InsideLabel insideLabel = node.getInsideLabel();
+        if (insideLabel != null) {
+            return insideLabel.getType().contains(labelType);
         }
         return false;
     }

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/DiagramConverterTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/DiagramConverterTests.java
@@ -31,7 +31,7 @@ import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.ElkShape;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.NodeType;
 import org.eclipse.sirius.components.diagrams.Position;
@@ -77,14 +77,14 @@ public class DiagramConverterTests {
 
     private TextBoundsService textBoundsService = new TextBoundsService() {
         @Override
-        public TextBounds getBounds(Label label) {
+        public TextBounds getBounds(InsideLabel label) {
             Size size = Size.of(TEXT_WIDTH, TEXT_HEIGHT);
             Position alignment = Position.UNDEFINED;
             return new TextBounds(size, alignment);
         }
 
         @Override
-        public TextBounds getAutoWrapBounds(Label label, double maxWidth) {
+        public TextBounds getAutoWrapBounds(InsideLabel label, double maxWidth) {
             Size size = Size.of(TEXT_WIDTH, TEXT_HEIGHT);
             Position alignment = Position.UNDEFINED;
             return new TextBounds(size, alignment);
@@ -108,7 +108,7 @@ public class DiagramConverterTests {
 
         // @formatter:off
         TestDiagramBuilder diagramBuilder = new TestDiagramBuilder();
-        Node node = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID))
+        Node node = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID, true))
                 .type(NodeType.NODE_RECTANGLE)
                 .style(diagramBuilder.getRectangularNodeStyle())
                 .build();
@@ -126,7 +126,7 @@ public class DiagramConverterTests {
 
         Map<String, ElkGraphElement> id2ElkGraphElements = convertedDiagram.getId2ElkGraphElements();
         assertThat(id2ElkGraphElements.get(node.getId().toString())).isInstanceOf(ElkNode.class);
-        assertThat(id2ElkGraphElements.get(node.getLabel().getId().toString())).isInstanceOf(ElkLabel.class);
+        assertThat(id2ElkGraphElements.get(node.getInsideLabel().getId().toString())).isInstanceOf(ElkLabel.class);
 
         ElkNode elkNode = (ElkNode) id2ElkGraphElements.get(node.getId().toString());
         this.assertSize(elkNode, Size.UNDEFINED.getWidth(), Size.UNDEFINED.getHeight());
@@ -146,7 +146,7 @@ public class DiagramConverterTests {
 
         // @formatter:off
         TestDiagramBuilder diagramBuilder = new TestDiagramBuilder();
-        Node node = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID))
+        Node node = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID, true))
                 .type(NodeType.NODE_IMAGE)
                 .style(diagramBuilder.getImageNodeStyle())
                 .build();
@@ -164,7 +164,7 @@ public class DiagramConverterTests {
 
         Map<String, ElkGraphElement> id2ElkGraphElements = convertedDiagram.getId2ElkGraphElements();
         assertThat(id2ElkGraphElements.get(node.getId().toString())).isInstanceOf(ElkNode.class);
-        assertThat(id2ElkGraphElements.get(node.getLabel().getId().toString())).isInstanceOf(ElkLabel.class);
+        assertThat(id2ElkGraphElements.get(node.getInsideLabel().getId().toString())).isInstanceOf(ElkLabel.class);
 
         ElkNode elkNode = (ElkNode) id2ElkGraphElements.get(node.getId().toString());
         this.assertSize(elkNode, TEXT_WIDTH, TEXT_HEIGHT);
@@ -187,7 +187,7 @@ public class DiagramConverterTests {
 
         // @formatter:off
         TestDiagramBuilder diagramBuilder = new TestDiagramBuilder();
-        Node node = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID))
+        Node node = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID, true))
                 .style(diagramBuilder.getImageNodeStyle())
                 .build();
 
@@ -220,11 +220,11 @@ public class DiagramConverterTests {
         // @formatter:off
         TestDiagramBuilder diagramBuilder = new TestDiagramBuilder();
 
-        Node borderNode = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID))
+        Node borderNode = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID, true))
                 .style(diagramBuilder.getRectangularNodeStyle())
                 .build();
 
-        Node node = Node.newNode(diagramBuilder.getNode(SECOND_NODE_ID))
+        Node node = Node.newNode(diagramBuilder.getNode(SECOND_NODE_ID, true))
                 .style(diagramBuilder.getImageNodeStyle())
                 .borderNodes(List.of(borderNode))
                 .build();
@@ -258,14 +258,14 @@ public class DiagramConverterTests {
         // @formatter:off
         TestDiagramBuilder diagramBuilder = new TestDiagramBuilder();
 
-        Node firstBorderNode = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID))
+        Node firstBorderNode = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID, true))
                 .style(diagramBuilder.getRectangularNodeStyle())
                 .build();
-        Node secondBorderNode = Node.newNode(diagramBuilder.getNode(SECOND_NODE_ID))
+        Node secondBorderNode = Node.newNode(diagramBuilder.getNode(SECOND_NODE_ID, true))
                 .style(diagramBuilder.getRectangularNodeStyle())
                 .build();
 
-        Node node = Node.newNode(diagramBuilder.getNode(THIRD_NODE_ID))
+        Node node = Node.newNode(diagramBuilder.getNode(THIRD_NODE_ID, true))
                 .style(diagramBuilder.getImageNodeStyle())
                 .borderNodes(List.of(firstBorderNode, secondBorderNode))
                 .build();

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/DiagramELKLayoutTest.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/DiagramELKLayoutTest.java
@@ -115,8 +115,8 @@ public class DiagramELKLayoutTest {
         Node firstParent = layoutedDiagram.getNodes().get(0);
 
         // Check that the parent node and the label have the right size
-        assertThat(firstParent.getLabel().getSize().getWidth()).isCloseTo(190.0, Offset.offset(5.0));
-        assertThat(firstParent.getLabel().getSize().getHeight()).isCloseTo(40.0, Offset.offset(5.0));
+        assertThat(firstParent.getInsideLabel().getSize().getWidth()).isCloseTo(190.0, Offset.offset(5.0));
+        assertThat(firstParent.getInsideLabel().getSize().getHeight()).isCloseTo(40.0, Offset.offset(5.0));
         assertThat(firstParent.getSize().getWidth()).isCloseTo(200.0, Offset.offset(5.0));
         assertThat(firstParent.getSize().getHeight()).isCloseTo(155.0, Offset.offset(5.0));
 

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/LayoutedDiagramProviderTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/services/LayoutedDiagramProviderTests.java
@@ -87,7 +87,7 @@ public class LayoutedDiagramProviderTests {
         // @formatter:off
         TestDiagramBuilder diagramBuilder = new TestDiagramBuilder();
 
-        Node node = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID))
+        Node node = Node.newNode(diagramBuilder.getNode(FIRST_NODE_ID, true))
                 .build();
 
         Edge edge = Edge.newEdge(diagramBuilder.getEdge(FIRST_EDGE_ID, node.getId(), node.getId()))
@@ -124,7 +124,7 @@ public class LayoutedDiagramProviderTests {
         elkNode.setParent(elkDiagram);
 
         ElkLabel elkLabel = ElkGraphFactory.eINSTANCE.createElkLabel();
-        elkLabel.setIdentifier(node.getLabel().getId().toString());
+        elkLabel.setIdentifier(node.getInsideLabel().getId().toString());
         elkLabel.setDimensions(LABEL_WIDTH, LABEL_HEIGHT);
         elkLabel.setX(LABEL_X);
         elkLabel.setY(LABEL_Y);

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/DiagramAssert.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/DiagramAssert.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import java.util.List;
 import org.assertj.core.api.AbstractAssert;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.Position;
@@ -158,7 +159,7 @@ public class DiagramAssert extends AbstractAssert<DiagramAssert, Diagram> {
             this.failWithMessage("The id of the node <%s> already exist in the diagram", node.getId());
         }
         ids.add(node.getId());
-        this.visitLabelId(ids, node.getLabel());
+        this.visitInsideLabelId(ids, node.getInsideLabel());
 
         node.getBorderNodes().forEach(borderNode -> this.visitNodeId(ids, borderNode));
         node.getChildNodes().forEach(childNode -> this.visitNodeId(ids, childNode));
@@ -176,6 +177,15 @@ public class DiagramAssert extends AbstractAssert<DiagramAssert, Diagram> {
     }
 
     private void visitLabelId(List<String> ids, Label label) {
+        if (label != null) {
+            if (ids.contains(label.getId())) {
+                this.failWithMessage("The id of the label <%s> already exist in the diagram", label.getId());
+            }
+            ids.add(label.getId());
+        }
+    }
+
+    private void visitInsideLabelId(List<String> ids, InsideLabel label) {
         if (label != null) {
             if (ids.contains(label.getId())) {
                 this.failWithMessage("The id of the label <%s> already exist in the diagram", label.getId());

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/DiagramAssertions.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/DiagramAssertions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import org.assertj.core.api.Assertions;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
 import org.eclipse.sirius.components.diagrams.ImageNodeStyle;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.Node;
@@ -50,6 +51,10 @@ public class DiagramAssertions extends Assertions {
 
     public static LabelAssert assertThat(Label label) {
         return new LabelAssert(label);
+    }
+
+    public static InsideLabelAssert assertThat(InsideLabel insideLabel) {
+        return new InsideLabelAssert(insideLabel);
     }
 
     public static LabelStyleAssert assertThat(LabelStyle labelStyle) {

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/InsideLabelAssert.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/InsideLabelAssert.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sirius.components.diagrams.tests.DiagramAssertions.assertThat;
+
+import org.assertj.core.api.AbstractAssert;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
+
+/**
+ * Custom assertion class used to perform some tests on an inside label.
+ *
+ * @author gcoutable
+ */
+public class InsideLabelAssert extends AbstractAssert<InsideLabelAssert, InsideLabel> {
+
+    public InsideLabelAssert(InsideLabel actual) {
+        super(actual, InsideLabelAssert.class);
+    }
+
+    public InsideLabelAssert matches(InsideLabel insideLabel, IdPolicy idPolicy, LayoutPolicy layoutPolicy) {
+        this.isNotNull();
+
+        if (idPolicy == IdPolicy.WITH_ID) {
+            assertThat(this.actual.getId()).isEqualTo(insideLabel.getId());
+        }
+
+        // Actual label type can not be equal to label type because of the dummy label type set in NodeComponent.
+        assertThat(this.actual.getType()).isNotEqualTo(insideLabel.getType());
+
+        assertThat(this.actual.getText()).isEqualTo(insideLabel.getText());
+        assertThat(this.actual.getStyle()).matches(insideLabel.getStyle());
+
+        if (layoutPolicy == LayoutPolicy.WITH_LAYOUT) {
+            this.hasBounds(insideLabel.getPosition().getX(), insideLabel.getPosition().getY(), insideLabel.getSize().getWidth(), insideLabel.getSize().getHeight(), insideLabel.getAlignment().getX(), insideLabel.getAlignment().getY());
+        }
+
+        return this;
+    }
+
+    public InsideLabelAssert hasBounds(double x, double y, double width, double height, double xAlignment, double yAlignment) {
+        this.isNotNull();
+
+        Size size = this.actual.getSize();
+        if (size == null) {
+            this.failWithMessage("Expected label's size to be <'{'width: %.2f, height: %.2f'}'> but was null", width, height);
+        } else {
+            if (width != size.getWidth()) {
+                this.failWithMessage("Expected label's width to be <%.2f> but was <%.2f>", width, size.getWidth());
+            }
+            if (height != size.getHeight()) {
+                this.failWithMessage("Expected label's height to be <%.2f> but was <%.2f>", height, size.getHeight());
+            }
+        }
+
+        Position position = this.actual.getPosition();
+        if (position == null) {
+            this.failWithMessage("Expected label's position to be <'{'x: %.2f, y: %.2f'}'> but was null", x, y);
+        } else {
+            if (x != position.getX()) {
+                this.failWithMessage("Expected label's x to be <%.2f> but was <%.2f>", x, position.getX());
+            }
+            if (y != position.getY()) {
+                this.failWithMessage("Expected label's y to be <%.2f> but was <%.2f>", y, position.getY());
+            }
+        }
+
+        Position alignment = this.actual.getAlignment();
+        if (alignment == null) {
+            this.failWithMessage("Expected label's alignment to be <'{'x: %.2f, y: %.2f'}'> but was null", xAlignment, yAlignment);
+        } else {
+            if (x != alignment.getX()) {
+                this.failWithMessage("Expected label's x alignment to be <%.2f> but was <%.2f>", x, alignment.getX());
+            }
+            if (y != alignment.getY()) {
+                this.failWithMessage("Expected label's y alignment to be <%.2f> but was <%.2f>", y, alignment.getY());
+            }
+        }
+
+        return this;
+    }
+}

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/NodeAssert.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/NodeAssert.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ import java.util.List;
 
 import org.assertj.core.api.AbstractAssert;
 import org.eclipse.sirius.components.diagrams.ImageNodeStyle;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.Position;
 import org.eclipse.sirius.components.diagrams.RectangularNodeStyle;
@@ -73,7 +73,7 @@ public class NodeAssert extends AbstractAssert<NodeAssert, Node> {
             assertThat(this.actual.getTargetObjectId()).isEqualTo(node.getTargetObjectId());
             assertThat(this.actual.getDescriptionId()).isEqualTo(node.getDescriptionId());
 
-            assertThat(this.actual.getLabel()).matches(node.getLabel(), idPolicy, layoutPolicy);
+            assertThat(this.actual.getInsideLabel()).matches(node.getInsideLabel(), idPolicy, layoutPolicy);
 
             assertThat(this.actual.getStyle().getClass()).isEqualTo(node.getStyle().getClass());
             if (this.actual.getStyle() instanceof ImageNodeStyle && node.getStyle() instanceof ImageNodeStyle) {
@@ -177,11 +177,11 @@ public class NodeAssert extends AbstractAssert<NodeAssert, Node> {
     public void hasNoOverflow() {
         Size size = this.actual.getSize();
 
-        Label label = this.actual.getLabel();
-        if (!label.getType().equals(LabelType.OUTSIDE.getValue()) && !label.getType().equals(LabelType.OUTSIDE_CENTER.getValue())) {
-            Position labelTopLeftCorner = Position.at(label.getPosition().getX() + label.getAlignment().getX(), label.getPosition().getY() + label.getAlignment().getY());
-            Position labelTopRightCorner = Position.at(labelTopLeftCorner.getX() + label.getSize().getWidth(), labelTopLeftCorner.getY());
-            Position labelBottomLeftCorner = Position.at(labelTopLeftCorner.getX(), labelTopLeftCorner.getY() + label.getSize().getHeight());
+        InsideLabel insidelabel = this.actual.getInsideLabel();
+        if (!insidelabel.getType().equals(LabelType.OUTSIDE.getValue()) && !insidelabel.getType().equals(LabelType.OUTSIDE_CENTER.getValue())) {
+            Position labelTopLeftCorner = Position.at(insidelabel.getPosition().getX() + insidelabel.getAlignment().getX(), insidelabel.getPosition().getY() + insidelabel.getAlignment().getY());
+            Position labelTopRightCorner = Position.at(labelTopLeftCorner.getX() + insidelabel.getSize().getWidth(), labelTopLeftCorner.getY());
+            Position labelBottomLeftCorner = Position.at(labelTopLeftCorner.getX(), labelTopLeftCorner.getY() + insidelabel.getSize().getHeight());
             Position labelBottomRightCorner = Position.at(labelTopRightCorner.getX(), labelBottomLeftCorner.getY());
 
             assertThat(labelTopLeftCorner).isInside(size);

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/TestDiagramBuilder.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/TestDiagramBuilder.java
@@ -23,7 +23,7 @@ import org.eclipse.sirius.components.diagrams.Edge;
 import org.eclipse.sirius.components.diagrams.EdgeStyle;
 import org.eclipse.sirius.components.diagrams.FreeFormLayoutStrategy;
 import org.eclipse.sirius.components.diagrams.ImageNodeStyle;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.LineStyle;
 import org.eclipse.sirius.components.diagrams.Node;
@@ -83,29 +83,13 @@ public class TestDiagramBuilder {
         // @formatter:on
     }
 
-    public Node getNode(String id) {
-        // @formatter:off
-        LabelStyle labelStyle = LabelStyle.newLabelStyle()
-                .color("#000000")
-                .fontSize(16)
-                .iconURL("")
-                .build();
-        Label label = Label.newLabel(UUID.randomUUID().toString())
-                .type("labelType")
-                .text("text")
-                .position(Position.UNDEFINED)
-                .size(Size.UNDEFINED)
-                .alignment(Position.UNDEFINED)
-                .style(labelStyle)
-                .build();
-
-        return Node.newNode(id)
+    public Node getNode(String id, boolean withLabel) {
+        Node.Builder nodeBuilder = Node.newNode(id)
                 .type(NodeType.NODE_RECTANGLE)
                 .targetObjectId("nodeTargetObjectId")
                 .targetObjectKind("")
                 .targetObjectLabel("")
                 .descriptionId(UUID.randomUUID().toString())
-                .label(label)
                 .style(this.getRectangularNodeStyle())
                 .childrenLayoutStrategy(new FreeFormLayoutStrategy())
                 .position(Position.UNDEFINED)
@@ -114,9 +98,26 @@ public class TestDiagramBuilder {
                 .childNodes(List.of())
                 .modifiers(Set.of())
                 .state(ViewModifier.Normal)
-                .collapsingState(CollapsingState.EXPANDED)
-                .build();
-        // @formatter:on
+                .collapsingState(CollapsingState.EXPANDED);
+
+        if (withLabel) {
+            LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                    .color("#000000")
+                    .fontSize(16)
+                    .iconURL("")
+                    .build();
+            InsideLabel insideLabel = InsideLabel.newLabel(UUID.randomUUID().toString())
+                    .type("labelType")
+                    .text("text")
+                    .position(Position.UNDEFINED)
+                    .size(Size.UNDEFINED)
+                    .alignment(Position.UNDEFINED)
+                    .style(labelStyle)
+                    .build();
+            nodeBuilder.insideLabel(insideLabel);
+        }
+
+        return nodeBuilder.build();
     }
 
     public Edge getEdge(String id, String sourceId, String targetId) {

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/label/LabelBuilder.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/label/LabelBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Obeo.
+ * Copyright (c) 2022, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ package org.eclipse.sirius.components.diagrams.tests.builder.label;
 import java.util.Objects;
 import java.util.UUID;
 
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.Position;
@@ -29,7 +30,6 @@ import org.eclipse.sirius.components.diagrams.components.LabelType;
 public final class LabelBuilder {
 
     public Label basicLabel(String text, LabelType labelType) {
-        // @formatter:off
         LabelStyle labelStyle = LabelStyle.newLabelStyle()
                 .color("black")
                 .fontSize(14)
@@ -39,9 +39,7 @@ public final class LabelBuilder {
                 .strikeThrough(false)
                 .iconURL("")
                 .build();
-        // @formatter:on
 
-        // @formatter:off
         return Label.newLabel(UUID.randomUUID().toString())
                 .type(Objects.requireNonNull(labelType).getValue())
                 .text(Objects.requireNonNull(text))
@@ -50,7 +48,27 @@ public final class LabelBuilder {
                 .size(Size.UNDEFINED)
                 .style(labelStyle)
                 .build();
-        // @formatter:on
+    }
+
+    public InsideLabel basicInsideLabel(String text, LabelType labelType) {
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .color("black")
+                .fontSize(14)
+                .bold(false)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .iconURL("")
+                .build();
+
+        return InsideLabel.newLabel(UUID.randomUUID().toString())
+                .type(Objects.requireNonNull(labelType).getValue())
+                .text(Objects.requireNonNull(text))
+                .alignment(Position.UNDEFINED)
+                .position(Position.UNDEFINED)
+                .size(Size.UNDEFINED)
+                .style(labelStyle)
+                .build();
     }
 
 }

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/node/IconlabelNodeBuilder.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/node/IconlabelNodeBuilder.java
@@ -23,7 +23,7 @@ import org.eclipse.sirius.components.diagrams.CollapsingState;
 import org.eclipse.sirius.components.diagrams.CustomizableProperties;
 import org.eclipse.sirius.components.diagrams.INodeStyle;
 import org.eclipse.sirius.components.diagrams.IconLabelNodeStyle;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.NodeType;
 import org.eclipse.sirius.components.diagrams.Position;
@@ -48,7 +48,7 @@ public class IconlabelNodeBuilder<T> implements NodeBuilder<T> {
 
     private boolean isBorderNode;
 
-    private Label label;
+    private InsideLabel insideLabel;
 
     private Position position;
 
@@ -61,7 +61,7 @@ public class IconlabelNodeBuilder<T> implements NodeBuilder<T> {
     private Set<CustomizableProperties> customizedProperties = Set.of();
 
     public IconlabelNodeBuilder(NodesBuilder<T> nodesBuilder, String nodeLabel, boolean isBorderNode) {
-        this.label = new LabelBuilder().basicLabel(nodeLabel, LabelType.INSIDE_CENTER);
+        this.insideLabel = new LabelBuilder().basicInsideLabel(nodeLabel, LabelType.INSIDE_CENTER);
         this.isBorderNode = isBorderNode;
         this.nodesBuilder = Objects.requireNonNull(nodesBuilder);
     }
@@ -106,7 +106,7 @@ public class IconlabelNodeBuilder<T> implements NodeBuilder<T> {
                 .build();
         // @formatter:on
 
-        String labelText = this.label.getText();
+        String labelText = this.insideLabel.getText();
         String nodeId = UUID.randomUUID().toString();
         targetObjectIdToNodeId.put(labelText, nodeId);
 
@@ -117,7 +117,7 @@ public class IconlabelNodeBuilder<T> implements NodeBuilder<T> {
 
         return Node.newNode(nodeId)
                 .type(NodeType.NODE_ICON_LABEL)
-                .label(this.label)
+                .insideLabel(this.insideLabel)
                 .position(Objects.requireNonNull(this.position))
                 .size(Objects.requireNonNull(this.size))
                 .borderNode(this.isBorderNode)

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/node/ImageNodeBuilder.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/node/ImageNodeBuilder.java
@@ -23,7 +23,7 @@ import org.eclipse.sirius.components.diagrams.CollapsingState;
 import org.eclipse.sirius.components.diagrams.CustomizableProperties;
 import org.eclipse.sirius.components.diagrams.INodeStyle;
 import org.eclipse.sirius.components.diagrams.ImageNodeStyle;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.NodeType;
 import org.eclipse.sirius.components.diagrams.Position;
@@ -47,7 +47,7 @@ public final class ImageNodeBuilder<T> implements NodeBuilder<T> {
 
     private boolean isBorderNode;
 
-    private Label label;
+    private InsideLabel insideLabel;
 
     private Position position;
 
@@ -60,7 +60,7 @@ public final class ImageNodeBuilder<T> implements NodeBuilder<T> {
     private Set<CustomizableProperties> customizedProperties = Set.of();
 
     public ImageNodeBuilder(NodesBuilder<T> nodesBuilder, String nodeLabel, boolean isBorderNode) {
-        this.label = new LabelBuilder().basicLabel(nodeLabel, LabelType.OUTSIDE_CENTER);
+        this.insideLabel = new LabelBuilder().basicInsideLabel(nodeLabel, LabelType.OUTSIDE_CENTER);
         this.isBorderNode = isBorderNode;
         this.nodesBuilder = Objects.requireNonNull(nodesBuilder);
     }
@@ -106,7 +106,7 @@ public final class ImageNodeBuilder<T> implements NodeBuilder<T> {
                 .build();
         // @formatter:on
 
-        String labelText = this.label.getText();
+        String labelText = this.insideLabel.getText();
         String nodeId = UUID.randomUUID().toString();
         targetObjectIdToNodeId.put(labelText, nodeId);
 
@@ -117,7 +117,7 @@ public final class ImageNodeBuilder<T> implements NodeBuilder<T> {
 
         return Node.newNode(nodeId)
                 .type(NodeType.NODE_IMAGE)
-                .label(this.label)
+                .insideLabel(this.insideLabel)
                 .position(Objects.requireNonNull(this.position))
                 .size(Objects.requireNonNull(this.size))
                 .borderNode(this.isBorderNode)

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/node/RectangleNodeBuilder.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/builder/node/RectangleNodeBuilder.java
@@ -23,7 +23,7 @@ import org.eclipse.sirius.components.diagrams.CollapsingState;
 import org.eclipse.sirius.components.diagrams.CustomizableProperties;
 import org.eclipse.sirius.components.diagrams.ILayoutStrategy;
 import org.eclipse.sirius.components.diagrams.INodeStyle;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.LineStyle;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.Node.Builder;
@@ -52,7 +52,7 @@ public final class RectangleNodeBuilder<T> implements NodeBuilder<T> {
 
     private boolean withHeader;
 
-    private Label label;
+    private InsideLabel insideLabel;
 
     private Position position;
 
@@ -71,7 +71,7 @@ public final class RectangleNodeBuilder<T> implements NodeBuilder<T> {
     private Set<CustomizableProperties> customizedProperties = Set.of();
 
     public RectangleNodeBuilder(NodesBuilder<T> nodesBuilder, String nodeLabel, boolean isBorderNode) {
-        this.label = new LabelBuilder().basicLabel(nodeLabel, LabelType.INSIDE_CENTER);
+        this.insideLabel = new LabelBuilder().basicInsideLabel(nodeLabel, LabelType.INSIDE_CENTER);
         this.isBorderNode = isBorderNode;
         this.nodesBuilder = Objects.requireNonNull(nodesBuilder);
     }
@@ -137,7 +137,7 @@ public final class RectangleNodeBuilder<T> implements NodeBuilder<T> {
                 .build();
         // @formatter:on
 
-        String labeltext = this.label.getText();
+        String labeltext = this.insideLabel.getText();
         String nodeId = UUID.randomUUID().toString();
         targetObjectIdToNodeId.put(labeltext, nodeId);
 
@@ -148,7 +148,7 @@ public final class RectangleNodeBuilder<T> implements NodeBuilder<T> {
 
         Builder nodeBuilder = Node.newNode(nodeId)
                 .type(NodeType.NODE_RECTANGLE)
-                .label(this.label)
+                .insideLabel(this.insideLabel)
                 .position(Objects.requireNonNull(this.position))
                 .size(Objects.requireNonNull(this.size))
                 .borderNode(this.isBorderNode)
@@ -158,7 +158,7 @@ public final class RectangleNodeBuilder<T> implements NodeBuilder<T> {
                 .descriptionId(descriptionId)
                 .targetObjectId(labeltext)
                 .targetObjectKind("")
-                .targetObjectLabel(this.label.getText())
+                .targetObjectLabel(this.insideLabel.getText())
                 .style(Objects.requireNonNull(style))
                 .modifiers(Set.of())
                 .state(ViewModifier.Normal)

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/InsideLabel.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/InsideLabel.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.annotations.Immutable;
+
+/**
+ * An inside label.
+ *
+ * @author gcoutable
+ */
+@Immutable
+public final class InsideLabel {
+    private String id;
+
+    private String type;
+
+    private String text;
+
+    private Position position;
+
+    private Size size;
+
+    private Position alignment;
+
+    private LabelStyle style;
+
+    private InsideLabel() {
+        // Prevent instantiation
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public String getText() {
+        return this.text;
+    }
+
+    public Position getPosition() {
+        return this.position;
+    }
+
+    public Size getSize() {
+        return this.size;
+    }
+
+    public Position getAlignment() {
+        return this.alignment;
+    }
+
+    public LabelStyle getStyle() {
+        return this.style;
+    }
+
+    public static Builder newLabel(String id) {
+        return new Builder(id);
+    }
+
+    public static Builder newInsideLabel(InsideLabel insideLabel) {
+        return new Builder(insideLabel);
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, type: {2}, text: {3}'}'";
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.type, this.text);
+    }
+
+    /**
+     * The builder used to create a label.
+     *
+     * @author sbegaudeau
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+        private String id;
+
+        private String type;
+
+        private String text;
+
+        private Position position;
+
+        private Size size;
+
+        private Position alignment;
+
+        private LabelStyle style;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder(InsideLabel insideLabel) {
+            this.id = insideLabel.getId();
+            this.type = insideLabel.getType();
+            this.text = insideLabel.getText();
+            this.position = insideLabel.getPosition();
+            this.size = insideLabel.getSize();
+            this.alignment = insideLabel.getAlignment();
+            this.style = insideLabel.getStyle();
+        }
+
+        public Builder type(String type) {
+            this.type = Objects.requireNonNull(type);
+            return this;
+        }
+
+        public Builder text(String text) {
+            this.text = Objects.requireNonNull(text);
+            return this;
+        }
+
+        public Builder position(Position position) {
+            this.position = Objects.requireNonNull(position);
+            return this;
+        }
+
+        public Builder size(Size size) {
+            this.size = Objects.requireNonNull(size);
+            return this;
+        }
+
+        public Builder alignment(Position aligment) {
+            this.alignment = Objects.requireNonNull(aligment);
+            return this;
+        }
+
+        public Builder style(LabelStyle style) {
+            this.style = Objects.requireNonNull(style);
+            return this;
+        }
+
+        public InsideLabel build() {
+            InsideLabel label = new InsideLabel();
+            label.id = Objects.requireNonNull(this.id);
+            label.type = Objects.requireNonNull(this.type);
+            label.text = Objects.requireNonNull(this.text);
+            label.position = Objects.requireNonNull(this.position);
+            label.size = Objects.requireNonNull(this.size);
+            label.alignment = Objects.requireNonNull(this.alignment);
+            label.style = Objects.requireNonNull(this.style);
+            return label;
+        }
+    }
+}

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/Node.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/Node.java
@@ -50,7 +50,7 @@ public final class Node implements IDiagramElement {
 
     private CollapsingState collapsingState;
 
-    private Label label;
+    private InsideLabel insideLabel;
 
     private INodeStyle style;
 
@@ -124,8 +124,8 @@ public final class Node implements IDiagramElement {
         return this.collapsingState;
     }
 
-    public Label getLabel() {
-        return this.label;
+    public InsideLabel getInsideLabel() {
+        return this.insideLabel;
     }
 
     public INodeStyle getStyle() {
@@ -167,9 +167,8 @@ public final class Node implements IDiagramElement {
     @Override
     public String toString() {
         String pattern = "{0} '{'id: {1}, targetObjectId: {2}, targetObjectKind: {3}, targetObjectLabel: {4}, descriptionId: {5}, state: {6}, label: {7}, styleType: {8}, borderNodeCount: {9}, childNodeCount: {10}'}'";
-        return MessageFormat.format(pattern, this.getClass()
-                        .getSimpleName(), this.id, this.targetObjectId, this.targetObjectKind, this.targetObjectLabel, this.descriptionId, this.state,
-                this.label.getText(), this.style.getClass().getSimpleName(), this.borderNodes.size(), this.childNodes.size());
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.targetObjectId, this.targetObjectKind, this.targetObjectLabel, this.descriptionId, this.state,
+                this.insideLabel.getText(), this.style.getClass().getSimpleName(), this.borderNodes.size(), this.childNodes.size());
     }
 
     /**
@@ -200,7 +199,7 @@ public final class Node implements IDiagramElement {
 
         private CollapsingState collapsingState;
 
-        private Label label;
+        private InsideLabel insideLabel;
 
         private INodeStyle style;
 
@@ -235,7 +234,7 @@ public final class Node implements IDiagramElement {
             this.modifiers = node.getModifiers();
             this.state = node.getState();
             this.collapsingState = node.getCollapsingState();
-            this.label = node.getLabel();
+            this.insideLabel = node.getInsideLabel();
             this.style = node.getStyle();
             this.childrenLayoutStrategy = node.getChildrenLayoutStrategy();
             this.position = node.getPosition();
@@ -292,8 +291,8 @@ public final class Node implements IDiagramElement {
             return this;
         }
 
-        public Builder label(Label label) {
-            this.label = Objects.requireNonNull(label);
+        public Builder insideLabel(InsideLabel insideLabel) {
+            this.insideLabel = Objects.requireNonNull(insideLabel);
             return this;
         }
 
@@ -354,7 +353,7 @@ public final class Node implements IDiagramElement {
             node.modifiers = Objects.requireNonNull(this.modifiers);
             node.state = Objects.requireNonNull(this.state);
             node.collapsingState = Objects.requireNonNull(this.collapsingState);
-            node.label = this.label;
+            node.insideLabel = this.insideLabel;
             node.style = Objects.requireNonNull(this.style);
             node.childrenLayoutStrategy = this.childrenLayoutStrategy;
             node.position = Objects.requireNonNull(this.position);

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/Node.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/Node.java
@@ -354,7 +354,7 @@ public final class Node implements IDiagramElement {
             node.modifiers = Objects.requireNonNull(this.modifiers);
             node.state = Objects.requireNonNull(this.state);
             node.collapsingState = Objects.requireNonNull(this.collapsingState);
-            node.label = Objects.requireNonNull(this.label);
+            node.label = this.label;
             node.style = Objects.requireNonNull(this.style);
             node.childrenLayoutStrategy = this.childrenLayoutStrategy;
             node.position = Objects.requireNonNull(this.position);

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/InsideLabelComponent.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/InsideLabelComponent.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.components;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.diagrams.InsideLabel;
+import org.eclipse.sirius.components.diagrams.LabelStyle;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
+import org.eclipse.sirius.components.diagrams.description.LabelDescription;
+import org.eclipse.sirius.components.diagrams.description.LabelStyleDescription;
+import org.eclipse.sirius.components.diagrams.elements.InsideLabelElementProps;
+import org.eclipse.sirius.components.representations.Element;
+import org.eclipse.sirius.components.representations.IComponent;
+import org.eclipse.sirius.components.representations.VariableManager;
+
+/**
+ * The component used to render the inside label.
+ *
+ * @author gcoutable
+ */
+public class InsideLabelComponent implements IComponent {
+
+    private final InsideLabelComponentProps props;
+
+    public InsideLabelComponent(InsideLabelComponentProps props) {
+        this.props = Objects.requireNonNull(props);
+    }
+
+    @Override
+    public Element render() {
+        VariableManager variableManager = this.props.getVariableManager();
+        LabelDescription labelDescription = this.props.getLabelDescription();
+        Optional<InsideLabel> optionalPreviousInsideLabel = this.props.getPreviousInsideLabel();
+        String type = this.props.getType();
+        String idFromProvider = labelDescription.getIdProvider().apply(variableManager);
+        String id = UUID.nameUUIDFromBytes(idFromProvider.getBytes()).toString();
+        String text = labelDescription.getTextProvider().apply(variableManager);
+
+        LabelStyleDescription labelStyleDescription = labelDescription.getStyleDescriptionProvider().apply(variableManager);
+
+        String color = labelStyleDescription.getColorProvider().apply(variableManager);
+        Integer fontSize = labelStyleDescription.getFontSizeProvider().apply(variableManager);
+        Boolean bold = labelStyleDescription.getBoldProvider().apply(variableManager);
+        Boolean italic = labelStyleDescription.getItalicProvider().apply(variableManager);
+        Boolean strikeThrough = labelStyleDescription.getStrikeThroughProvider().apply(variableManager);
+        Boolean underline = labelStyleDescription.getUnderlineProvider().apply(variableManager);
+        String iconURL = labelStyleDescription.getIconURLProvider().apply(variableManager);
+
+        Position position = optionalPreviousInsideLabel.map(InsideLabel::getPosition).orElse(Position.UNDEFINED);
+        Size size = optionalPreviousInsideLabel.map(InsideLabel::getSize).orElse(Size.UNDEFINED);
+        Position aligment = optionalPreviousInsideLabel.map(InsideLabel::getAlignment).orElse(Position.UNDEFINED);
+
+        var labelStyle = LabelStyle.newLabelStyle()
+                .color(color)
+                .fontSize(fontSize)
+                .bold(bold)
+                .italic(italic)
+                .strikeThrough(strikeThrough)
+                .underline(underline)
+                .iconURL(iconURL)
+                .build();
+
+        InsideLabelElementProps insideLabelElementProps = InsideLabelElementProps.newInsideLabelElementProps(id)
+                .type(type)
+                .text(text)
+                .position(position)
+                .size(size)
+                .alignment(aligment)
+                .style(labelStyle)
+                .build();
+        return new Element(InsideLabelElementProps.TYPE, insideLabelElementProps);
+    }
+}

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/InsideLabelComponentProps.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/InsideLabelComponentProps.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.components;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.sirius.components.diagrams.InsideLabel;
+import org.eclipse.sirius.components.diagrams.description.LabelDescription;
+import org.eclipse.sirius.components.representations.IProps;
+import org.eclipse.sirius.components.representations.VariableManager;
+
+/**
+ * The properties of the inside label component.
+ *
+ * @author gcoutable
+ */
+public class InsideLabelComponentProps implements IProps {
+
+    private final VariableManager variableManager;
+
+    private final LabelDescription labelDescription;
+
+    private final Optional<InsideLabel> optionalPreviousInsideLabel;
+
+    private final String type;
+
+    public InsideLabelComponentProps(VariableManager variableManager, LabelDescription labelDescription, Optional<InsideLabel> optionalPreviousInsideLabel, String type) {
+        this.variableManager = Objects.requireNonNull(variableManager);
+        this.labelDescription = Objects.requireNonNull(labelDescription);
+        this.optionalPreviousInsideLabel = Objects.requireNonNull(optionalPreviousInsideLabel);
+        this.type = Objects.requireNonNull(type);
+    }
+
+    public VariableManager getVariableManager() {
+        return this.variableManager;
+    }
+
+    public LabelDescription getLabelDescription() {
+        return this.labelDescription;
+    }
+
+    public Optional<InsideLabel> getPreviousInsideLabel() {
+        return this.optionalPreviousInsideLabel;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+}

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/NodeComponent.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/NodeComponent.java
@@ -185,19 +185,21 @@ public class NodeComponent implements IComponent {
         }
         List<Element> childNodes = this.getChildNodes(optionalPreviousNode, nodeVariableManager, nodeId, parentState, nodeDescriptionRequestor);
 
-        LabelDescription labelDescription = nodeDescription.getLabelDescription();
-        nodeVariableManager.put(LabelDescription.OWNER_ID, nodeId);
-
-        // This value is not the real label type. The real one will be provided by the ISiriusWebLayoutConfigurator in
-        // the diagrams-layout.
-        LabelType dummyLabelType = this.getLabelType(containmentKind, type, style);
-
-        Optional<Label> optionalPreviousLabel = optionalPreviousNode.map(Node::getLabel);
-        LabelComponentProps labelComponentProps = new LabelComponentProps(nodeVariableManager, labelDescription, optionalPreviousLabel, dummyLabelType.getValue());
-        Element labelElement = new Element(LabelComponent.class, labelComponentProps);
-
         List<Element> nodeChildren = new ArrayList<>();
-        nodeChildren.add(labelElement);
+        LabelDescription labelDescription = nodeDescription.getLabelDescription();
+        if (labelDescription != null) {
+            nodeVariableManager.put(LabelDescription.OWNER_ID, nodeId);
+
+            // This value is not the real label type. The real one will be provided by the ISiriusWebLayoutConfigurator in
+            // the diagrams-layout.
+            LabelType dummyLabelType = this.getLabelType(containmentKind, type, style);
+
+            Optional<Label> optionalPreviousLabel = optionalPreviousNode.map(Node::getLabel);
+            LabelComponentProps labelComponentProps = new LabelComponentProps(nodeVariableManager, labelDescription, optionalPreviousLabel, dummyLabelType.getValue());
+            Element labelElement = new Element(LabelComponent.class, labelComponentProps);
+            nodeChildren.add(labelElement);
+        }
+
         nodeChildren.addAll(borderNodes);
         nodeChildren.addAll(childNodes);
         // @formatter:off

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/NodeComponent.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/NodeComponent.java
@@ -24,7 +24,7 @@ import org.eclipse.sirius.components.diagrams.CollapsingState;
 import org.eclipse.sirius.components.diagrams.CustomizableProperties;
 import org.eclipse.sirius.components.diagrams.ILayoutStrategy;
 import org.eclipse.sirius.components.diagrams.INodeStyle;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.NodeType;
 import org.eclipse.sirius.components.diagrams.ParametricSVGNodeType;
@@ -194,10 +194,10 @@ public class NodeComponent implements IComponent {
             // the diagrams-layout.
             LabelType dummyLabelType = this.getLabelType(containmentKind, type, style);
 
-            Optional<Label> optionalPreviousLabel = optionalPreviousNode.map(Node::getLabel);
-            LabelComponentProps labelComponentProps = new LabelComponentProps(nodeVariableManager, labelDescription, optionalPreviousLabel, dummyLabelType.getValue());
-            Element labelElement = new Element(LabelComponent.class, labelComponentProps);
-            nodeChildren.add(labelElement);
+            Optional<InsideLabel> optionalPreviousInsideLabel = optionalPreviousNode.map(Node::getInsideLabel);
+            InsideLabelComponentProps insideLabelComponentProps = new InsideLabelComponentProps(nodeVariableManager, labelDescription, optionalPreviousInsideLabel, dummyLabelType.getValue());
+            Element insideLabelElement = new Element(InsideLabelComponent.class, insideLabelComponentProps);
+            nodeChildren.add(insideLabelElement);
         }
 
         nodeChildren.addAll(borderNodes);

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/description/NodeDescription.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/description/NodeDescription.java
@@ -367,7 +367,7 @@ public final class NodeDescription implements IDiagramElementDescription {
             nodeDescription.targetObjectLabelProvider = Objects.requireNonNull(this.targetObjectLabelProvider);
             nodeDescription.semanticElementsProvider = Objects.requireNonNull(this.semanticElementsProvider);
             nodeDescription.shouldRenderPredicate = Objects.requireNonNull(this.shouldRenderPredicate);
-            nodeDescription.labelDescription = Objects.requireNonNull(this.labelDescription);
+            nodeDescription.labelDescription = this.labelDescription;
             nodeDescription.styleProvider = Objects.requireNonNull(this.styleProvider);
             nodeDescription.sizeProvider = Objects.requireNonNull(this.sizeProvider);
             nodeDescription.userResizable = this.userResizable;

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/elements/InsideLabelElementProps.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/elements/InsideLabelElementProps.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.elements;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.annotations.Immutable;
+import org.eclipse.sirius.components.diagrams.LabelStyle;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
+import org.eclipse.sirius.components.representations.IProps;
+
+/**
+ * The properties of the inside label element.
+ *
+ * @author gcoutable
+ */
+@Immutable
+public final class InsideLabelElementProps implements IProps {
+
+    public static final String TYPE = "InsideLabel";
+
+    private String id;
+
+    private String type;
+
+    private String text;
+
+    private Position position;
+
+    private Size size;
+
+    private Position alignment;
+
+    private LabelStyle style;
+
+    private InsideLabelElementProps() {
+        // Prevent instantiation
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public String getText() {
+        return this.text;
+    }
+
+    public Position getPosition() {
+        return this.position;
+    }
+
+    public Size getSize() {
+        return this.size;
+    }
+
+    public Position getAlignment() {
+        return this.alignment;
+    }
+
+    public LabelStyle getStyle() {
+        return this.style;
+    }
+
+    public static Builder newInsideLabelElementProps(String id) {
+        return new Builder(id);
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, type: {2}, text: {3}'}'";
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.type, this.text);
+    }
+
+    /**
+     * The builder used to create an inside label element.
+     *
+     * @author sbegaudeau
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+        private String id;
+
+        private String type;
+
+        private String text;
+
+        private Position position;
+
+        private Size size;
+
+        private Position alignment;
+
+        private LabelStyle style;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder type(String type) {
+            this.type = Objects.requireNonNull(type);
+            return this;
+        }
+
+        public Builder text(String text) {
+            this.text = Objects.requireNonNull(text);
+            return this;
+        }
+
+        public Builder position(Position position) {
+            this.position = Objects.requireNonNull(position);
+            return this;
+        }
+
+        public Builder size(Size size) {
+            this.size = Objects.requireNonNull(size);
+            return this;
+        }
+
+        public Builder alignment(Position aligment) {
+            this.alignment = Objects.requireNonNull(aligment);
+            return this;
+        }
+
+        public Builder style(LabelStyle style) {
+            this.style = Objects.requireNonNull(style);
+            return this;
+        }
+
+        public InsideLabelElementProps build() {
+            InsideLabelElementProps insideLabelElementProps = new InsideLabelElementProps();
+            insideLabelElementProps.id = Objects.requireNonNull(this.id);
+            insideLabelElementProps.type = Objects.requireNonNull(this.type);
+            insideLabelElementProps.text = Objects.requireNonNull(this.text);
+            insideLabelElementProps.position = Objects.requireNonNull(this.position);
+            insideLabelElementProps.size = Objects.requireNonNull(this.size);
+            insideLabelElementProps.alignment = Objects.requireNonNull(this.alignment);
+            insideLabelElementProps.style = Objects.requireNonNull(this.style);
+            return insideLabelElementProps;
+        }
+    }
+}

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/renderer/DiagramComponentPropsValidator.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/renderer/DiagramComponentPropsValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ import org.eclipse.sirius.components.diagrams.components.DiagramComponent;
 import org.eclipse.sirius.components.diagrams.components.DiagramComponentProps;
 import org.eclipse.sirius.components.diagrams.components.EdgeComponent;
 import org.eclipse.sirius.components.diagrams.components.EdgeComponentProps;
+import org.eclipse.sirius.components.diagrams.components.InsideLabelComponent;
+import org.eclipse.sirius.components.diagrams.components.InsideLabelComponentProps;
 import org.eclipse.sirius.components.diagrams.components.LabelComponent;
 import org.eclipse.sirius.components.diagrams.components.LabelComponentProps;
 import org.eclipse.sirius.components.diagrams.components.NodeComponent;
@@ -42,6 +44,8 @@ public class DiagramComponentPropsValidator implements IComponentPropsValidator 
             checkValidProps = props instanceof EdgeComponentProps;
         } else if (LabelComponent.class.equals(componentType)) {
             checkValidProps = props instanceof LabelComponentProps;
+        } else if (InsideLabelComponent.class.equals(componentType)) {
+            checkValidProps = props instanceof InsideLabelComponentProps;
         }
 
         return checkValidProps;

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/renderer/DiagramElementFactory.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/renderer/DiagramElementFactory.java
@@ -17,12 +17,14 @@ import java.util.List;
 
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.Node.Builder;
 import org.eclipse.sirius.components.diagrams.components.LabelType;
 import org.eclipse.sirius.components.diagrams.elements.DiagramElementProps;
 import org.eclipse.sirius.components.diagrams.elements.EdgeElementProps;
+import org.eclipse.sirius.components.diagrams.elements.InsideLabelElementProps;
 import org.eclipse.sirius.components.diagrams.elements.LabelElementProps;
 import org.eclipse.sirius.components.diagrams.elements.NodeElementProps;
 import org.eclipse.sirius.components.representations.IElementFactory;
@@ -50,6 +52,8 @@ public class DiagramElementFactory implements IElementFactory {
             object = this.instantiateEdge(edgeElementProps, children);
         } else if (LabelElementProps.TYPE.equals(type) && props instanceof LabelElementProps labelElementProps) {
             object = this.instantiateLabel(labelElementProps);
+        } else if (InsideLabelElementProps.TYPE.equals(type) && props instanceof InsideLabelElementProps insideLabelElementProps) {
+            object = this.instantiateInsideLabel(insideLabelElementProps);
         }
         return object;
     }
@@ -58,7 +62,6 @@ public class DiagramElementFactory implements IElementFactory {
         List<Node> nodes = new ArrayList<>();
         List<Edge> edges = new ArrayList<>();
 
-        // @formatter:off
         children.forEach(child -> {
             if (child instanceof Node node) {
                 nodes.add(node);
@@ -78,17 +81,14 @@ public class DiagramElementFactory implements IElementFactory {
                 .nodes(nodes)
                 .edges(edges)
                 .build();
-        // @formatter:on
     }
 
     private Node instantiateNode(NodeElementProps props, List<Object> children) {
-        // @formatter:off
-        Label label = children.stream()
-                .filter(Label.class::isInstance)
-                .map(Label.class::cast)
+        InsideLabel insideLabel = children.stream()
+                .filter(InsideLabel.class::isInstance)
+                .map(InsideLabel.class::cast)
                 .findFirst()
                 .orElse(null);
-        // @formatter:on
 
         List<Node> childNodes = new ArrayList<>();
         List<Node> borderNodes = new ArrayList<>();
@@ -101,7 +101,6 @@ public class DiagramElementFactory implements IElementFactory {
             }
         });
 
-        // @formatter:off
         Builder nodeBuilder = Node.newNode(props.getId())
                 .type(props.getType())
                 .targetObjectId(props.getTargetObjectId())
@@ -109,7 +108,6 @@ public class DiagramElementFactory implements IElementFactory {
                 .targetObjectLabel(props.getTargetObjectLabel())
                 .descriptionId(props.getDescriptionId())
                 .borderNode(props.isBorderNode())
-                .label(label)
                 .style(props.getStyle())
                 .position(props.getPosition())
                 .size(props.getSize())
@@ -122,16 +120,18 @@ public class DiagramElementFactory implements IElementFactory {
                 .collapsingState(props.getCollapsingState())
                 .labelEditable(props.isLabelEditable());
 
+        if (insideLabel != null) {
+            nodeBuilder.insideLabel(insideLabel);
+        }
+
         if (props.getChildrenLayoutStrategy() != null) {
             nodeBuilder.childrenLayoutStrategy(props.getChildrenLayoutStrategy());
         }
 
         return nodeBuilder.build();
-        // @formatter:on
     }
 
     private Edge instantiateEdge(EdgeElementProps props, List<Object> children) {
-        // @formatter:off
         Label beginLabel = this.getLabel(children, LabelType.EDGE_BEGIN);
         Label centerLabel = this.getLabel(children, LabelType.EDGE_CENTER);
         Label endLabel = this.getLabel(children, LabelType.EDGE_END);
@@ -153,23 +153,19 @@ public class DiagramElementFactory implements IElementFactory {
                 .state(props.getState())
                 .modifiers(props.getModifiers())
                 .build();
-        // @formatter:on
     }
 
     private Label getLabel(List<Object> children, LabelType labelType) {
-        // @formatter:off
         return children.stream()
                 .filter(Label.class::isInstance)
                 .map(Label.class::cast)
                 .filter(label -> label.getType().equals(labelType.getValue()))
                 .findFirst()
                 .orElse(null);
-        // @formatter:on
 
     }
 
     private Label instantiateLabel(LabelElementProps props) {
-        // @formatter:off
         return Label.newLabel(props.getId())
                 .type(props.getType())
                 .text(props.getText())
@@ -178,7 +174,17 @@ public class DiagramElementFactory implements IElementFactory {
                 .alignment(props.getAlignment())
                 .style(props.getStyle())
                 .build();
-        // @formatter:on
+    }
+
+    private InsideLabel instantiateInsideLabel(InsideLabelElementProps props) {
+        return InsideLabel.newLabel(props.getId())
+                .type(props.getType())
+                .text(props.getText())
+                .position(props.getPosition())
+                .size(props.getSize())
+                .alignment(props.getAlignment())
+                .style(props.getStyle())
+                .build();
     }
 
 }

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/renderer/DiagramInstancePropsValidator.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/renderer/DiagramInstancePropsValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package org.eclipse.sirius.components.diagrams.renderer;
 
 import org.eclipse.sirius.components.diagrams.elements.DiagramElementProps;
 import org.eclipse.sirius.components.diagrams.elements.EdgeElementProps;
+import org.eclipse.sirius.components.diagrams.elements.InsideLabelElementProps;
 import org.eclipse.sirius.components.diagrams.elements.LabelElementProps;
 import org.eclipse.sirius.components.diagrams.elements.NodeElementProps;
 import org.eclipse.sirius.components.representations.IInstancePropsValidator;
@@ -38,6 +39,8 @@ public class DiagramInstancePropsValidator implements IInstancePropsValidator {
             checkValidProps = props instanceof EdgeElementProps;
         } else if (LabelElementProps.TYPE.equals(type)) {
             checkValidProps = props instanceof LabelElementProps;
+        } else if (InsideLabelElementProps.TYPE.equals(type)) {
+            checkValidProps = props instanceof InsideLabelElementProps;
         }
 
         return checkValidProps;

--- a/packages/diagrams/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/DiagramRendererNodeTests.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/DiagramRendererNodeTests.java
@@ -26,7 +26,7 @@ import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.FreeFormLayoutStrategy;
 import org.eclipse.sirius.components.diagrams.INodeStyle;
 import org.eclipse.sirius.components.diagrams.ImageNodeStyle;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.LineStyle;
 import org.eclipse.sirius.components.diagrams.Node;
@@ -98,14 +98,14 @@ public class DiagramRendererNodeTests {
         assertThat(diagram.getNodes()).extracting(Node::getBorderNodes).allMatch(List::isEmpty);
         assertThat(diagram.getNodes()).extracting(Node::getStyle).allMatch(s -> s instanceof RectangularNodeStyle);
         assertThat(diagram.getNodes()).extracting(Node::getSize).allMatch(s -> s.getHeight() == -1 && s.getWidth() == -1);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getId).allMatch(id -> UUID.nameUUIDFromBytes(LABEL_ID.getBytes()).toString().equals(id));
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getText).allMatch(LABEL_TEXT::equals);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getColor).allMatch(LABEL_COLOR::equals);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getFontSize).allMatch(size -> LABEL_FONT_SIZE == size);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::isBold).allMatch(bold -> bold);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::isItalic).allMatch(italic -> italic);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::isUnderline).allMatch(underline -> underline);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::isStrikeThrough).allMatch(strikeThrough -> strikeThrough);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getId).allMatch(id -> UUID.nameUUIDFromBytes(LABEL_ID.getBytes()).toString().equals(id));
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getText).allMatch(LABEL_TEXT::equals);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::getColor).allMatch(LABEL_COLOR::equals);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::getFontSize).allMatch(size -> LABEL_FONT_SIZE == size);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::isBold).allMatch(bold -> bold);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::isItalic).allMatch(italic -> italic);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::isUnderline).allMatch(underline -> underline);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::isStrikeThrough).allMatch(strikeThrough -> strikeThrough);
     }
 
     @Test
@@ -135,14 +135,14 @@ public class DiagramRendererNodeTests {
         assertThat(diagram.getNodes()).extracting(Node::getBorderNodes).allMatch(List::isEmpty);
         assertThat(diagram.getNodes()).extracting(Node::getStyle).allMatch(s -> s instanceof RectangularNodeStyle);
         assertThat(diagram.getNodes()).extracting(Node::getSize).allMatch(s -> s.getHeight() == 200 && s.getWidth() == 10);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getId).allMatch(id -> UUID.nameUUIDFromBytes(LABEL_ID.getBytes()).toString().equals(id));
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getText).allMatch(LABEL_TEXT::equals);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getColor).allMatch(LABEL_COLOR::equals);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getFontSize).allMatch(size -> LABEL_FONT_SIZE == size);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::isBold).allMatch(bold -> bold);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::isItalic).allMatch(italic -> italic);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::isUnderline).allMatch(underline -> underline);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::isStrikeThrough).allMatch(strikeThrough -> strikeThrough);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getId).allMatch(id -> UUID.nameUUIDFromBytes(LABEL_ID.getBytes()).toString().equals(id));
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getText).allMatch(LABEL_TEXT::equals);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::getColor).allMatch(LABEL_COLOR::equals);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::getFontSize).allMatch(size -> LABEL_FONT_SIZE == size);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::isBold).allMatch(bold -> bold);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::isItalic).allMatch(italic -> italic);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::isUnderline).allMatch(underline -> underline);
+        assertThat(diagram.getNodes()).extracting(Node::getInsideLabel).extracting(InsideLabel::getStyle).extracting(LabelStyle::isStrikeThrough).allMatch(strikeThrough -> strikeThrough);
     }
 
     @Test

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/diagramFragment.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/diagramFragment.ts
@@ -12,7 +12,7 @@
  *******************************************************************************/
 
 import { edgeFragment } from './edgeFragment';
-import { labelFragment } from './labelFragment';
+import { insideLabelFragment, labelFragment } from './labelFragment';
 import { nodeFragment } from './nodeFragment';
 
 export const diagramFragment = `
@@ -67,4 +67,5 @@ fragment diagramFragment on Diagram {
 ${nodeFragment}
 ${edgeFragment}
 ${labelFragment}
+${insideLabelFragment}
 `;

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/diagramFragment.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/diagramFragment.types.ts
@@ -12,13 +12,13 @@
  *******************************************************************************/
 
 import { GQLEdge } from './edgeFragment.types';
-import { GQLNode } from './nodeFragment.types';
+import { GQLNode, GQLNodeStyle } from './nodeFragment.types';
 
 export interface GQLDiagram {
   id: string;
   targetObjectId: string;
   metadata: GQLRepresentationMetadata;
-  nodes: GQLNode[];
+  nodes: GQLNode<GQLNodeStyle>[];
   edges: GQLEdge[];
 }
 

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/labelFragment.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/labelFragment.ts
@@ -27,3 +27,20 @@ fragment labelFragment on Label {
   }
 }
 `;
+
+export const insideLabelFragment = `
+fragment insideLabelFragment on InsideLabel {
+  id
+  type
+  text
+  style {
+    color
+    fontSize
+    bold
+    italic
+    underline
+    strikeThrough
+    iconURL
+  }
+}
+`;

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/labelFragment.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/labelFragment.types.ts
@@ -18,6 +18,13 @@ export interface GQLLabel {
   style: GQLLabelStyle;
 }
 
+export interface GQLInsideLabel {
+  id: string;
+  type: string;
+  text: string;
+  style: GQLLabelStyle;
+}
+
 export interface GQLLabelStyle {
   color: string;
   fontSize: number;

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/nodeFragment.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/nodeFragment.ts
@@ -20,8 +20,8 @@ fragment nodeFragment on Node {
   targetObjectLabel
   descriptionId
   state
-  label {
-    ...labelFragment
+  insideLabel {
+    ...insideLabelFragment
   }
   style {
     __typename

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/nodeFragment.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/graphql/subscription/nodeFragment.types.ts
@@ -10,9 +10,9 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { GQLLabel } from './labelFragment.types';
+import { GQLInsideLabel } from './labelFragment.types';
 
-export interface GQLNode {
+export interface GQLNode<T extends GQLNodeStyle> {
   id: string;
   type: string;
   targetObjectId: string;
@@ -20,11 +20,11 @@ export interface GQLNode {
   targetObjectLabel: string;
   descriptionId: string;
   state: GQLViewModifier;
-  label: GQLLabel;
-  style: GQLNodeStyle;
+  insideLabel: GQLInsideLabel | undefined;
+  style: T;
   childrenLayoutStrategy?: ILayoutStrategy;
-  borderNodes: GQLNode[] | undefined;
-  childNodes: GQLNode[] | undefined;
+  borderNodes: GQLNode<GQLNodeStyle>[] | undefined;
+  childNodes: GQLNode<GQLNodeStyle>[] | undefined;
   position: GQLPosition;
   size: GQLSize;
   labelEditable: boolean;

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/DiagramRenderer.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/DiagramRenderer.types.ts
@@ -54,7 +54,7 @@ export interface NodeData {
   targetObjectKind: string;
   targetObjectLabel: string;
   descriptionId: string;
-  label: Label | null;
+  label: Label | undefined;
   faded: boolean;
   isBorderNode: boolean;
   borderNodePosition: BorderNodePositon | null;

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/direct-edit/useDiagramDirectEdit.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/direct-edit/useDiagramDirectEdit.tsx
@@ -38,7 +38,7 @@ export const useDiagramDirectEdit = (): UseDiagramDirectEditValue => {
       const validFirstInputChar =
         !event.metaKey && !event.ctrlKey && key.length === 1 && directEditActivationValidCharacters.test(key);
       let currentlyEditedLabelId: string | undefined | null = nodes.find((node) => node.selected)?.data.label?.id;
-      let isLabelEditable: boolean | undefined = nodes.find((node) => node.selected)?.data.labelEditable;
+      const isLabelEditable: boolean = nodes.find((node) => node.selected)?.data.labelEditable || false;
       if (!currentlyEditedLabelId) {
         currentlyEditedLabelId = edges.find((edge) => edge.selected)?.data?.label?.id;
       }

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.types.ts
@@ -142,7 +142,7 @@ export enum GQLViewModifier {
 
 export interface GQLNode {
   id: string;
-  label: GQLLabel;
+  insideLabel: GQLLabel;
   descriptionId: string;
   type: string;
   targetObjectId: string;

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/representation/operations.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/representation/operations.ts
@@ -107,8 +107,8 @@ export const diagramEventSubscription = gql`
     targetObjectLabel
     descriptionId
     state
-    label {
-      ...labelFields
+    insideLabel {
+      ...insideLabelFields
     }
     style {
       ... on RectangularNodeStyle {
@@ -190,6 +190,33 @@ export const diagramEventSubscription = gql`
   }
 
   fragment labelFields on Label {
+    id
+    type
+    text
+    style {
+      color
+      fontSize
+      bold
+      italic
+      underline
+      strikeThrough
+      iconURL
+    }
+    position {
+      x
+      y
+    }
+    size {
+      width
+      height
+    }
+    alignment {
+      x
+      y
+    }
+  }
+
+  fragment insideLabelFields on InsideLabel {
     id
     type
     text

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/sprotty/convertDiagram.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/sprotty/convertDiagram.tsx
@@ -131,7 +131,7 @@ const convertNode = (
 ): Node => {
   const {
     id,
-    label,
+    insideLabel,
     descriptionId,
     type,
     targetObjectId,
@@ -151,7 +151,7 @@ const convertNode = (
 
   node.state = ViewModifier[GQLViewModifier[state]];
 
-  const convertedLabel = convertLabel(node, label, httpOrigin, readOnly, theme);
+  const convertedLabel = convertLabel(node, insideLabel, httpOrigin, readOnly, theme);
   (borderNodes ?? [])
     .filter((borderNode) => borderNode.state !== GQLViewModifier.Hidden)
     .map((borderNode) => convertBorderNode(node, borderNode, httpOrigin, readOnly, autoLayout, theme));
@@ -185,7 +185,7 @@ const convertBorderNode = (
 ): BorderNode => {
   const {
     id,
-    label,
+    insideLabel,
     descriptionId,
     type,
     targetObjectId,
@@ -201,7 +201,7 @@ const convertBorderNode = (
   const node: BorderNode = new BorderNode();
   parentElement.add(node);
 
-  const convertedLabel = convertLabel(node, label, httpOrigin, readOnly, theme);
+  const convertedLabel = convertLabel(node, insideLabel, httpOrigin, readOnly, theme);
 
   node.id = id;
   node.type = type.replace('node:', 'port:');

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/diagram/DiagramLayoutIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/diagram/DiagramLayoutIntegrationTests.java
@@ -47,7 +47,7 @@ public class DiagramLayoutIntegrationTests {
     public void givenDiagramWhenLayoutIsPerformedThenValidLayoutDataAreComputed() {
         TestDiagramBuilder builder = new TestDiagramBuilder();
         var diagram = Diagram.newDiagram(builder.getDiagram("diagram"))
-                .nodes(List.of(builder.getNode("node")))
+                .nodes(List.of(builder.getNode("node", true)))
                 .build();
 
         DiagramLayoutConfiguration diagramLayoutConfiguration = new DiagramLayoutConfigurationProvider().getDiagramLayoutConfiguration(diagram, new DiagramLayoutData(Map.of(), Map.of(), Map.of()), Optional.empty());

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/view/ViewInitialDirectEditElementLabelProviderIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/view/ViewInitialDirectEditElementLabelProviderIntegrationTests.java
@@ -438,7 +438,7 @@ public class ViewInitialDirectEditElementLabelProviderIntegrationTests extends A
     private void editDiagramElementLabel(DiagramRefreshedEventPayload diagramRefreshedEventPayload) {
         var diagram = diagramRefreshedEventPayload.diagram();
         // Get any node label
-        var label = diagram.getNodes().get(0).getLabel();
+        var label = diagram.getNodes().get(0).getInsideLabel();
         var labelId = label.getId();
         var query = """
                 query initialDirectEditElementLabel($editingContextId: ID!, $diagramId: ID!, $labelId: ID!) {

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/DiagramOperationInterpreterViewSwitch.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/DiagramOperationInterpreterViewSwitch.java
@@ -25,7 +25,7 @@ import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.diagrams.CollapsingState;
 import org.eclipse.sirius.components.diagrams.Edge;
 import org.eclipse.sirius.components.diagrams.FreeFormLayoutStrategy;
-import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.InsideLabel;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.LineStyle;
 import org.eclipse.sirius.components.diagrams.Node;
@@ -177,7 +177,7 @@ public class DiagramOperationInterpreterViewSwitch extends DiagramSwitch<Optiona
                 .iconURL("")
                 .build();
 
-        var label = Label.newLabel("")
+        var insideLabel = InsideLabel.newLabel("")
                 .type("")
                 .text("")
                 .position(Position.UNDEFINED)
@@ -202,7 +202,7 @@ public class DiagramOperationInterpreterViewSwitch extends DiagramSwitch<Optiona
                 .modifiers(Set.of())
                 .state(ViewModifier.Normal)
                 .collapsingState(CollapsingState.EXPANDED)
-                .label(label)
+                .insideLabel(insideLabel)
                 .style(nodeStyle)
                 .childrenLayoutStrategy(new FreeFormLayoutStrategy())
                 .position(Position.UNDEFINED)

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/providers/ViewInitialDirectEditElementLabelProvider.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/providers/ViewInitialDirectEditElementLabelProvider.java
@@ -108,7 +108,7 @@ public class ViewInitialDirectEditElementLabelProvider implements IInitialDirect
                 String descriptionId = node.getDescriptionId();
                 optionalLabelEditTool = this.getNodeDescription(diagramDescription.getNodeDescriptions(), descriptionId).map(NodeDescription::getPalette).map(NodePalette::getLabelEditTool);
                 semanticElement = this.objectService.getObject(editingContext, node.getTargetObjectId());
-                initialDirectEditElementLabel = node.getLabel().getText();
+                initialDirectEditElementLabel = node.getInsideLabel().getText();
             } else if (diagramElement instanceof Edge edge) {
                 String descriptionId = edge.getDescriptionId();
                 semanticElement = this.objectService.getObject(editingContext, edge.getTargetObjectId());

--- a/packages/view/backend/sirius-components-view-emf/src/test/java/org/eclipse/sirius/components/view/emf/view/DynamicDiagramsTests.java
+++ b/packages/view/backend/sirius-components-view-emf/src/test/java/org/eclipse/sirius/components/view/emf/view/DynamicDiagramsTests.java
@@ -112,7 +112,7 @@ public class DynamicDiagramsTests {
         assertThat(result).isNotNull();
         assertThat(result.getEdges()).isEmpty();
         assertThat(result.getNodes()).hasSize(2);
-        assertThat(result.getNodes()).extracting(node -> node.getLabel().getText()).containsExactlyInAnyOrder("Class1", "Class2");
+        assertThat(result.getNodes()).extracting(node -> node.getInsideLabel().getText()).containsExactlyInAnyOrder("Class1", "Class2");
     }
 
     @Test


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1982

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?