### PR TITLE
[2027] Support both versions of the ITool interface in the imageURL data fetchers

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -54,6 +54,7 @@ It will start by improving a bit performances since diagrams were persisted twic
 - https://github.com/eclipse-sirius/sirius-components/issues/1991[#1991] [form] Fix an issue where widgets from different groups share the same ID.
 - https://github.com/eclipse-sirius/sirius-components/issues/1305[#1305] [diagram] Fix an issue where the default tools of the palette's tool sections where not updated.
 - https://github.com/eclipse-sirius/sirius-components/issues/2008[#2008] [view] Make edge tool more robust for applications which use a custom IViewRepresentationDescriptionSearchService.
+- https://github.com/eclipse-sirius/sirius-components/issues/2027[#2027] [diagram] Support both versions of the ITool interface in the imageURL data fetchers
 
 === New Features
 

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/SingleClickOnDiagramElementToolImageURLDataFetcher.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/SingleClickOnDiagramElementToolImageURLDataFetcher.java
@@ -29,7 +29,13 @@ public class SingleClickOnDiagramElementToolImageURLDataFetcher implements IData
 
     @Override
     public String get(DataFetchingEnvironment environment) throws Exception {
-        ITool tool = environment.getSource();
-        return URLConstants.IMAGE_BASE_PATH + tool.imageURL();
+        String url = "";
+        Object source = environment.getSource();
+        if (source instanceof org.eclipse.sirius.components.diagrams.tools.ITool tool) {
+            url = URLConstants.IMAGE_BASE_PATH + tool.getImageURL();
+        } else if (source instanceof ITool tool) {
+            url = URLConstants.IMAGE_BASE_PATH + tool.imageURL();
+        }
+        return url;
     }
 }

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/SingleClickOnTwoDiagramElementsToolImageURLDataFetcher.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/SingleClickOnTwoDiagramElementsToolImageURLDataFetcher.java
@@ -29,7 +29,13 @@ public class SingleClickOnTwoDiagramElementsToolImageURLDataFetcher implements I
 
     @Override
     public String get(DataFetchingEnvironment environment) throws Exception {
-        ITool tool = environment.getSource();
-        return URLConstants.IMAGE_BASE_PATH + tool.imageURL();
+        String url = "";
+        Object source = environment.getSource();
+        if (source instanceof org.eclipse.sirius.components.diagrams.tools.ITool tool) {
+            url = URLConstants.IMAGE_BASE_PATH + tool.getImageURL();
+        } else if (source instanceof ITool tool) {
+            url = URLConstants.IMAGE_BASE_PATH + tool.imageURL();
+        }
+        return url;
     }
 }


### PR DESCRIPTION
It feels more like a workaround. Not sure if there is a good reason to have 2 versions of `ITool`, `SingleClickOnDiagramElementTool`, `SingleClickOnTwoDiagramElementsTool` and `SingleClickOnTwoDiagramElementsCandidate`.
