### PR TITLE
[cleanup] Fix the expected presence of the feedback message service

### DIFF
--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/configuration/ViewReconnectionToolsExecutorParameters.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/configuration/ViewReconnectionToolsExecutorParameters.java
@@ -12,19 +12,21 @@
  *******************************************************************************/
 package org.eclipse.sirius.components.view.emf.configuration;
 
+import java.util.Objects;
+
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.core.api.IURLParser;
 import org.eclipse.sirius.components.view.emf.IViewRepresentationDescriptionPredicate;
 import org.eclipse.sirius.components.view.emf.IViewRepresentationDescriptionSearchService;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
 
 /**
  * Bundles the common dependencies that view tool services need into a single object for convenience.
  *
  * @author frouene
  */
-@Configuration
-public class ViewToolConfiguration {
+@Service
+public class ViewReconnectionToolsExecutorParameters {
 
     private final IURLParser urlParser;
 
@@ -34,11 +36,11 @@ public class ViewToolConfiguration {
 
     private final IObjectService objectService;
 
-    public ViewToolConfiguration(IURLParser urlParser, IViewRepresentationDescriptionPredicate viewRepresentationDescriptionPredicate, IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService, IObjectService objectService) {
-        this.urlParser = urlParser;
-        this.viewRepresentationDescriptionPredicate = viewRepresentationDescriptionPredicate;
-        this.viewRepresentationDescriptionSearchService = viewRepresentationDescriptionSearchService;
-        this.objectService = objectService;
+    public ViewReconnectionToolsExecutorParameters(IURLParser urlParser, IViewRepresentationDescriptionPredicate viewRepresentationDescriptionPredicate, IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService, IObjectService objectService) {
+        this.urlParser = Objects.requireNonNull(urlParser);
+        this.viewRepresentationDescriptionPredicate = Objects.requireNonNull(viewRepresentationDescriptionPredicate);
+        this.viewRepresentationDescriptionSearchService = Objects.requireNonNull(viewRepresentationDescriptionSearchService);
+        this.objectService = Objects.requireNonNull(objectService);
     }
 
     public IURLParser getUrlParser() {

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/DiagramOperationInterpreter.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/DiagramOperationInterpreter.java
@@ -59,16 +59,14 @@ public class DiagramOperationInterpreter implements IOperationInterpreter {
         this.editService = Objects.requireNonNull(editService);
         this.diagramContext = diagramContext;
         this.convertedNodes = Objects.requireNonNull(convertedNodes);
-        this.feedbackMessageService = feedbackMessageService;
+        this.feedbackMessageService = Objects.requireNonNull(feedbackMessageService);
     }
 
     public IStatus executeTool(Tool tool, VariableManager variableManager) {
         Optional<VariableManager> optionalVariableManager = this.executeOperations(tool.getBody(), variableManager);
         if (optionalVariableManager.isEmpty()) {
             var feedbackMessages = new ArrayList<>(List.of(String.format("Something went wrong while executing the tool '%s'", tool.getName())));
-            if (Objects.nonNull(this.feedbackMessageService)) {
-                feedbackMessages.addAll(this.feedbackMessageService.getFeedbackMessages());
-            }
+            feedbackMessages.addAll(this.feedbackMessageService.getFeedbackMessages());
             return new Failure(String.join(", ", feedbackMessages));
         }
         return new Success();

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewReconnectionToolsExecutor.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewReconnectionToolsExecutor.java
@@ -38,7 +38,7 @@ import org.eclipse.sirius.components.view.View;
 import org.eclipse.sirius.components.view.emf.IJavaServiceProvider;
 import org.eclipse.sirius.components.view.emf.IViewRepresentationDescriptionPredicate;
 import org.eclipse.sirius.components.view.emf.IViewRepresentationDescriptionSearchService;
-import org.eclipse.sirius.components.view.emf.configuration.ViewToolConfiguration;
+import org.eclipse.sirius.components.view.emf.configuration.ViewReconnectionToolsExecutorParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -70,15 +70,15 @@ public class ViewReconnectionToolsExecutor implements IReconnectionToolsExecutor
 
     private final Logger logger = LoggerFactory.getLogger(ViewReconnectionToolsExecutor.class);
 
-    public ViewReconnectionToolsExecutor(ViewToolConfiguration configuration, IEditService editService, List<IJavaServiceProvider> javaServiceProviders,
-            ApplicationContext applicationContext, IFeedbackMessageService feedbackMessageService) {
-        this.objectService = Objects.requireNonNull(configuration.getObjectService());
+    public ViewReconnectionToolsExecutor(ViewReconnectionToolsExecutorParameters parameters, IEditService editService, List<IJavaServiceProvider> javaServiceProviders,
+                                         ApplicationContext applicationContext, IFeedbackMessageService feedbackMessageService) {
+        this.objectService = Objects.requireNonNull(parameters.getObjectService());
         this.editService = Objects.requireNonNull(editService);
-        this.viewRepresentationDescriptionSearchService = Objects.requireNonNull(configuration.getViewRepresentationDescriptionSearchService());
+        this.viewRepresentationDescriptionSearchService = Objects.requireNonNull(parameters.getViewRepresentationDescriptionSearchService());
         this.javaServiceProviders = Objects.requireNonNull(javaServiceProviders);
-        this.viewRepresentationDescriptionPredicate = Objects.requireNonNull(configuration.getViewRepresentationDescriptionPredicate());
+        this.viewRepresentationDescriptionPredicate = Objects.requireNonNull(parameters.getViewRepresentationDescriptionPredicate());
         this.applicationContext = Objects.requireNonNull(applicationContext);
-        this.feedbackMessageService = feedbackMessageService;
+        this.feedbackMessageService = Objects.requireNonNull(feedbackMessageService);
     }
 
     @Override

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewToolSectionsProvider.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewToolSectionsProvider.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.dto.SingleClickOnDia
 import org.eclipse.sirius.components.collaborative.diagrams.dto.SingleClickOnTwoDiagramElementsCandidate;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.SingleClickOnTwoDiagramElementsTool;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.ToolSection;
+import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.core.api.IURLParser;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
@@ -44,7 +45,6 @@ import org.eclipse.sirius.components.view.EdgeTool;
 import org.eclipse.sirius.components.view.NodeTool;
 import org.eclipse.sirius.components.view.emf.IViewRepresentationDescriptionPredicate;
 import org.eclipse.sirius.components.view.emf.IViewRepresentationDescriptionSearchService;
-import org.eclipse.sirius.components.view.emf.configuration.ViewToolConfiguration;
 import org.springframework.stereotype.Service;
 
 /**
@@ -76,14 +76,17 @@ public class ViewToolSectionsProvider implements IToolSectionsProvider {
 
     private final IDiagramIdProvider diagramIdProvider;
 
+    private final IObjectService objectService;
+
     private final Function<EObject, UUID> idProvider = (eObject) -> UUID.nameUUIDFromBytes(EcoreUtil.getURI(eObject).toString().getBytes());
 
-    public ViewToolSectionsProvider(ViewToolConfiguration configuration, IDiagramDescriptionService diagramDescriptionService, IDiagramIdProvider diagramIdProvider) {
-        this.urlParser = Objects.requireNonNull(configuration.getUrlParser());
-        this.viewRepresentationDescriptionPredicate = Objects.requireNonNull(configuration.getViewRepresentationDescriptionPredicate());
-        this.viewRepresentationDescriptionSearchService = Objects.requireNonNull(configuration.getViewRepresentationDescriptionSearchService());
+    public ViewToolSectionsProvider(IURLParser urlParser, IViewRepresentationDescriptionPredicate viewRepresentationDescriptionPredicate, IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService, IDiagramDescriptionService diagramDescriptionService, IDiagramIdProvider diagramIdProvider, IObjectService objectService) {
+        this.urlParser = Objects.requireNonNull(urlParser);
+        this.viewRepresentationDescriptionPredicate = Objects.requireNonNull(viewRepresentationDescriptionPredicate);
+        this.viewRepresentationDescriptionSearchService = Objects.requireNonNull(viewRepresentationDescriptionSearchService);
         this.diagramDescriptionService = Objects.requireNonNull(diagramDescriptionService);
         this.diagramIdProvider = Objects.requireNonNull(diagramIdProvider);
+        this.objectService = Objects.requireNonNull(objectService);
     }
 
     @Override

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/form/ViewFormDescriptionConverter.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/form/ViewFormDescriptionConverter.java
@@ -74,7 +74,7 @@ public class ViewFormDescriptionConverter implements IRepresentationDescriptionC
         this.editService = Objects.requireNonNull(editService);
         this.formIdProvider = Objects.requireNonNull(formIdProvider);
         this.customWidgetConverterProviders = Objects.requireNonNull(customWidgetConverterProviders);
-        this.feedbackMessageService = feedbackMessageService;
+        this.feedbackMessageService = Objects.requireNonNull(feedbackMessageService);
     }
 
     @Override

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/form/ViewFormDescriptionConverterSwitch.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/form/ViewFormDescriptionConverterSwitch.java
@@ -110,7 +110,7 @@ public class ViewFormDescriptionConverterSwitch extends ViewSwitch<AbstractWidge
         this.editService = Objects.requireNonNull(editService);
         this.objectService = Objects.requireNonNull(objectService);
         this.customWidgetConverters = Objects.requireNonNull(customWidgetConverters);
-        this.feedbackMessageService = feedbackMessageService;
+        this.feedbackMessageService = Objects.requireNonNull(feedbackMessageService);
     }
 
     @Override
@@ -806,9 +806,7 @@ public class ViewFormDescriptionConverterSwitch extends ViewSwitch<AbstractWidge
 
     private Failure buildFailureWithFeedbackMessages(String technicalMessage) {
         var errorMessages = new ArrayList<>(List.of(technicalMessage));
-        if (Objects.nonNull(this.feedbackMessageService)) {
-            errorMessages.addAll(this.feedbackMessageService.getFeedbackMessages());
-        }
+        errorMessages.addAll(this.feedbackMessageService.getFeedbackMessages());
         return new Failure(String.join(", ", errorMessages));
     }
 


### PR DESCRIPTION
As of today, the service is not in any way optional. This commit will
make sure that the code and the reality are aligned.

Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?