### PR TITLE
[2124] Rename DocumentMetadataAdapter and move it in sirius-components-emf

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,9 +17,11 @@
 
 === Breaking changes
 
-- https://github.com/eclipse-sirius/sirius-components/issues/2080[#2080] [tree] EditingContextRepresentationDataFetcher will filter on IRepresentation unstead of ISemanticRepresentation to be able to support TreeDescription.
+- https://github.com/eclipse-sirius/sirius-components/issues/2080[#2080] [tree] EditingContextRepresentationDataFetcher will filter on IRepresentation instead of ISemanticRepresentation to be able to support TreeDescription.
 +
 As such targetObjectId is removed from RepresentationMetadata.
+- https://github.com/eclipse-sirius/sirius-components/issues/2124[#2124] [sirius-web,emf] The `org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter` has been renamed `ResourceMetadataAdapter` and moved to the `org.eclipse.sirius.components.emf` package (in `sirius-components-emf`).
+This allows for code which does not depend on Sirius Web and the Document notion to properly display the top-level elements of a project in the UI.
 
 === Dependency update
 
@@ -35,7 +37,7 @@ e not EObjects.
 - https://github.com/eclipse-sirius/sirius-components/issues/2032[#2032] [form] Add domainType on PageDescription in the view DSL and takes into account the impacts for the FormDescriptionAggregator.
 Change for `IPropertiesDescriptionRegistry` which now handles `PageDescription` directly instead of `FormDescription`.
 Add of the `selection` variable available in some context.
-- https://github.com/eclipse-sirius/sirius-components/issues/2072[#2072] [view] Fix an NPE when trying to instanciate List/Select/MultiSelect widgets with no candidates expression specified (which is the initial state on creation).
+- https://github.com/eclipse-sirius/sirius-components/issues/2072[#2072] [view] Fix an NPE when trying to instantiate List/Select/MultiSelect widgets with no candidates expression specified (which is the initial state on creation).
 An absent/empty candidates expression now simply means the widget is empty.
 - https://github.com/eclipse-sirius/sirius-components/issues/2067[#2064] [view] Enable completion support and other text field customizations for custom widgets
 - https://github.com/eclipse-sirius/sirius-components/issues/2092[#2092] [form] Fix support for help expressions on the _FlexboxContainer_ widget
@@ -52,7 +54,7 @@ image:doc/screenshots/ShowIconOptionSelectWidget.jpg[Icons on select widget opti
 - https://github.com/eclipse-sirius/sirius-components/issues/2055[#2055] [form] Added initial version of a custom widget to view & edit EMF references (both single and multi-valued).
 - https://github.com/eclipse-sirius/sirius-components/issues/2056[#2056] [form] Add the possibility to control read-only mode for widgets with an expression.
 - https://github.com/eclipse-sirius/sirius-components/issues/2077[#2077] [form] Add the ability to define a border style for groups and flexbox containers.
-- https://github.com/eclipse-sirius/sirius-components/issues/2080[#2080] [tree] Add an inital label value when editing tree items label.
+- https://github.com/eclipse-sirius/sirius-components/issues/2080[#2080] [tree] Add an initial label value when editing tree items label.
 
 === Improvements
 
@@ -540,7 +542,7 @@ This allows representation precondition expressions to be more precise as they k
 - https://github.com/eclipse-sirius/sirius-components/issues/1281[#1281] [form] The `LinkDescription` now requires a `displayProvider` and a `styleProvider`. The `displayProvider` is used to display the text of the hyperLink.
 The GraphQL API has also been changed with two additional fields on the type `Link`: `display` and `style` (optional). The front-end use the `display` value instead of the `label` value to display the hyperlink text.
 The `label` value is displayed before the widget to be consistent with other properties sections.
-- https://github.com/eclipse-sirius/sirius-components/issues/1320[#1320] [diagram] The `selectedNode` variable is now always _defined_ in the context of drop hanlders and single-click tools. Previously, if the target of the drop or single-click tool was the diagram itself (instead of a node), the variable was not defined at all. Now it is defined but `null` in these cases.
+- https://github.com/eclipse-sirius/sirius-components/issues/1320[#1320] [diagram] The `selectedNode` variable is now always _defined_ in the context of drop handlers and single-click tools. Previously, if the target of the drop or single-click tool was the diagram itself (instead of a node), the variable was not defined at all. Now it is defined but `null` in these cases.
 - https://github.com/eclipse-sirius/sirius-components/issues/1289[#1289] [core] The `representationDescriptions` GraphQL query now returns a new attribute named `defaultName` in addition to the `label` and `id`. For view-based representations and , the `defaultName` is computed from the `RepresentationDescription`'s `titleExpression`.
 
 === Dependency update
@@ -836,7 +838,7 @@ When closed, clicking on any of the views' icon will re-open the panel to make t
 - [frontend] Switch to typescript 4.5.4
 - [frontend] Switch to @typescript-eslint/parser 5.7.0
 - [frontend] Switch to xstate 4.26.1
-- [frontend] Update various development dependencies such as Rollup, ESLint, Pretier and Jest
+- [frontend] Update various development dependencies such as Rollup, ESLint, Prettier and Jest
 
 === New features
 
@@ -975,7 +977,7 @@ In addition to members of the Sirius core team, this release includes contributi
 === Breaking changes
 
 - https://github.com/eclipse-sirius/sirius-components/issues/673[#673] [graphql] Rename namespace to domain in the GraphQL API
-- [core] Remove the need to give a looger to the `BaseRender`
+- [core] Remove the need to give a logger to the `BaseRender`
 - [properties] Remove useless fields from the properties payloads
 - [graphql] Use pagination for the fields used by the onboarding such as `EditingContext#stereotypeDescriptions` or `EditingContext#representations`
 - https://github.com/eclipse-sirius/sirius-components/issues/563[#563] [core] Update the support for custom images by referencing images by their identifiers instead of their file name

--- a/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/ResourceMetadataAdapter.java
+++ b/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/ResourceMetadataAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.web.services.documents;
+package org.eclipse.sirius.components.emf;
 
 import java.util.Objects;
 
@@ -19,23 +19,23 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.Notifier;
 
 /**
- * An EMF adapter used to store some metadata related to the documents.
+ * An EMF adapter used to store some metadata related to EMF Resources.
  *
  * <p>
  * This adapter is currently used to store the following metadata:
  * </p>
  * <ul>
- * <li>name: The name of the document which can be modified</li>
+ * <li>name: The user-friendly name of the resource if presented in the UI</li>
  * </ul>
  *
  * @author sbegaudeau
  */
-public class DocumentMetadataAdapter implements Adapter {
+public class ResourceMetadataAdapter implements Adapter {
     private String name;
 
     private Notifier notifier;
 
-    public DocumentMetadataAdapter(String name) {
+    public ResourceMetadataAdapter(String name) {
         this.name = Objects.requireNonNull(name);
     }
 

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/FlowProjectTemplatesInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/FlowProjectTemplatesInitializer.java
@@ -36,6 +36,7 @@ import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
@@ -44,7 +45,6 @@ import org.eclipse.sirius.web.persistence.repositories.IDocumentRepository;
 import org.eclipse.sirius.web.persistence.repositories.IProjectRepository;
 import org.eclipse.sirius.web.services.api.id.IDParser;
 import org.eclipse.sirius.web.services.api.projects.IProjectTemplateInitializer;
-import org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -141,7 +141,7 @@ public class FlowProjectTemplatesInitializer implements IProjectTemplateInitiali
                     this.logger.warn(exception.getMessage(), exception);
                 }
 
-                resource.eAdapters().add(new DocumentMetadataAdapter(DOCUMENT_TITLE));
+                resource.eAdapters().add(new ResourceMetadataAdapter(DOCUMENT_TITLE));
 
                 resourceSet.getResources().add(resource);
             }

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StudioProjectTemplatesInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StudioProjectTemplatesInitializer.java
@@ -35,6 +35,7 @@ import org.eclipse.sirius.components.domain.Domain;
 import org.eclipse.sirius.components.domain.DomainFactory;
 import org.eclipse.sirius.components.domain.Entity;
 import org.eclipse.sirius.components.domain.Relation;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
 import org.eclipse.sirius.components.view.ChangeContext;
@@ -60,7 +61,6 @@ import org.eclipse.sirius.web.persistence.repositories.IDocumentRepository;
 import org.eclipse.sirius.web.persistence.repositories.IProjectRepository;
 import org.eclipse.sirius.web.services.api.id.IDParser;
 import org.eclipse.sirius.web.services.api.projects.IProjectTemplateInitializer;
-import org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -166,7 +166,7 @@ public class StudioProjectTemplatesInitializer implements IProjectTemplateInitia
                     this.logger.warn(exception.getMessage(), exception);
                 }
 
-                resource.eAdapters().add(new DocumentMetadataAdapter(DOMAIN_DOCUMENT_NAME));
+                resource.eAdapters().add(new ResourceMetadataAdapter(DOMAIN_DOCUMENT_NAME));
 
                 resourceSet.getResources().add(resource);
             }
@@ -184,7 +184,7 @@ public class StudioProjectTemplatesInitializer implements IProjectTemplateInitia
             if (optionalViewDocumentEntity.isPresent()) {
                 DocumentEntity documentEntity = optionalViewDocumentEntity.get();
                 JsonResource resource = new JSONResourceFactory().createResourceFromPath(documentEntity.getId().toString());
-                resource.eAdapters().add(new DocumentMetadataAdapter(VIEW_DOCUMENT_NAME));
+                resource.eAdapters().add(new ResourceMetadataAdapter(VIEW_DOCUMENT_NAME));
                 try (var inputStream = new ByteArrayInputStream(documentEntity.getContent().getBytes())) {
                     resource.load(inputStream, null);
                 } catch (IOException exception) {

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/papaya/PapayaStudioTemplatesInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/papaya/PapayaStudioTemplatesInitializer.java
@@ -28,6 +28,7 @@ import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
@@ -39,7 +40,6 @@ import org.eclipse.sirius.web.sample.papaya.domain.PapayaDomainProvider;
 import org.eclipse.sirius.web.sample.papaya.view.PapayaViewProvider;
 import org.eclipse.sirius.web.services.api.id.IDParser;
 import org.eclipse.sirius.web.services.api.projects.IProjectTemplateInitializer;
-import org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -139,7 +139,7 @@ public class PapayaStudioTemplatesInitializer implements IProjectTemplateInitial
                     this.logger.warn(exception.getMessage(), exception);
                 }
 
-                resource.eAdapters().add(new DocumentMetadataAdapter(DOMAIN_DOCUMENT_NAME));
+                resource.eAdapters().add(new ResourceMetadataAdapter(DOMAIN_DOCUMENT_NAME));
 
                 resourceSet.getResources().add(resource);
             }
@@ -156,7 +156,7 @@ public class PapayaStudioTemplatesInitializer implements IProjectTemplateInitial
             if (optionalViewDocumentEntity.isPresent()) {
                 DocumentEntity documentEntity = optionalViewDocumentEntity.get();
                 JsonResource resource = new JSONResourceFactory().createResourceFromPath(documentEntity.getId().toString());
-                resource.eAdapters().add(new DocumentMetadataAdapter(VIEW_DOCUMENT_NAME));
+                resource.eAdapters().add(new ResourceMetadataAdapter(VIEW_DOCUMENT_NAME));
                 try (var inputStream = new ByteArrayInputStream(documentEntity.getContent().getBytes())) {
                     resource.load(inputStream, null);
                 } catch (IOException exception) {

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/services/EditingContextActionHandler.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/services/EditingContextActionHandler.java
@@ -43,6 +43,7 @@ import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.collaborative.api.IEditingContextActionHandler;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.domain.DomainFactory;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
 import org.eclipse.sirius.components.emf.utils.EMFResourceUtils;
@@ -56,7 +57,6 @@ import org.eclipse.sirius.components.view.diagram.DiagramFactory;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
 import org.eclipse.sirius.web.sample.papaya.domain.PapayaDomainProvider;
 import org.eclipse.sirius.web.sample.papaya.view.PapayaViewProvider;
-import org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
@@ -116,28 +116,28 @@ public class EditingContextActionHandler implements IEditingContextActionHandler
 
     private void createEmptyResource(ResourceSet resourceSet) {
         JsonResource resource = new JSONResourceFactory().createResourceFromPath(UUID.randomUUID().toString());
-        resource.eAdapters().add(new DocumentMetadataAdapter("Others..."));
+        resource.eAdapters().add(new ResourceMetadataAdapter("Others..."));
         resourceSet.getResources().add(resource);
     }
 
     private void createEmptyFlowResource(ResourceSet resourceSet) {
         JsonResource resource = new JSONResourceFactory().createResourceFromPath(UUID.randomUUID().toString());
         resource.getContents().add(FlowFactory.eINSTANCE.createSystem());
-        resource.eAdapters().add(new DocumentMetadataAdapter("Flow"));
+        resource.eAdapters().add(new ResourceMetadataAdapter("Flow"));
         resourceSet.getResources().add(resource);
     }
 
     private void createEmptyDomainResource(ResourceSet resourceSet) {
         JsonResource resource = new JSONResourceFactory().createResourceFromPath(UUID.randomUUID().toString());
         resource.getContents().add(DomainFactory.eINSTANCE.createDomain());
-        resource.eAdapters().add(new DocumentMetadataAdapter("Domain"));
+        resource.eAdapters().add(new ResourceMetadataAdapter("Domain"));
         resourceSet.getResources().add(resource);
     }
 
     private void createPapayaDomainResource(ResourceSet resourceSet) {
         JsonResource resource = new JSONResourceFactory().createResourceFromPath(UUID.randomUUID().toString());
         new PapayaDomainProvider().getDomains().forEach(resource.getContents()::add);
-        resource.eAdapters().add(new DocumentMetadataAdapter("Papaya Domain"));
+        resource.eAdapters().add(new ResourceMetadataAdapter("Papaya Domain"));
         resourceSet.getResources().add(resource);
     }
 
@@ -148,7 +148,7 @@ public class EditingContextActionHandler implements IEditingContextActionHandler
         newView.getDescriptions().add(diagramDescription);
         JsonResource resource = new JSONResourceFactory().createResourceFromPath(UUID.randomUUID().toString());
         resource.getContents().add(newView);
-        resource.eAdapters().add(new DocumentMetadataAdapter("View"));
+        resource.eAdapters().add(new ResourceMetadataAdapter("View"));
         resourceSet.getResources().add(resource);
     }
 
@@ -156,21 +156,21 @@ public class EditingContextActionHandler implements IEditingContextActionHandler
 
         JsonResource resource = new JSONResourceFactory().createResourceFromPath(UUID.randomUUID().toString());
         resource.getContents().add(new PapayaViewProvider().getView());
-        resource.eAdapters().add(new DocumentMetadataAdapter("Papaya View"));
+        resource.eAdapters().add(new ResourceMetadataAdapter("Papaya View"));
         resourceSet.getResources().add(resource);
     }
 
 
     private void createRobotFlowResource(ResourceSet resourceSet) {
         this.getResourceFromClassPathResource(new ClassPathResource("robot.flow")).ifPresent(resource -> {
-            resource.eAdapters().add(new DocumentMetadataAdapter("Robot Flow"));
+            resource.eAdapters().add(new ResourceMetadataAdapter("Robot Flow"));
             resourceSet.getResources().add(resource);
         });
     }
 
     private void createBigGuyFlowResource(ResourceSet resourceSet) {
         this.getResourceFromClassPathResource(new ClassPathResource("Big_Guy.flow")).ifPresent(resource -> {
-            resource.eAdapters().add(new DocumentMetadataAdapter("Big Guy Flow (17k elements)"));
+            resource.eAdapters().add(new ResourceMetadataAdapter("Big Guy Flow (17k elements)"));
             resourceSet.getResources().add(resource);
         });
     }

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/documents/CreateDocumentEventHandler.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/documents/CreateDocumentEventHandler.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.core.configuration.StereotypeDescription;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
@@ -142,7 +143,7 @@ public class CreateDocumentEventHandler implements IEditingContextEventHandler {
                     this.logger.warn(exception.getMessage(), exception);
                 }
 
-                resource.eAdapters().add(new DocumentMetadataAdapter(name));
+                resource.eAdapters().add(new ResourceMetadataAdapter(name));
 
                 resourceSet.getResources().add(resource);
 

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/documents/RenameDocumentEventHandler.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/documents/RenameDocumentEventHandler.java
@@ -28,6 +28,7 @@ import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.core.api.SuccessPayload;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.web.services.api.document.Document;
 import org.eclipse.sirius.web.services.api.document.IDocumentService;
@@ -101,8 +102,8 @@ public class RenameDocumentEventHandler implements IEditingContextEventHandler {
                         .findFirst()
                         .ifPresent(resource -> {
                             resource.eAdapters().stream()
-                                .filter(DocumentMetadataAdapter.class::isInstance)
-                                .map(DocumentMetadataAdapter.class::cast)
+                                .filter(ResourceMetadataAdapter.class::isInstance)
+                                .map(ResourceMetadataAdapter.class::cast)
                                 .findFirst()
                                 .ifPresent(adapter -> adapter.setName(newName));
                         });

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/documents/UploadDocumentEventHandler.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/documents/UploadDocumentEventHandler.java
@@ -44,6 +44,7 @@ import org.eclipse.sirius.components.core.api.ErrorPayload;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
 import org.eclipse.sirius.components.emf.utils.EMFResourceUtils;
@@ -141,7 +142,7 @@ public class UploadDocumentEventHandler implements IEditingContextEventHandler {
                             this.logger.warn(exception.getMessage(), exception);
                         }
 
-                        resource.eAdapters().add(new DocumentMetadataAdapter(name));
+                        resource.eAdapters().add(new ResourceMetadataAdapter(name));
                         resourceSet.getResources().add(resource);
 
                         payload = new UploadDocumentSuccessPayload(input.id(), document);

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/editingcontext/EditingContextPersistenceService.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/editingcontext/EditingContextPersistenceService.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IEditingContextPersistenceService;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EObjectIDManager;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
@@ -35,7 +36,6 @@ import org.eclipse.sirius.web.services.api.document.Document;
 import org.eclipse.sirius.web.services.api.events.DocumentsModifiedEvent;
 import org.eclipse.sirius.web.services.api.id.IDParser;
 import org.eclipse.sirius.web.services.documents.DocumentMapper;
-import org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
@@ -151,9 +151,9 @@ public class EditingContextPersistenceService implements IEditingContextPersiste
                              .flatMap(this.projectRepository::findById)
                              .map(projectEntity -> {
                                  var name = resource.eAdapters().stream()
-                                         .filter(DocumentMetadataAdapter.class::isInstance)
-                                         .map(DocumentMetadataAdapter.class::cast)
-                                         .findFirst().map(DocumentMetadataAdapter::getName)
+                                         .filter(ResourceMetadataAdapter.class::isInstance)
+                                         .map(ResourceMetadataAdapter.class::cast)
+                                         .findFirst().map(ResourceMetadataAdapter::getName)
                                          .orElse("");
 
                                  DocumentEntity documentEntity = new DocumentEntity();

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchService.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchService.java
@@ -28,6 +28,7 @@ import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IEditingContextSearchService;
 import org.eclipse.sirius.components.core.configuration.IRepresentationDescriptionRegistryConfigurer;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.EditingContextCrossReferenceAdapter;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
@@ -37,7 +38,6 @@ import org.eclipse.sirius.web.persistence.entities.DocumentEntity;
 import org.eclipse.sirius.web.persistence.repositories.IDocumentRepository;
 import org.eclipse.sirius.web.persistence.repositories.IProjectRepository;
 import org.eclipse.sirius.web.services.api.id.IDParser;
-import org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter;
 import org.eclipse.sirius.web.services.editingcontext.api.IDynamicRepresentationDescriptionService;
 import org.eclipse.sirius.web.services.editingcontext.api.IEditingDomainFactoryService;
 import org.eclipse.sirius.web.services.representations.RepresentationDescriptionRegistry;
@@ -107,7 +107,7 @@ public class EditingContextSearchService implements IEditingContextSearchService
                 resourceSet.getResources().add(resource);
                 resource.load(inputStream, null);
 
-                resource.eAdapters().add(new DocumentMetadataAdapter(documentEntity.getName()));
+                resource.eAdapters().add(new ResourceMetadataAdapter(documentEntity.getName()));
             } catch (IOException | IllegalArgumentException exception) {
                 this.logger.warn("An error occured while loading document {}: {}.", documentEntity.getId(), exception.getMessage());
                 resourceSet.getResources().remove(resource);

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/explorer/ExplorerDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/explorer/ExplorerDescriptionProvider.java
@@ -32,6 +32,7 @@ import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IURLParser;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.core.api.SemanticKindConstants;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.representations.Failure;
 import org.eclipse.sirius.components.representations.GetOrCreateRandomIdProvider;
@@ -41,7 +42,6 @@ import org.eclipse.sirius.components.trees.TreeItem;
 import org.eclipse.sirius.components.trees.description.TreeDescription;
 import org.eclipse.sirius.components.trees.renderer.TreeRenderer;
 import org.eclipse.sirius.web.services.api.representations.IRepresentationService;
-import org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter;
 import org.eclipse.sirius.web.services.explorer.api.IDeleteTreeItemHandler;
 import org.eclipse.sirius.web.services.explorer.api.IRenameTreeItemHandler;
 import org.springframework.stereotype.Service;
@@ -159,10 +159,10 @@ public class ExplorerDescriptionProvider implements IExplorerDescriptionProvider
     private String getResourceLabel(Resource resource) {
         // @formatter:off
         return resource.eAdapters().stream()
-                .filter(DocumentMetadataAdapter.class::isInstance)
-                .map(DocumentMetadataAdapter.class::cast)
+                .filter(ResourceMetadataAdapter.class::isInstance)
+                .map(ResourceMetadataAdapter.class::cast)
                 .findFirst()
-                .map(DocumentMetadataAdapter::getName)
+                .map(ResourceMetadataAdapter::getName)
                 .orElse(resource.getURI().lastSegment());
         // @formatter:on
     }

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/explorer/RenameDocumentTreeItemHandler.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/explorer/RenameDocumentTreeItemHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Obeo.
+ * Copyright (c) 2021, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.representations.Failure;
 import org.eclipse.sirius.components.representations.IStatus;
@@ -28,7 +29,6 @@ import org.eclipse.sirius.components.trees.TreeItem;
 import org.eclipse.sirius.web.persistence.entities.DocumentEntity;
 import org.eclipse.sirius.web.persistence.repositories.IDocumentRepository;
 import org.eclipse.sirius.web.services.api.id.IDParser;
-import org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter;
 import org.eclipse.sirius.web.services.explorer.api.IRenameTreeItemHandler;
 import org.springframework.stereotype.Service;
 
@@ -75,8 +75,8 @@ public class RenameDocumentTreeItemHandler implements IRenameTreeItemHandler {
                     .findFirst()
                     .ifPresent(resource -> {
                         resource.eAdapters().stream()
-                            .filter(DocumentMetadataAdapter.class::isInstance)
-                            .map(DocumentMetadataAdapter.class::cast)
+                            .filter(ResourceMetadataAdapter.class::isInstance)
+                            .map(ResourceMetadataAdapter.class::cast)
                             .findFirst()
                             .ifPresent(adapter -> adapter.setName(documentEntity.getName()));
                     });

--- a/packages/sirius-web/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/documents/CreateDocumentEventHandlerTests.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/documents/CreateDocumentEventHandlerTests.java
@@ -24,6 +24,7 @@ import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.core.configuration.StereotypeDescription;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.web.services.api.document.CreateDocumentInput;
 import org.eclipse.sirius.web.services.api.document.CreateDocumentSuccessPayload;
@@ -116,7 +117,7 @@ public class CreateDocumentEventHandlerTests {
         assertThat(payload).isInstanceOf(CreateDocumentSuccessPayload.class);
 
         assertThat(editingDomain.getResourceSet().getResources().size()).isEqualTo(1);
-        Condition<Object> condition = new Condition<>(adapter -> adapter instanceof DocumentMetadataAdapter, "has an DocumentMetadataAdapter");
+        Condition<Object> condition = new Condition<>(adapter -> adapter instanceof ResourceMetadataAdapter, "has an DocumentMetadataAdapter");
         assertThat(editingDomain.getResourceSet().getResources().get(0).eAdapters()).areAtLeastOne(condition);
     }
 

--- a/packages/sirius-web/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/documents/RenameDocumentEventHandlerTests.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/documents/RenameDocumentEventHandlerTests.java
@@ -27,6 +27,7 @@ import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.core.api.SuccessPayload;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
 import org.eclipse.sirius.web.services.api.document.Document;
@@ -65,7 +66,7 @@ public class RenameDocumentEventHandlerTests {
 
         AdapterFactoryEditingDomain editingDomain = new EditingDomainFactory().create();
 
-        DocumentMetadataAdapter adapter = new DocumentMetadataAdapter(OLD_NAME);
+        ResourceMetadataAdapter adapter = new ResourceMetadataAdapter(OLD_NAME);
         Resource resource = new JSONResourceFactory().createResourceFromPath(documentId.toString());
         resource.eAdapters().add(adapter);
         editingDomain.getResourceSet().getResources().add(resource);

--- a/packages/sirius-web/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/editingcontext/EditingContextPersistenceServiceTests.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/editingcontext/EditingContextPersistenceServiceTests.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IEditingContextPersistenceService;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
@@ -32,7 +33,6 @@ import org.eclipse.sirius.web.persistence.entities.DocumentEntity;
 import org.eclipse.sirius.web.persistence.entities.ProjectEntity;
 import org.eclipse.sirius.web.persistence.repositories.IDocumentRepository;
 import org.eclipse.sirius.web.persistence.repositories.IProjectRepository;
-import org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter;
 import org.eclipse.sirius.web.services.documents.EditingDomainFactory;
 import org.junit.jupiter.api.Test;
 
@@ -144,7 +144,7 @@ public class EditingContextPersistenceServiceTests {
 
     private DocumentEntity createFakeDocument(String documentName, UUID documentId, ProjectEntity projectEntity, AdapterFactoryEditingDomain editingDomain) {
         JsonResource resource = new JSONResourceFactory().createResourceFromPath(documentId.toString());
-        resource.eAdapters().add(new DocumentMetadataAdapter(documentName));
+        resource.eAdapters().add(new ResourceMetadataAdapter(documentName));
 
         EClass eClass = EcoreFactory.eINSTANCE.createEClass();
         eClass.setName("Concept");

--- a/packages/sirius-web/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchServiceTests.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchServiceTests.java
@@ -27,6 +27,7 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IEditingContextSearchService;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.emf.services.IEditingContextEPackageService;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
@@ -34,7 +35,6 @@ import org.eclipse.sirius.web.persistence.entities.DocumentEntity;
 import org.eclipse.sirius.web.persistence.entities.ProjectEntity;
 import org.eclipse.sirius.web.persistence.repositories.IDocumentRepository;
 import org.eclipse.sirius.web.persistence.repositories.IProjectRepository;
-import org.eclipse.sirius.web.services.documents.DocumentMetadataAdapter;
 import org.eclipse.sirius.web.services.editingcontext.api.IDynamicRepresentationDescriptionService;
 import org.eclipse.sirius.web.services.editingcontext.api.IEditingDomainFactoryService;
 import org.eclipse.sirius.web.services.projects.api.EditingContextMetadata;
@@ -167,8 +167,8 @@ public class EditingContextSearchServiceTests {
         assertThat(resource.eAdapters()).hasSize(2);
         // @formatter:off
         var optionalDocumentMetadataAdapter = resource.eAdapters().stream()
-                .filter(DocumentMetadataAdapter.class::isInstance)
-                .map(DocumentMetadataAdapter.class::cast)
+                .filter(ResourceMetadataAdapter.class::isInstance)
+                .map(ResourceMetadataAdapter.class::cast)
                 .findFirst();
         // @formatter:on
         assertThat(optionalDocumentMetadataAdapter).isPresent();


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/2124
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [x] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?