### PR TITLE
[2133] Fix NPE in Related Elements view

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,7 @@ An absent/empty candidates expression now simply means the widget is empty.
 - https://github.com/eclipse-sirius/sirius-components/issues/2067[#2064] [view] Enable completion support and other text field customizations for custom widgets
 - https://github.com/eclipse-sirius/sirius-components/issues/2092[#2092] [form] Fix support for help expressions on the _FlexboxContainer_ widget
 - https://github.com/eclipse-sirius/sirius-components/issues/2088[#2088] [tree] Fix initial value of the tree filter bar
+- https://github.com/eclipse-sirius/sirius-components/issues/2133[#2133] [workbench] Fix NPE in Related Elements view
 
 === New Features
 

--- a/integration-tests/cypress/e2e/project/edit/related-elements-view.cy.js
+++ b/integration-tests/cypress/e2e/project/edit/related-elements-view.cy.js
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the erms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * This test suite will be used to validate the proper lifecycle of our application.
+ *
+ * For that, we will open and close in various ways several representations and we will evaluate if we have
+ * the proper number of representations and if they behave properly.
+ */
+describe('/projects/:projectId/edit - Related ELements View', () => {
+  beforeEach(() => {
+    cy.deleteAllProjects();
+    cy.createProject('Cypress Project').then((res) => {
+      const projectId = res.body.data.createProject.project.id;
+      cy.wrap(projectId).as('projectId');
+      const robot_flow_id = 'c26b6086-b444-3ee6-b8cd-9a4fde5956a7';
+
+      cy.createDocument(projectId, robot_flow_id, 'robot').then(() => {
+        cy.visit(`/projects/${projectId}/edit`);
+      });
+    });
+  });
+
+  it('can open the related elements view', function () {
+    cy.getByTestId('robot').dblclick();
+    cy.getByTestId('Robot').dblclick();
+    cy.getByTestId('viewselector-Related Elements').click();
+    cy.getByTestId('view-Related Elements').within(() => {
+      cy.getByTestId('form').should('exist');
+    });
+  });
+});

--- a/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/relatedelements/DefaultRelatedElementsDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/relatedelements/DefaultRelatedElementsDescriptionProvider.java
@@ -62,9 +62,6 @@ public class DefaultRelatedElementsDescriptionProvider implements IRelatedElemen
 
         // @formatter:off
         Function<VariableManager, String> targetObjectIdProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class)
-                .filter(self -> self instanceof List<?>)
-                .map(self -> (List<?>) self)
-                .flatMap(self -> self.stream().findFirst())
                 .map(this.objectService::getId)
                 .orElse(null);
 


### PR DESCRIPTION
Since #2032, `self` is a single element, not a list.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/2133
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?