### PR TITLE
[2080] Add an inital label value when editing tree items label

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,10 @@
 
 === Breaking changes
 
+- https://github.com/eclipse-sirius/sirius-components/issues/2080[#2080] [tree] EditingContextRepresentationDataFetcher will filter on IRepresentation unstead of ISemanticRepresentation to be able to support TreeDescription.
++
+As such targetObjectId is removed from RepresentationMetadata.
+
 === Dependency update
 
 - [releng] Switch to Jacoco 0.8.10
@@ -24,7 +28,8 @@
 
 === Bug fixes
 
-- https://github.com/eclipse-sirius/sirius-components/issues/2058[#2058] [view] Fix an issue where the default icon for List widget candidates was missing when the candidates were not EObjects.
+- https://github.com/eclipse-sirius/sirius-components/issues/2058[#2058] [view] Fix an issue where the default icon for List widget candidates was missing when the candidates wer
+e not EObjects.
 - https://github.com/eclipse-sirius/sirius-components/issues/2060[#2060] [form] Fix an issue where the list widget was displayed on a single line inside a flexbox container, no matter the length of the labels of its items.
 - https://github.com/eclipse-sirius/sirius-components/issues/2076[#2076] [sirius-web] Fix `EditingDomainFactoryService` declaration to use an interface.
 - https://github.com/eclipse-sirius/sirius-components/issues/2032[#2032] [form] Add domainType on PageDescription in the view DSL and takes into account the impacts for the FormDescriptionAggregator.
@@ -47,6 +52,7 @@ image:doc/screenshots/ShowIconOptionSelectWidget.jpg[Icons on select widget opti
 - https://github.com/eclipse-sirius/sirius-components/issues/2055[#2055] [form] Added initial version of a custom widget to view & edit EMF references (both single and multi-valued).
 - https://github.com/eclipse-sirius/sirius-components/issues/2056[#2056] [form] Add the possibility to control read-only mode for widgets with an expression.
 - https://github.com/eclipse-sirius/sirius-components/issues/2077[#2077] [form] Add the ability to define a border style for groups and flexbox containers.
+- https://github.com/eclipse-sirius/sirius-components/issues/2080[#2080] [tree] Add an inital label value when editing tree items label.
 
 === Improvements
 

--- a/integration-tests/cypress/e2e/project/edit/explorer.cy.js
+++ b/integration-tests/cypress/e2e/project/edit/explorer.cy.js
@@ -87,6 +87,7 @@ describe('/projects/:projectId/edit - Explorer', () => {
     cy.getByTestId('selected').contains('robot');
     cy.getByTestId('robot').click();
     cy.getByTestId('robot').type('renamed-robot{esc}');
+    cy.getByTestId('name-edit').should('not.exist');
     cy.getByTestId('robot').should('exist');
   });
 
@@ -167,21 +168,31 @@ describe('/projects/:projectId/edit - Explorer', () => {
     cy.getByTestId('tree-root-elements').children().last().contains('robot').should('exist');
     cy.getByTestId('tree-root-elements').children().first().contains('robot').should('not.exist');
     cy.getByTestId('tree-root-elements').children().last().contains('Flow').should('not.exist');
+
     // Rename Flow Model to sFlow
     cy.getByTestId('Flow').click();
     cy.getByTestId('Flow-more').click();
     cy.getByTestId('treeitem-contextmenu').findByTestId('rename-tree-item').click();
+    cy.getByTestId('name-edit').should('exist');
+    cy.getByTestId('name-edit').get('input').should('have.value', 'Flow');
     cy.getByTestId('name-edit').type('sFlow{enter}');
+    cy.getByTestId('sFlow').should('exist');
+
     // Check documents order
     cy.getByTestId('tree-root-elements').children().first().contains('robot').should('exist');
     cy.getByTestId('tree-root-elements').children().last().contains('sFlow').should('exist');
     cy.getByTestId('tree-root-elements').children().first().contains('sFlow').should('not.exist');
     cy.getByTestId('tree-root-elements').children().last().contains('robot').should('not.exist');
+
     // Rename sFlow Model to ROBOT
     cy.getByTestId('sFlow').click();
     cy.getByTestId('sFlow-more').click();
     cy.getByTestId('treeitem-contextmenu').findByTestId('rename-tree-item').click();
+    cy.getByTestId('name-edit').should('exist');
+    cy.getByTestId('name-edit').get('input').should('have.value', 'sFlow');
     cy.getByTestId('name-edit').type('ROBOT{enter}');
+    cy.getByTestId('ROBOT').should('exist');
+
     // Check documents order
     cy.getByTestId('tree-root-elements').children().first().contains('robot').should('exist');
     cy.getByTestId('tree-root-elements').children().last().contains('ROBOT').should('exist');

--- a/integration-tests/cypress/e2e/project/edit/representation-context-menu.cy.js
+++ b/integration-tests/cypress/e2e/project/edit/representation-context-menu.cy.js
@@ -50,6 +50,8 @@ describe('/projects/:projectId/edit - Representation Context Menu', () => {
     cy.getByTestId('representation-tab-B01').should('not.exist');
     cy.getByTestId('A01-more').click();
     cy.getByTestId('treeitem-contextmenu').findByTestId('rename-tree-item').click();
+    cy.getByTestId('name-edit').should('exist');
+    cy.getByTestId('name-edit').get('input').should('have.value', 'A01');
     cy.getByTestId('name-edit').type('A02{enter}');
 
     /*    
@@ -68,6 +70,8 @@ describe('/projects/:projectId/edit - Representation Context Menu', () => {
     cy.getByTestId('representation-tab-B01').should('not.exist');
     cy.getByTestId('A01-more').click();
     cy.getByTestId('treeitem-contextmenu').findByTestId('rename-tree-item').click();
+    cy.getByTestId('name-edit').should('exist');
+    cy.getByTestId('name-edit').get('input').should('have.value', 'A01');
     cy.getByTestId('name-edit').type('A02{enter}');
 
     /*    

--- a/packages/compatibility/backend/sirius-components-compatibility-emf/src/test/java/org/eclipse/sirius/components/compatibility/emf/compatibility/operations/NavigationOperationHandlerTests.java
+++ b/packages/compatibility/backend/sirius-components-compatibility-emf/src/test/java/org/eclipse/sirius/components/compatibility/emf/compatibility/operations/NavigationOperationHandlerTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Obeo.
+ * Copyright (c) 2022, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -62,9 +62,9 @@ public class NavigationOperationHandlerTests {
     private final IRepresentationMetadataSearchService representationMetadataSearchService = new IRepresentationMetadataSearchService.NoOp() {
         @Override
         public List<RepresentationMetadata> findAllByTargetObjectId(IEditingContext editingContext, String targetObjectId) {
-            var firstRepresentationMetadata = new RepresentationMetadata(FIRST_DIAGRAM_ID, Diagram.KIND, FIRST_DIAGRAM_LABEL, FIRST_DIAGRAM_DESCRIPTION_ID, targetObjectId);
-            var secondRepresentationMetadata = new RepresentationMetadata(SECOND_DIAGRAM_ID, Diagram.KIND, SECOND_DIAGRAM_LABEL, FIRST_DIAGRAM_DESCRIPTION_ID, targetObjectId);
-            var thirdRepresentationMetadata = new RepresentationMetadata(THIRD_DIAGRAM_ID, Diagram.KIND, THIRD_DIAGRAM_LABEL, SECOND_DIAGRAM_DESCRIPTION_ID, targetObjectId);
+            var firstRepresentationMetadata = new RepresentationMetadata(FIRST_DIAGRAM_ID, Diagram.KIND, FIRST_DIAGRAM_LABEL, FIRST_DIAGRAM_DESCRIPTION_ID);
+            var secondRepresentationMetadata = new RepresentationMetadata(SECOND_DIAGRAM_ID, Diagram.KIND, SECOND_DIAGRAM_LABEL, FIRST_DIAGRAM_DESCRIPTION_ID);
+            var thirdRepresentationMetadata = new RepresentationMetadata(THIRD_DIAGRAM_ID, Diagram.KIND, THIRD_DIAGRAM_LABEL, SECOND_DIAGRAM_DESCRIPTION_ID);
             return List.of(firstRepresentationMetadata, secondRepresentationMetadata, thirdRepresentationMetadata);
         }
     };

--- a/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessorRegistry.java
+++ b/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessorRegistry.java
@@ -20,8 +20,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import jakarta.annotation.PreDestroy;
-
 import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessor;
 import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorFactory;
 import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
@@ -34,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import jakarta.annotation.PreDestroy;
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 

--- a/packages/core/backend/sirius-components-core/src/main/java/org/eclipse/sirius/components/core/RepresentationMetadata.java
+++ b/packages/core/backend/sirius-components-core/src/main/java/org/eclipse/sirius/components/core/RepresentationMetadata.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Obeo.
+ * Copyright (c) 2022, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -29,14 +29,11 @@ public class RepresentationMetadata {
 
     private final String descriptionId;
 
-    private final String targetObjectId;
-
-    public RepresentationMetadata(String id, String kind, String label, String descriptionId, String targetObjectId) {
+    public RepresentationMetadata(String id, String kind, String label, String descriptionId) {
         this.id = Objects.requireNonNull(id);
         this.kind = Objects.requireNonNull(kind);
         this.label = Objects.requireNonNull(label);
         this.descriptionId = Objects.requireNonNull(descriptionId);
-        this.targetObjectId = targetObjectId;
     }
 
     public String getId() {
@@ -55,13 +52,9 @@ public class RepresentationMetadata {
         return this.descriptionId;
     }
 
-    public String getTargetObjectId() {
-        return this.targetObjectId;
-    }
-
     @Override
     public String toString() {
-        String pattern = "{0} '{'id: {1}, kind: {2}, label: {3}, descriptionId: {4}, targetObjectId: {5}'}'";
-        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.kind, this.label, this.descriptionId, this.targetObjectId);
+        String pattern = "{0} '{'id: {1}, kind: {2}, label: {3}, descriptionId: {4}'}'";
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.kind, this.label, this.descriptionId);
     }
 }

--- a/packages/sirius-web/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/editingcontext/EditingContextRepresentationsDataFetcher.java
+++ b/packages/sirius-web/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/editingcontext/EditingContextRepresentationsDataFetcher.java
@@ -15,13 +15,11 @@ package org.eclipse.sirius.web.graphql.datafetchers.editingcontext;
 import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
 import org.eclipse.sirius.components.core.RepresentationMetadata;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
 import org.eclipse.sirius.components.representations.IRepresentation;
-import org.eclipse.sirius.components.representations.ISemanticRepresentation;
 import org.eclipse.sirius.web.services.api.representations.IRepresentationService;
 import org.eclipse.sirius.web.services.api.representations.RepresentationDescriptor;
 
@@ -90,14 +88,7 @@ public class EditingContextRepresentationsDataFetcher implements IDataFetcherWit
     }
 
     private RepresentationMetadata toRepresentationMetadata(IRepresentation representation) {
-        // @formatter:off
-        String targetObjectId = Optional.of(representation)
-                .filter(ISemanticRepresentation.class::isInstance)
-                .map(ISemanticRepresentation.class::cast)
-                .map(ISemanticRepresentation::getTargetObjectId)
-                .orElse(null);
-        // @formatter:on
-        return new RepresentationMetadata(representation.getId(), representation.getKind(), representation.getLabel(), representation.getDescriptionId(), targetObjectId);
+        return new RepresentationMetadata(representation.getId(), representation.getKind(), representation.getLabel(), representation.getDescriptionId());
     }
 
 }

--- a/packages/sirius-web/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/representation/RepresentationMetadataDescriptionDataFetcher.java
+++ b/packages/sirius-web/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/representation/RepresentationMetadataDescriptionDataFetcher.java
@@ -24,12 +24,15 @@ import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProce
 import org.eclipse.sirius.components.collaborative.dto.GetRepresentationDescriptionInput;
 import org.eclipse.sirius.components.collaborative.dto.GetRepresentationDescriptionPayload;
 import org.eclipse.sirius.components.collaborative.forms.PropertiesEventProcessorFactory;
+import org.eclipse.sirius.components.collaborative.trees.TreeEventProcessorFactory;
 import org.eclipse.sirius.components.core.RepresentationMetadata;
 import org.eclipse.sirius.components.forms.description.FormDescription;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
 import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
+import org.eclipse.sirius.components.representations.Failure;
 import org.eclipse.sirius.components.representations.GetOrCreateRandomIdProvider;
 import org.eclipse.sirius.components.representations.IRepresentationDescription;
+import org.eclipse.sirius.components.trees.description.TreeDescription;
 
 import graphql.schema.DataFetchingEnvironment;
 import reactor.core.publisher.Mono;
@@ -53,7 +56,27 @@ public class RepresentationMetadataDescriptionDataFetcher implements IDataFetche
             .build();
     // @formatter:on
 
+    // @formatter:off
+    private static final IRepresentationDescription FAKE_DETAILS_TREE = TreeDescription.newTreeDescription(TreeEventProcessorFactory.TREE_ID)
+            .label("Explorer")
+            .idProvider(new GetOrCreateRandomIdProvider())
+            .treeItemIdProvider(variableManager -> TreeEventProcessorFactory.TREE_ID)
+            .kindProvider(variableManager -> TreeEventProcessorFactory.TREE_ID)
+            .labelProvider(variableManager -> TreeEventProcessorFactory.TREE_ID)
+            .imageURLProvider(variableManager -> TreeEventProcessorFactory.TREE_ID)
+            .editableProvider(variableManager -> null)
+            .deletableProvider(variableManager -> null)
+            .elementsProvider(variableManager -> null)
+            .hasChildrenProvider(variableManager -> null)
+            .childrenProvider(variableManager -> null)
+            .canCreatePredicate(variableManager -> true)
+            .deleteHandler(variableManager -> null)
+            .renameHandler((variableManager, newValue) -> new Failure(""))
+            .build();
+    // @formatter:on
+
     private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+
 
     public RepresentationMetadataDescriptionDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
         this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
@@ -64,15 +87,20 @@ public class RepresentationMetadataDescriptionDataFetcher implements IDataFetche
         CompletableFuture<IRepresentationDescription> result = Mono.<IRepresentationDescription>empty().toFuture();
 
         RepresentationMetadata representationMetadata = environment.getSource();
-        if (Objects.equals(PropertiesEventProcessorFactory.DETAILS_VIEW_ID, representationMetadata.getDescriptionId())) {
+        if (Objects.equals(PropertiesEventProcessorFactory.DETAILS_VIEW_ID, representationMetadata.getDescriptionId()) || (Objects.equals(TreeEventProcessorFactory.TREE_ID, representationMetadata.getDescriptionId()))) {
             /*
-             * The FormDescription used for the details view can not be found by
-             * IRepresentationDescriptionSearchService, but we can get away by returning a fake one with the same id as
-             * no GraphQL query actually needs to see its content. We need to return *something* with the correct id
+             * The FormDescription used for the details view and the TreeDescription used for the explorer can not be found by
+             * IRepresentationDescriptionSearchService. We can get away by returning fake ones with the same ids as
+             * no GraphQL query actually needs to see their content. We need to return *something* with the correct ids
              * only to allow GraphQL resolution to continue on queries like "completionProposals" defined on
              * FormDescription.
              */
-            result = Mono.just(FAKE_DETAILS_DESCRIPTION).toFuture();
+            if (Objects.equals(PropertiesEventProcessorFactory.DETAILS_VIEW_ID, representationMetadata.getDescriptionId())) {
+                result = Mono.just(FAKE_DETAILS_DESCRIPTION).toFuture();
+            }
+            if (Objects.equals(TreeEventProcessorFactory.TREE_ID, representationMetadata.getDescriptionId())) {
+                result = Mono.just(FAKE_DETAILS_TREE).toFuture();
+            }
         } else {
             Map<String, Object> localContext = environment.getLocalContext();
 
@@ -80,7 +108,6 @@ public class RepresentationMetadataDescriptionDataFetcher implements IDataFetche
             String representationId = Optional.ofNullable(localContext.get(LocalContextConstants.REPRESENTATION_ID)).map(Object::toString).orElse(null);
             if (editingContextId != null && representationId != null) {
                 GetRepresentationDescriptionInput input = new GetRepresentationDescriptionInput(UUID.randomUUID(), editingContextId, representationId);
-
                 // @formatter:off
                 result = this.editingContextEventProcessorRegistry.dispatchEvent(input.editingContextId(), input)
                         .filter(GetRepresentationDescriptionPayload.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/FlowProjectTemplatesInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/FlowProjectTemplatesInitializer.java
@@ -19,12 +19,14 @@ import fr.obeo.dsl.designer.sample.flow.FlowElementUsage;
 import fr.obeo.dsl.designer.sample.flow.FlowFactory;
 import fr.obeo.dsl.designer.sample.flow.Processor;
 import fr.obeo.dsl.designer.sample.flow.System;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
@@ -133,7 +135,7 @@ public class FlowProjectTemplatesInitializer implements IProjectTemplateInitiali
                         Diagram diagram = this.diagramCreationService.create(topographyDiagram.getLabel(), semanticTarget, topographyDiagram, editingContext);
                         this.representationPersistenceService.save(editingContext, diagram);
 
-                        result = Optional.of(new RepresentationMetadata(diagram.getId(), diagram.getKind(), diagram.getLabel(), diagram.getDescriptionId(), diagram.getTargetObjectId()));
+                        result = Optional.of(new RepresentationMetadata(diagram.getId(), diagram.getKind(), diagram.getLabel(), diagram.getDescriptionId()));
                     }
                 } catch (IOException exception) {
                     this.logger.warn(exception.getMessage(), exception);

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StudioProjectTemplatesInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StudioProjectTemplatesInitializer.java
@@ -160,7 +160,7 @@ public class StudioProjectTemplatesInitializer implements IProjectTemplateInitia
                         Diagram diagram = this.diagramCreationService.create(topographyDiagram.getLabel(), semanticTarget, topographyDiagram, editingContext);
                         this.representationPersistenceService.save(editingContext, diagram);
 
-                        result = Optional.of(new RepresentationMetadata(diagram.getId(), diagram.getKind(), diagram.getLabel(), diagram.getDescriptionId(), diagram.getTargetObjectId()));
+                        result = Optional.of(new RepresentationMetadata(diagram.getId(), diagram.getKind(), diagram.getLabel(), diagram.getDescriptionId()));
                     }
                 } catch (IOException exception) {
                     this.logger.warn(exception.getMessage(), exception);

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/papaya/PapayaStudioTemplatesInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/papaya/PapayaStudioTemplatesInitializer.java
@@ -133,7 +133,7 @@ public class PapayaStudioTemplatesInitializer implements IProjectTemplateInitial
                         Diagram diagram = this.diagramCreationService.create(topographyDiagram.getLabel(), semanticTarget, topographyDiagram, editingContext);
                         this.representationPersistenceService.save(editingContext, diagram);
 
-                        result = Optional.of(new RepresentationMetadata(diagram.getId(), diagram.getKind(), diagram.getLabel(), diagram.getDescriptionId(), diagram.getTargetObjectId()));
+                        result = Optional.of(new RepresentationMetadata(diagram.getId(), diagram.getKind(), diagram.getLabel(), diagram.getDescriptionId()));
                     }
                 } catch (IOException exception) {
                     this.logger.warn(exception.getMessage(), exception);

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/explorer/ExplorerInitialDirectEditTreeItemLabelProvider.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/explorer/ExplorerInitialDirectEditTreeItemLabelProvider.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.services.explorer;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.collaborative.trees.api.IInitialDirectEditTreeItemLabelProvider;
+import org.eclipse.sirius.components.collaborative.trees.dto.InitialDirectEditElementLabelInput;
+import org.eclipse.sirius.components.collaborative.trees.dto.InitialDirectEditElementLabelSuccessPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.trees.Tree;
+import org.eclipse.sirius.components.trees.TreeItem;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to compute the initial label to display when the direct edit of a tree item of the explorer is triggered on the frontend.
+ *
+ * @author mcharfadi
+ */
+@Service
+public class ExplorerInitialDirectEditTreeItemLabelProvider implements IInitialDirectEditTreeItemLabelProvider {
+
+    public static final String EXPLORER_DESCRIPTION_ID = UUID.nameUUIDFromBytes("explorer_tree_description".getBytes()).toString();
+
+    public static final String EXPLORER_DOCUMENT_KIND = "siriusComponents://representation?type=Tree";
+
+    public static final String EXPLORER_NAME = "Explorer";
+
+    @Override
+    public boolean canHandle(Tree tree) {
+        return tree.getId().startsWith("explorer://");
+    }
+
+    @Override
+    public IPayload handle(IEditingContext editingContext, Tree tree, InitialDirectEditElementLabelInput input) {
+        String initialLabel = tree.getChildren().stream()
+                .map(treeItems -> this.searchById(treeItems, input.treeItemId()))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(treeItem -> treeItem.getLabel())
+                .findFirst()
+                .orElse("");
+
+        return new InitialDirectEditElementLabelSuccessPayload(input.id(), initialLabel);
+    }
+
+    private Optional<TreeItem> searchById(TreeItem treeItem, String id) {
+        Optional<TreeItem> optionalTreeItem = Optional.empty();
+        if (treeItem.getId().equals(id)) {
+            optionalTreeItem = Optional.of(treeItem);
+        }
+        if (optionalTreeItem.isEmpty() && treeItem.isHasChildren()) {
+            optionalTreeItem = treeItem.getChildren().stream()
+                    .map(treeItems -> this.searchById(treeItems, id))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get).findFirst();
+        }
+        return optionalTreeItem;
+    }
+
+}

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/TreeEventProcessorFactory.java
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/TreeEventProcessorFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ package org.eclipse.sirius.components.collaborative.trees;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.eclipse.sirius.components.collaborative.api.IRepresentationConfiguration;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessor;
@@ -40,6 +41,8 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
  */
 @Service
 public class TreeEventProcessorFactory implements IRepresentationEventProcessorFactory {
+
+    public static final String TREE_ID = UUID.nameUUIDFromBytes("explorer_tree_description".getBytes()).toString();
 
     private final IExplorerDescriptionProvider explorerDescriptionProvider;
 

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/api/IInitialDirectEditTreeItemLabelProvider.java
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/api/IInitialDirectEditTreeItemLabelProvider.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.trees.api;
+
+import org.eclipse.sirius.components.collaborative.trees.dto.InitialDirectEditElementLabelInput;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.trees.Tree;
+
+/**
+ * IInitialDirectEditTreeItemLabelProvider.
+ *
+ * @author mcharfadi
+ */
+public interface IInitialDirectEditTreeItemLabelProvider {
+
+    boolean canHandle(Tree treeDescription);
+
+    IPayload handle(IEditingContext editingContext, Tree tree, InitialDirectEditElementLabelInput input);
+}

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/api/TreeConfiguration.java
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/api/TreeConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ public class TreeConfiguration implements IRepresentationConfiguration {
 
     public TreeConfiguration(String editingContextId, List<String> expanded) {
         String uniqueId = editingContextId + expanded.toString();
-        this.treeId = UUID.nameUUIDFromBytes(uniqueId.getBytes()).toString();
+        this.treeId = "explorer://" + UUID.nameUUIDFromBytes(uniqueId.getBytes()).toString();
         this.expanded = Objects.requireNonNull(expanded);
     }
 

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/dto/InitialDirectEditElementLabelInput.java
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/dto/InitialDirectEditElementLabelInput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Obeo.
+ * Copyright (c) 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,15 +12,14 @@
  *******************************************************************************/
 package org.eclipse.sirius.components.collaborative.trees.dto;
 
-import java.util.List;
 import java.util.UUID;
 
-import org.eclipse.sirius.components.core.api.IInput;
+import org.eclipse.sirius.components.collaborative.trees.api.ITreeInput;
 
 /**
- * The input of the tree event subscription.
+ * The "initial direct edit element label" query input.
  *
- * @author sbegaudeau
+ * @author mcharfadi
  */
-public record TreeEventInput(UUID id, String editingContextId, String treeId, List<String> expanded) implements IInput {
+public record InitialDirectEditElementLabelInput(UUID id, String editingContextId, String representationId, String treeItemId, String initialLabel) implements ITreeInput {
 }

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/dto/InitialDirectEditElementLabelSuccessPayload.java
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/dto/InitialDirectEditElementLabelSuccessPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Obeo.
+ * Copyright (c) 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,15 +12,19 @@
  *******************************************************************************/
 package org.eclipse.sirius.components.collaborative.trees.dto;
 
-import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
-import org.eclipse.sirius.components.core.api.IInput;
+import org.eclipse.sirius.components.core.api.IPayload;
 
 /**
- * The input of the tree event subscription.
+ * The "initial direct edit element label" success payload.
  *
- * @author sbegaudeau
+ * @author mcharfadi
  */
-public record TreeEventInput(UUID id, String editingContextId, String treeId, List<String> expanded) implements IInput {
+public record InitialDirectEditElementLabelSuccessPayload(UUID id, String initialDirectEditElementLabel) implements IPayload {
+    public InitialDirectEditElementLabelSuccessPayload {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(initialDirectEditElementLabel);
+    }
 }

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/handlers/InitialDirectEditTreeItemLabelEventHandler.java
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/handlers/InitialDirectEditTreeItemLabelEventHandler.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.trees.handlers;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
+import org.eclipse.sirius.components.collaborative.api.ChangeKind;
+import org.eclipse.sirius.components.collaborative.trees.api.IInitialDirectEditTreeItemLabelProvider;
+import org.eclipse.sirius.components.collaborative.trees.api.ITreeEventHandler;
+import org.eclipse.sirius.components.collaborative.trees.api.ITreeInput;
+import org.eclipse.sirius.components.collaborative.trees.dto.InitialDirectEditElementLabelInput;
+import org.eclipse.sirius.components.collaborative.trees.dto.InitialDirectEditElementLabelSuccessPayload;
+import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.trees.Tree;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import reactor.core.publisher.Sinks.Many;
+import reactor.core.publisher.Sinks.One;
+
+/**
+ * Handler for InitialDirectEditElementLabelInput which simply forwards to the first available IInitialDirectEditTreeItemLabelProvider which can handle the
+ * request.
+ *
+ * @author mcharfadi
+ */
+@Service
+public class InitialDirectEditTreeItemLabelEventHandler implements ITreeEventHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(InitialDirectEditTreeItemLabelEventHandler.class);
+
+    private final List<IInitialDirectEditTreeItemLabelProvider> initialDirectEditTreeItemLabelProvider;
+
+    public InitialDirectEditTreeItemLabelEventHandler(List<IInitialDirectEditTreeItemLabelProvider> initialDirectEditTreeItemLabelProvider) {
+        this.initialDirectEditTreeItemLabelProvider = Objects.requireNonNull(initialDirectEditTreeItemLabelProvider);
+    }
+
+    @Override
+    public boolean canHandle(ITreeInput treeInput) {
+        return treeInput instanceof InitialDirectEditElementLabelInput;
+    }
+
+    @Override
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, Tree tree, ITreeInput treeInput) {
+        IPayload payload = new InitialDirectEditElementLabelSuccessPayload(treeInput.id(), "");
+        ChangeDescription changeDescription = new ChangeDescription(ChangeKind.NOTHING, treeInput.representationId(), treeInput);
+
+        if (treeInput instanceof InitialDirectEditElementLabelInput input) {
+            Optional<IInitialDirectEditTreeItemLabelProvider> optionalPathProvider = this.initialDirectEditTreeItemLabelProvider.stream().filter(treePathProvider -> treePathProvider.canHandle(tree)).findFirst();
+            if (optionalPathProvider.isPresent()) {
+                IPayload resultPayload = optionalPathProvider.get().handle(editingContext, tree, input);
+                if (resultPayload instanceof InitialDirectEditElementLabelSuccessPayload) {
+                    payload = resultPayload;
+                } else if (resultPayload instanceof ErrorPayload errorPayload) {
+                    this.logger.warn(errorPayload.message());
+                }
+            }
+        }
+        changeDescriptionSink.tryEmitNext(changeDescription);
+        payloadSink.tryEmitValue(payload);
+    }
+
+}

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/main/resources/schema/tree.graphqls
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/main/resources/schema/tree.graphqls
@@ -14,6 +14,7 @@ type TreePath {
 
 input TreeEventInput {
   id: ID!
+  treeId: String!
   editingContextId: ID!
   expanded: [String!]!
 }
@@ -46,6 +47,7 @@ type TreeItem {
 type TreeDescription implements RepresentationDescription {
   id: ID!
   label: String!
+  initialDirectEditTreeItemLabel(treeItemId: ID!): String!
 }
 
 extend type Mutation {
@@ -63,11 +65,11 @@ input DeleteTreeItemInput {
 union DeleteTreeItemPayload = SuccessPayload | ErrorPayload
 
 input RenameTreeItemInput {
-    id: ID!
-    editingContextId: ID!
-    representationId: ID!
-    treeItemId: ID!
-    newLabel: String!
+  id: ID!
+  editingContextId: ID!
+  representationId: ID!
+  treeItemId: ID!
+  newLabel: String!
 }
 
 union RenameTreeItemPayload = SuccessPayload | ErrorPayload

--- a/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/tree/TreeItemInitialDirectEditLabelDataFetcher.java
+++ b/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/tree/TreeItemInitialDirectEditLabelDataFetcher.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.trees.graphql.datafetchers.tree;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
+import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
+import org.eclipse.sirius.components.collaborative.trees.dto.InitialDirectEditElementLabelInput;
+import org.eclipse.sirius.components.collaborative.trees.dto.InitialDirectEditElementLabelSuccessPayload;
+import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
+
+import graphql.schema.DataFetchingEnvironment;
+import reactor.core.publisher.Mono;
+
+/**
+ * The "initial direct edit element label" query input.
+ *
+ * @author mcharfadi
+ */
+@QueryDataFetcher(type = "TreeDescription", field = "initialDirectEditTreeItemLabel")
+public class TreeItemInitialDirectEditLabelDataFetcher implements IDataFetcherWithFieldCoordinates<CompletableFuture<String>> {
+
+    private static final String INPUT_ARGUMENT = "treeItemId";
+
+    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+
+    public TreeItemInitialDirectEditLabelDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
+        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    }
+
+    @Override
+    public CompletableFuture<String> get(DataFetchingEnvironment environment) throws Exception {
+        Map<String, Object> localContext = environment.getLocalContext();
+        String editingContextId = Optional.ofNullable(localContext.get(LocalContextConstants.EDITING_CONTEXT_ID)).map(Object::toString).orElse(null);
+        String representationId = Optional.ofNullable(localContext.get(LocalContextConstants.REPRESENTATION_ID)).map(Object::toString).orElse(null);
+        String treeItemId = environment.getArgument(INPUT_ARGUMENT);
+
+        if (editingContextId != null && representationId != null && treeItemId != null) {
+            var input = new InitialDirectEditElementLabelInput(UUID.randomUUID(), editingContextId, representationId, treeItemId, "");
+            // @formatter:off
+            return this.editingContextEventProcessorRegistry.dispatchEvent(editingContextId, input)
+                    .filter(InitialDirectEditElementLabelSuccessPayload.class::isInstance)
+                    .map(InitialDirectEditElementLabelSuccessPayload.class::cast)
+                    .map(InitialDirectEditElementLabelSuccessPayload::initialDirectEditElementLabel)
+                    .toFuture();
+            // @formatter:on
+        }
+        return Mono.<String> empty().toFuture();
+    }
+}

--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemDirectEditInput.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemDirectEditInput.tsx
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { gql, useMutation, useQuery } from '@apollo/client';
+import { useMultiToast } from '@eclipse-sirius/sirius-components-core';
+import TextField from '@material-ui/core/TextField';
+import { useEffect, useRef, useState } from 'react';
+import {
+  GQLErrorPayload,
+  GQLInitialDirectEditElementLabelData,
+  GQLInitialDirectEditElementLabelInput,
+  GQLRenameTreeItemPayload,
+  GQLSuccessPayload,
+  TreeItemDirectEditInputProps,
+  TreeItemDirectEditInputState,
+} from './TreeItemDirectEditInput.types';
+
+const renameTreeItemMutation = gql`
+  mutation renameTreeItem($input: RenameTreeItemInput!) {
+    renameTreeItem(input: $input) {
+      __typename
+      ... on ErrorPayload {
+        message
+      }
+    }
+  }
+`;
+
+const initialDirectEditElementLabeQuery = gql`
+  query initialDirectEditElementLabel($editingContextId: ID!, $representationId: ID!, $treeItemId: ID!) {
+    viewer {
+      editingContext(editingContextId: $editingContextId) {
+        representation(representationId: $representationId) {
+          description {
+            ... on TreeDescription {
+              initialDirectEditTreeItemLabel(treeItemId: $treeItemId)
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const TreeItemDirectEditInput = ({
+  editingContextId,
+  treeId,
+  treeItemId,
+  editingkey,
+  onClose,
+}: TreeItemDirectEditInputProps) => {
+  const [state, setState] = useState<TreeItemDirectEditInputState>({
+    newLabel: editingkey,
+  });
+
+  const { addErrorMessage } = useMultiToast();
+
+  const isErrorPayload = (payload: GQLRenameTreeItemPayload): payload is GQLErrorPayload =>
+    payload.__typename === 'ErrorPayload';
+  const isSuccessPayload = (payload: GQLRenameTreeItemPayload): payload is GQLSuccessPayload =>
+    payload.__typename === 'SuccessPayload';
+
+  const textInput = useRef(null);
+
+  const { data: initialLabelTreeItemItemData, error: initialLabelTreeItemItemError } = useQuery<
+    GQLInitialDirectEditElementLabelData,
+    GQLInitialDirectEditElementLabelInput
+  >(initialDirectEditElementLabeQuery, {
+    variables: {
+      editingContextId: editingContextId,
+      representationId: treeId,
+      treeItemId: treeItemId,
+    },
+  });
+
+  useEffect(() => {
+    let cleanup = undefined;
+    if (initialLabelTreeItemItemError) {
+      addErrorMessage('An unexpected error has occurred, please refresh the page');
+    }
+    if (initialLabelTreeItemItemData?.viewer.editingContext.representation.description.initialDirectEditTreeItemLabel) {
+      const initialLabel =
+        initialLabelTreeItemItemData?.viewer.editingContext.representation.description.initialDirectEditTreeItemLabel;
+      if (!editingkey) {
+        setState((prevState) => {
+          return { ...prevState, newLabel: initialLabel };
+        });
+        const timeOutId = setTimeout(() => {
+          textInput.current.select();
+        }, 0);
+        cleanup = () => clearTimeout(timeOutId);
+      }
+    }
+    return cleanup;
+  }, [initialLabelTreeItemItemError, initialLabelTreeItemItemData]);
+
+  const [renameTreeItem, { data: renameTreeItemData, error: renameTreeItemError }] =
+    useMutation(renameTreeItemMutation);
+
+  useEffect(() => {
+    if (renameTreeItemError) {
+      addErrorMessage('An unexpected error has occurred, please refresh the page');
+    }
+    if (renameTreeItemData) {
+      const { renameTreeItem } = renameTreeItemData;
+      if (isErrorPayload(renameTreeItem)) {
+        addErrorMessage(renameTreeItem.messages);
+      } else if (isSuccessPayload(renameTreeItem)) {
+        if (renameTreeItem.__typename === 'SuccessPayload') {
+          onClose();
+        }
+      }
+    }
+  }, [renameTreeItemData, renameTreeItemError]);
+
+  const doRename = () => {
+    const isNameValid = state.newLabel.length >= 1;
+    if (isNameValid) {
+      renameTreeItem({
+        variables: {
+          input: {
+            id: crypto.randomUUID(),
+            editingContextId: editingContextId,
+            representationId: treeId,
+            treeItemId: treeItemId,
+            newLabel: state.newLabel,
+          },
+        },
+      });
+    } else {
+      onClose();
+    }
+  };
+
+  const handleChange = (event) => {
+    const newLabel = event.target.value;
+    setState((prevState) => {
+      return { ...prevState, newLabel: newLabel };
+    });
+  };
+
+  const onFinishEditing = (event) => {
+    const { key } = event;
+    if (key === 'Enter') {
+      doRename();
+    } else if (key === 'Escape') {
+      onClose();
+    }
+  };
+
+  const onFocusIn = (event) => event.target.select();
+
+  useEffect(() => {
+    document.addEventListener('mousedown', doRename);
+    return () => document.removeEventListener('mousedown', doRename);
+  });
+
+  return (
+    <>
+      <TextField
+        name="name"
+        size="small"
+        inputRef={textInput}
+        placeholder={'Enter the new name'}
+        value={state.newLabel}
+        onChange={handleChange}
+        onFocus={onFocusIn}
+        onKeyDown={onFinishEditing}
+        autoFocus
+        data-testid="name-edit"
+      />
+    </>
+  );
+};

--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemDirectEditInput.types.ts
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemDirectEditInput.types.ts
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+export interface TreeItemDirectEditInputProps {
+  editingContextId: string;
+  treeId: string;
+  treeItemId: string;
+  editingkey: string;
+  onClose: () => void;
+}
+
+export interface TreeItemDirectEditInputState {
+  newLabel: string;
+}
+
+export interface GQLInitialDirectEditElementLabelInput {
+  editingContextId: string;
+  representationId: string;
+  treeItemId: string;
+}
+
+export interface GQLInitialDirectEditElementLabelData {
+  viewer: GQLViewer;
+}
+
+export interface GQLViewer {
+  editingContext: GQLEditingContext;
+}
+
+export interface GQLEditingContext {
+  representation: GQLRepresentation;
+}
+
+export interface GQLRepresentation {
+  description: GQLRepresentationDescription;
+}
+
+export interface GQLRepresentationDescription {
+  __typename: string;
+  initialDirectEditTreeItemLabel: string;
+}
+
+export interface GQLRenameTreeItemPayload {
+  __typename: string;
+}
+
+export interface GQLSuccessPayload extends GQLRenameTreeItemPayload {
+  messages: string;
+}
+
+export interface GQLErrorPayload extends GQLRenameTreeItemPayload {
+  messages: string;
+}

--- a/packages/trees/frontend/sirius-components-trees/src/views/ExplorerView.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/views/ExplorerView.tsx
@@ -170,6 +170,7 @@ export const ExplorerView = ({ editingContextId, selection, setSelection, readOn
       variables: {
         input: {
           id,
+          treeId: 'explorer',
           editingContextId,
           expanded,
         },

--- a/packages/trees/frontend/sirius-components-trees/src/views/ExplorerView.types.ts
+++ b/packages/trees/frontend/sirius-components-trees/src/views/ExplorerView.types.ts
@@ -17,6 +17,7 @@ export interface GQLExplorerEventVariables {
 
 export interface GQLExplorerEventInput {
   id: string;
+  treeId: string;
   editingContextId: string;
   expanded: string[];
 }


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/2080

- EditingContextRepresentationDataFetcher will filter on IRepresentation unstead of ISemanticRepresentation to be able to support TreeDescription. As such targetObjectId is removed from RepresentationMetadata.
- The GraphQl input TreeEventInput now have an attribute treeId that start with "explorer://" when it's the explorer.
- A React component TreeItemDirectEditInput and the interface IInitialDirectEditTreeItemLabelProvider on the back-end are created.