### PR TITLE
[releng] Upgrade JaCoCo Maven Plug-in from 0.8.8 to 0.8.10

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,8 @@
 
 === Dependency update
 
+- [releng] Switch to Jacoco 0.8.10
+
 === Bug fixes
 
 === New Features

--- a/packages/charts/backend/sirius-components-charts/pom.xml
+++ b/packages/charts/backend/sirius-components-charts/pom.xml
@@ -98,7 +98,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/charts/backend/sirius-components-collaborative-charts/pom.xml
+++ b/packages/charts/backend/sirius-components-collaborative-charts/pom.xml
@@ -97,7 +97,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/compatibility/backend/sirius-components-compatibility-emf/pom.xml
+++ b/packages/compatibility/backend/sirius-components-compatibility-emf/pom.xml
@@ -125,7 +125,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/compatibility/backend/sirius-components-compatibility/pom.xml
+++ b/packages/compatibility/backend/sirius-components-compatibility/pom.xml
@@ -234,7 +234,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/core/backend/sirius-components-annotations-spring/pom.xml
+++ b/packages/core/backend/sirius-components-annotations-spring/pom.xml
@@ -71,7 +71,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/core/backend/sirius-components-annotations/pom.xml
+++ b/packages/core/backend/sirius-components-annotations/pom.xml
@@ -64,7 +64,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/core/backend/sirius-components-collaborative/pom.xml
+++ b/packages/core/backend/sirius-components-collaborative/pom.xml
@@ -118,7 +118,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/core/backend/sirius-components-core/pom.xml
+++ b/packages/core/backend/sirius-components-core/pom.xml
@@ -92,7 +92,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/core/backend/sirius-components-graphql-api/pom.xml
+++ b/packages/core/backend/sirius-components-graphql-api/pom.xml
@@ -90,7 +90,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/core/backend/sirius-components-representations/pom.xml
+++ b/packages/core/backend/sirius-components-representations/pom.xml
@@ -76,7 +76,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/pom.xml
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/pom.xml
@@ -118,7 +118,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/diagrams/backend/sirius-components-diagrams-layout-api/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout-api/pom.xml
@@ -85,7 +85,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/pom.xml
@@ -174,7 +174,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/pom.xml
@@ -89,7 +89,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/diagrams/backend/sirius-components-diagrams/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams/pom.xml
@@ -83,7 +83,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/domain/backend/sirius-components-domain-emf/pom.xml
+++ b/packages/domain/backend/sirius-components-domain-emf/pom.xml
@@ -105,7 +105,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/emf/backend/sirius-components-emf/pom.xml
+++ b/packages/emf/backend/sirius-components-emf/pom.xml
@@ -159,7 +159,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/emf/backend/sirius-components-interpreter/pom.xml
+++ b/packages/emf/backend/sirius-components-interpreter/pom.xml
@@ -120,7 +120,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/pom.xml
@@ -107,7 +107,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors-graphql/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors-graphql/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors/pom.xml
@@ -111,7 +111,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/forms/backend/sirius-components-collaborative-forms/pom.xml
+++ b/packages/forms/backend/sirius-components-collaborative-forms/pom.xml
@@ -107,7 +107,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/forms/backend/sirius-components-forms-graphql/pom.xml
+++ b/packages/forms/backend/sirius-components-forms-graphql/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/forms/backend/sirius-components-forms-tests/pom.xml
+++ b/packages/forms/backend/sirius-components-forms-tests/pom.xml
@@ -80,7 +80,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/forms/backend/sirius-components-forms/pom.xml
+++ b/packages/forms/backend/sirius-components-forms/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/releng/backend/sirius-components-test-coverage/pom.xml
+++ b/packages/releng/backend/sirius-components-test-coverage/pom.xml
@@ -272,7 +272,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<id>test-report</id>

--- a/packages/selection/backend/sirius-components-collaborative-selection/pom.xml
+++ b/packages/selection/backend/sirius-components-collaborative-selection/pom.xml
@@ -102,7 +102,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/selection/backend/sirius-components-selection-graphql/pom.xml
+++ b/packages/selection/backend/sirius-components-selection-graphql/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/selection/backend/sirius-components-selection/pom.xml
+++ b/packages/selection/backend/sirius-components-selection/pom.xml
@@ -83,7 +83,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/sirius-web/backend/sirius-web-graphql/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-graphql/pom.xml
@@ -139,7 +139,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/sirius-web/backend/sirius-web-persistence/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-persistence/pom.xml
@@ -118,7 +118,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/sirius-web/backend/sirius-web-sample-application/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-sample-application/pom.xml
@@ -261,7 +261,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/sirius-web/backend/sirius-web-services-api/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-services-api/pom.xml
@@ -102,7 +102,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/sirius-web/backend/sirius-web-services/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-services/pom.xml
@@ -127,7 +127,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/sirius-web/backend/sirius-web-spring/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-spring/pom.xml
@@ -107,7 +107,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/starters/backend/sirius-components-starter/pom.xml
+++ b/packages/starters/backend/sirius-components-starter/pom.xml
@@ -197,7 +197,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/tests/backend/sirius-components-spring-tests/pom.xml
+++ b/packages/tests/backend/sirius-components-spring-tests/pom.xml
@@ -85,7 +85,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/tests/backend/sirius-components-tests/pom.xml
+++ b/packages/tests/backend/sirius-components-tests/pom.xml
@@ -81,7 +81,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/trees/backend/sirius-components-collaborative-trees/pom.xml
+++ b/packages/trees/backend/sirius-components-collaborative-trees/pom.xml
@@ -106,7 +106,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/trees/backend/sirius-components-trees-graphql/pom.xml
+++ b/packages/trees/backend/sirius-components-trees-graphql/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/trees/backend/sirius-components-trees/pom.xml
+++ b/packages/trees/backend/sirius-components-trees/pom.xml
@@ -88,7 +88,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/validation/backend/sirius-components-collaborative-validation/pom.xml
+++ b/packages/validation/backend/sirius-components-collaborative-validation/pom.xml
@@ -98,7 +98,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/validation/backend/sirius-components-validation-graphql/pom.xml
+++ b/packages/validation/backend/sirius-components-validation-graphql/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/validation/backend/sirius-components-validation/pom.xml
+++ b/packages/validation/backend/sirius-components-validation/pom.xml
@@ -83,7 +83,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/view/backend/sirius-components-view-emf/pom.xml
+++ b/packages/view/backend/sirius-components-view-emf/pom.xml
@@ -126,7 +126,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/web/backend/sirius-components-graphql/pom.xml
+++ b/packages/web/backend/sirius-components-graphql/pom.xml
@@ -114,7 +114,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>

--- a/packages/web/backend/sirius-components-web/pom.xml
+++ b/packages/web/backend/sirius-components-web/pom.xml
@@ -93,7 +93,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
I use Java 20 locally, and JaCoCo does not support classes compiled with that JDK, causing lots of noise (stack traces) when running the tests locally.
[JaCoCo 0.8.9](https://github.com/jacoco/jacoco/releases/tag/v0.8.9) added support for Java 19 and 20.
