### PR TITLE
[2123] Add support for non-selectable tree items

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -117,6 +117,7 @@ The existing context menu contributions now only apply to the _Explorer_ view.
 - https://github.com/eclipse-sirius/sirius-components/issues/2091[#2091] [diagram] Add support for the direct edit in the diagram with nodes.
 - https://github.com/eclipse-sirius/sirius-components/issues/2142[#2142] [diagram] Add support for Edge labels (begin, center, end) in sirius-components-diagrams-reactflow.
 - https://github.com/eclipse-sirius/sirius-components/issues/2097[#2097] [forms] Add click handler support on the reference value of a reference widget.
+- https://github.com/eclipse-sirius/sirius-components/issues/2123[#2123] [tree] Add support for non-selectable tree items
 
 == v2023.6.0
 

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/explorer/ExplorerDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/explorer/ExplorerDescriptionProvider.java
@@ -29,8 +29,8 @@ import org.eclipse.sirius.components.collaborative.trees.api.IExplorerDescriptio
 import org.eclipse.sirius.components.compatibility.services.ImageConstants;
 import org.eclipse.sirius.components.core.RepresentationMetadata;
 import org.eclipse.sirius.components.core.api.IEditingContext;
-import org.eclipse.sirius.components.core.api.IURLParser;
 import org.eclipse.sirius.components.core.api.IObjectService;
+import org.eclipse.sirius.components.core.api.IURLParser;
 import org.eclipse.sirius.components.core.api.SemanticKindConstants;
 import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
@@ -96,6 +96,7 @@ public class ExplorerDescriptionProvider implements IExplorerDescriptionProvider
                 .imageURLProvider(this::getImageURL)
                 .editableProvider(this::isEditable)
                 .deletableProvider(this::isDeletable)
+                .selectableProvider(this::isSelectable)
                 .elementsProvider(this::getElements)
                 .hasChildrenProvider(this::hasChildren)
                 .childrenProvider(this::getChildren)
@@ -183,6 +184,10 @@ public class ExplorerDescriptionProvider implements IExplorerDescriptionProvider
     }
 
     private boolean isDeletable(VariableManager variableManager) {
+        return true;
+    }
+
+    private boolean isSelectable(VariableManager variableManager) {
         return true;
     }
 

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/main/resources/schema/tree.graphqls
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/main/resources/schema/tree.graphqls
@@ -39,6 +39,7 @@ type TreeItem {
   imageURL: String!
   editable: Boolean!
   deletable: Boolean!
+  selectable: Boolean!
   expanded: Boolean!
   hasChildren: Boolean!
   children: [TreeItem]!

--- a/packages/trees/backend/sirius-components-trees/src/main/java/org/eclipse/sirius/components/trees/TreeItem.java
+++ b/packages/trees/backend/sirius-components-trees/src/main/java/org/eclipse/sirius/components/trees/TreeItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,8 @@ public final class TreeItem {
 
     private boolean deletable;
 
+    private boolean selectable;
+
     private boolean hasChildren;
 
     private boolean expanded;
@@ -68,6 +70,10 @@ public final class TreeItem {
 
     public boolean isDeletable() {
         return this.deletable;
+    }
+
+    public boolean isSelectable() {
+        return this.selectable;
     }
 
     public String getImageURL() {
@@ -116,6 +122,8 @@ public final class TreeItem {
 
         private boolean deletable;
 
+        private boolean selectable;
+
         private boolean hasChildren;
 
         private boolean expanded;
@@ -142,12 +150,17 @@ public final class TreeItem {
         }
 
         public Builder editable(boolean editable) {
-            this.editable = Objects.requireNonNull(editable);
+            this.editable = editable;
             return this;
         }
 
         public Builder deletable(boolean deletable) {
-            this.deletable = Objects.requireNonNull(deletable);
+            this.deletable = deletable;
+            return this;
+        }
+
+        public Builder selectable(boolean selectable) {
+            this.selectable = selectable;
             return this;
         }
 
@@ -172,10 +185,11 @@ public final class TreeItem {
             treeItem.kind = Objects.requireNonNull(this.kind);
             treeItem.label = Objects.requireNonNull(this.label);
             treeItem.imageURL = Objects.requireNonNull(this.imageURL);
-            treeItem.editable = Objects.requireNonNull(this.editable);
-            treeItem.deletable = Objects.requireNonNull(this.deletable);
-            treeItem.expanded = Objects.requireNonNull(this.expanded);
-            treeItem.hasChildren = Objects.requireNonNull(this.hasChildren);
+            treeItem.editable = this.editable;
+            treeItem.deletable = this.deletable;
+            treeItem.selectable = this.selectable;
+            treeItem.expanded = this.expanded;
+            treeItem.hasChildren = this.hasChildren;
             treeItem.children = Objects.requireNonNull(this.children);
             return treeItem;
         }

--- a/packages/trees/backend/sirius-components-trees/src/main/java/org/eclipse/sirius/components/trees/description/TreeDescription.java
+++ b/packages/trees/backend/sirius-components-trees/src/main/java/org/eclipse/sirius/components/trees/description/TreeDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -48,6 +48,8 @@ public final class TreeDescription implements IRepresentationDescription {
     private Function<VariableManager, Boolean> editableProvider;
 
     private Function<VariableManager, Boolean> deletableProvider;
+
+    private Function<VariableManager, Boolean> selectableProvider;
 
     private Function<VariableManager, List<?>> elementsProvider;
 
@@ -102,6 +104,11 @@ public final class TreeDescription implements IRepresentationDescription {
     public Function<VariableManager, Boolean> getDeletableProvider() {
         return this.deletableProvider;
     }
+
+    public Function<VariableManager, Boolean> getSelectableProvider() {
+        return this.selectableProvider;
+    }
+
 
     public Function<VariableManager, List<?>> getElementsProvider() {
         return this.elementsProvider;
@@ -163,6 +170,8 @@ public final class TreeDescription implements IRepresentationDescription {
 
         private Function<VariableManager, Boolean> deletableProvider;
 
+        private Function<VariableManager, Boolean> selectableProvider = (variableManager) -> true;
+
         private Function<VariableManager, List<?>> elementsProvider;
 
         private Function<VariableManager, List<?>> childrenProvider;
@@ -219,6 +228,11 @@ public final class TreeDescription implements IRepresentationDescription {
             return this;
         }
 
+        public Builder selectableProvider(Function<VariableManager, Boolean> selectableProvider) {
+            this.selectableProvider = Objects.requireNonNull(selectableProvider);
+            return this;
+        }
+
         public Builder elementsProvider(Function<VariableManager, List<?>> elementsProvider) {
             this.elementsProvider = Objects.requireNonNull(elementsProvider);
             return this;
@@ -260,6 +274,7 @@ public final class TreeDescription implements IRepresentationDescription {
             treeDescription.imageURLProvider = Objects.requireNonNull(this.imageURLProvider);
             treeDescription.editableProvider = Objects.requireNonNull(this.editableProvider);
             treeDescription.deletableProvider = Objects.requireNonNull(this.deletableProvider);
+            treeDescription.selectableProvider = Objects.requireNonNull(this.selectableProvider);
             treeDescription.elementsProvider = Objects.requireNonNull(this.elementsProvider);
             treeDescription.childrenProvider = Objects.requireNonNull(this.childrenProvider);
             treeDescription.hasChildrenProvider = Objects.requireNonNull(this.hasChildrenProvider);

--- a/packages/trees/backend/sirius-components-trees/src/main/java/org/eclipse/sirius/components/trees/renderer/TreeRenderer.java
+++ b/packages/trees/backend/sirius-components-trees/src/main/java/org/eclipse/sirius/components/trees/renderer/TreeRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -66,6 +66,7 @@ public class TreeRenderer {
         String label = this.treeDescription.getLabelProvider().apply(treeItemVariableManager);
         boolean editable = this.treeDescription.getEditableProvider().apply(treeItemVariableManager);
         boolean deletable = this.treeDescription.getDeletableProvider().apply(treeItemVariableManager);
+        boolean selectable = this.treeDescription.getSelectableProvider().apply(treeItemVariableManager);
         String imageURL = this.treeDescription.getImageURLProvider().apply(treeItemVariableManager);
         Boolean hasChildren = this.treeDescription.getHasChildrenProvider().apply(treeItemVariableManager);
 
@@ -85,6 +86,7 @@ public class TreeRenderer {
                 .label(label)
                 .editable(editable)
                 .deletable(deletable)
+                .selectable(selectable)
                 .imageURL(imageURL)
                 .children(childrenTreeItems)
                 .hasChildren(hasChildren)

--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItem.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItem.tsx
@@ -48,6 +48,10 @@ const useTreeItemStyle = makeStyles((theme) => ({
       backgroundColor: 'var(--blue-lagoon-lighten-90)',
     },
   },
+  nonSelectable: {
+    fontStyle: 'italic',
+    opacity: 0.6,
+  },
   arrow: {
     cursor: 'pointer',
   },
@@ -297,6 +301,9 @@ export const TreeItem = ({
   const onClick: React.MouseEventHandler<HTMLDivElement> = (event) => {
     if (!state.editingMode) {
       refDom.current.focus();
+      if (!item.selectable) {
+        return;
+      }
 
       if (event.ctrlKey || event.metaKey) {
         event.stopPropagation();
@@ -392,7 +399,7 @@ export const TreeItem = ({
             data-depth={depth}
             data-expanded={item.expanded.toString()}
             data-testid={dataTestid}>
-            <div className={classes.content}>
+            <div className={`${classes.content} ${item.selectable ? '' : classes.nonSelectable}`}>
               <div
                 className={classes.imageAndLabel}
                 onDoubleClick={() => item.hasChildren && onExpand(item.id, depth)}

--- a/packages/trees/frontend/sirius-components-trees/src/views/ExplorerView.types.ts
+++ b/packages/trees/frontend/sirius-components-trees/src/views/ExplorerView.types.ts
@@ -50,6 +50,7 @@ export interface GQLTreeItem {
   expanded: boolean;
   editable: boolean;
   deletable: boolean;
+  selectable: boolean;
 }
 
 export interface GQLGetTreePathVariables {

--- a/packages/trees/frontend/sirius-components-trees/src/views/__tests__/GraphqlTreeEventSubscription.test.ts
+++ b/packages/trees/frontend/sirius-components-trees/src/views/__tests__/GraphqlTreeEventSubscription.test.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,7 @@ const getDocumentSubscription = gql`
     label
     editable
     deletable
+    selectable
     kind
     imageURL
   }

--- a/packages/trees/frontend/sirius-components-trees/src/views/getTreeEventSubscription.ts
+++ b/packages/trees/frontend/sirius-components-trees/src/views/getTreeEventSubscription.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,7 @@ fragment treeItemFields on TreeItem {
   label
   editable
   deletable
+  selectable
   kind
   imageURL
 }


### PR DESCRIPTION
Draft for now as there are no tests and I'm not sure about how to style the non-selectable items on the front. For now they are simply `font-style: italic`:

![screenshot-2023-06-29_16-08](https://github.com/eclipse-sirius/sirius-components/assets/10608/d534ce40-686d-4e6a-be8a-9a04489fee30)
