### PR TITLE
[cleanup] Update the View elements builders

### DIFF
--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ButtonDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ButtonDescriptionBuilder.java
@@ -114,7 +114,7 @@ public class ButtonDescriptionBuilder {
      *
      * @generated
      */
-    public ButtonDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalButtonDescriptionStyle... values) {
+    public ButtonDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalButtonDescriptionStyle ... values) {
         for (org.eclipse.sirius.components.view.form.ConditionalButtonDescriptionStyle value : values) {
             this.getButtonDescription().getConditionalStyles().add(value);
         }

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/CheckboxDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/CheckboxDescriptionBuilder.java
@@ -105,7 +105,7 @@ public class CheckboxDescriptionBuilder {
      *
      * @generated
      */
-    public CheckboxDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalCheckboxDescriptionStyle... values) {
+    public CheckboxDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalCheckboxDescriptionStyle ... values) {
         for (org.eclipse.sirius.components.view.form.ConditionalCheckboxDescriptionStyle value : values) {
             this.getCheckboxDescription().getConditionalStyles().add(value);
         }

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/CheckboxDescriptionStyleBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/CheckboxDescriptionStyleBuilder.java
@@ -52,5 +52,15 @@ public class CheckboxDescriptionStyleBuilder {
         return this;
     }
 
+    /**
+     * Setter for LabelPlacement.
+     *
+     * @generated
+     */
+    public CheckboxDescriptionStyleBuilder labelPlacement(org.eclipse.sirius.components.view.form.LabelPlacement value) {
+        this.getCheckboxDescriptionStyle().setLabelPlacement(value);
+        return this;
+    }
+
 }
 

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ConditionalCheckboxDescriptionStyleBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ConditionalCheckboxDescriptionStyleBuilder.java
@@ -61,5 +61,15 @@ public class ConditionalCheckboxDescriptionStyleBuilder {
         return this;
     }
 
+    /**
+     * Setter for LabelPlacement.
+     *
+     * @generated
+     */
+    public ConditionalCheckboxDescriptionStyleBuilder labelPlacement(org.eclipse.sirius.components.view.form.LabelPlacement value) {
+        this.getConditionalCheckboxDescriptionStyle().setLabelPlacement(value);
+        return this;
+    }
+
 }
 

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ConditionalContainerBorderStyleBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ConditionalContainerBorderStyleBuilder.java
@@ -25,7 +25,7 @@ public class ConditionalContainerBorderStyleBuilder {
      *
      * @generated
      */
-    private final org.eclipse.sirius.components.view.form.ConditionalContainerBorderStyle conditionalContainerBorderStyle = org.eclipse.sirius.components.view.form.FormFactory.eINSTANCE.createConditionalContainerBorderStyle();
+    private org.eclipse.sirius.components.view.form.ConditionalContainerBorderStyle conditionalContainerBorderStyle = org.eclipse.sirius.components.view.form.FormFactory.eINSTANCE.createConditionalContainerBorderStyle();
 
     /**
      * Return instance org.eclipse.sirius.components.view.form.ConditionalContainerBorderStyle.

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ContainerBorderStyleBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ContainerBorderStyleBuilder.java
@@ -25,7 +25,7 @@ public class ContainerBorderStyleBuilder {
      *
      * @generated
      */
-    private final org.eclipse.sirius.components.view.form.ContainerBorderStyle containerBorderStyle = org.eclipse.sirius.components.view.form.FormFactory.eINSTANCE.createContainerBorderStyle();
+    private org.eclipse.sirius.components.view.form.ContainerBorderStyle containerBorderStyle = org.eclipse.sirius.components.view.form.FormFactory.eINSTANCE.createContainerBorderStyle();
 
     /**
      * Return instance org.eclipse.sirius.components.view.form.ContainerBorderStyle.

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/FlexboxContainerDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/FlexboxContainerDescriptionBuilder.java
@@ -116,7 +116,7 @@ public class FlexboxContainerDescriptionBuilder {
      *
      * @generated
      */
-    public FlexboxContainerDescriptionBuilder conditionalBorderStyles(org.eclipse.sirius.components.view.form.ConditionalContainerBorderStyle... values) {
+    public FlexboxContainerDescriptionBuilder conditionalBorderStyles(org.eclipse.sirius.components.view.form.ConditionalContainerBorderStyle ... values) {
         for (org.eclipse.sirius.components.view.form.ConditionalContainerBorderStyle value : values) {
             this.getFlexboxContainerDescription().getConditionalBorderStyles().add(value);
         }

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/GroupDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/GroupDescriptionBuilder.java
@@ -95,7 +95,7 @@ public class GroupDescriptionBuilder {
      *
      * @generated
      */
-    public GroupDescriptionBuilder widgets(org.eclipse.sirius.components.view.form.WidgetDescription... values) {
+    public GroupDescriptionBuilder widgets(org.eclipse.sirius.components.view.form.WidgetDescription ... values) {
         for (org.eclipse.sirius.components.view.form.WidgetDescription value : values) {
             this.getGroupDescription().getWidgets().add(value);
         }
@@ -117,7 +117,7 @@ public class GroupDescriptionBuilder {
      *
      * @generated
      */
-    public GroupDescriptionBuilder conditionalBorderStyles(org.eclipse.sirius.components.view.form.ConditionalContainerBorderStyle... values) {
+    public GroupDescriptionBuilder conditionalBorderStyles(org.eclipse.sirius.components.view.form.ConditionalContainerBorderStyle ... values) {
         for (org.eclipse.sirius.components.view.form.ConditionalContainerBorderStyle value : values) {
             this.getGroupDescription().getConditionalBorderStyles().add(value);
         }

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ListDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ListDescriptionBuilder.java
@@ -123,7 +123,7 @@ public class ListDescriptionBuilder {
      *
      * @generated
      */
-    public ListDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalListDescriptionStyle... values) {
+    public ListDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalListDescriptionStyle ... values) {
         for (org.eclipse.sirius.components.view.form.ConditionalListDescriptionStyle value : values) {
             this.getListDescription().getConditionalStyles().add(value);
         }

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/MultiSelectDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/MultiSelectDescriptionBuilder.java
@@ -123,7 +123,7 @@ public class MultiSelectDescriptionBuilder {
      *
      * @generated
      */
-    public MultiSelectDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalMultiSelectDescriptionStyle... values) {
+    public MultiSelectDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalMultiSelectDescriptionStyle ... values) {
         for (org.eclipse.sirius.components.view.form.ConditionalMultiSelectDescriptionStyle value : values) {
             this.getMultiSelectDescription().getConditionalStyles().add(value);
         }

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/RadioDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/RadioDescriptionBuilder.java
@@ -123,7 +123,7 @@ public class RadioDescriptionBuilder {
      *
      * @generated
      */
-    public RadioDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalRadioDescriptionStyle... values) {
+    public RadioDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalRadioDescriptionStyle ... values) {
         for (org.eclipse.sirius.components.view.form.ConditionalRadioDescriptionStyle value : values) {
             this.getRadioDescription().getConditionalStyles().add(value);
         }

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/RichTextDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/RichTextDescriptionBuilder.java
@@ -84,7 +84,7 @@ public class RichTextDescriptionBuilder {
      *
      * @generated
      */
-    public RichTextDescriptionBuilder body(org.eclipse.sirius.components.view.Operation... values) {
+    public RichTextDescriptionBuilder body(org.eclipse.sirius.components.view.Operation ... values) {
         for (org.eclipse.sirius.components.view.Operation value : values) {
             this.getRichTextDescription().getBody().add(value);
         }

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/SelectDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/SelectDescriptionBuilder.java
@@ -123,7 +123,7 @@ public class SelectDescriptionBuilder {
      *
      * @generated
      */
-    public SelectDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalSelectDescriptionStyle... values) {
+    public SelectDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalSelectDescriptionStyle ... values) {
         for (org.eclipse.sirius.components.view.form.ConditionalSelectDescriptionStyle value : values) {
             this.getSelectDescription().getConditionalStyles().add(value);
         }

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/TextAreaDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/TextAreaDescriptionBuilder.java
@@ -105,7 +105,7 @@ public class TextAreaDescriptionBuilder {
      *
      * @generated
      */
-    public TextAreaDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalTextareaDescriptionStyle... values) {
+    public TextAreaDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalTextareaDescriptionStyle ... values) {
         for (org.eclipse.sirius.components.view.form.ConditionalTextareaDescriptionStyle value : values) {
             this.getTextAreaDescription().getConditionalStyles().add(value);
         }

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/TextfieldDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/TextfieldDescriptionBuilder.java
@@ -105,7 +105,7 @@ public class TextfieldDescriptionBuilder {
      *
      * @generated
      */
-    public TextfieldDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalTextfieldDescriptionStyle... values) {
+    public TextfieldDescriptionBuilder conditionalStyles(org.eclipse.sirius.components.view.form.ConditionalTextfieldDescriptionStyle ... values) {
         for (org.eclipse.sirius.components.view.form.ConditionalTextfieldDescriptionStyle value : values) {
             this.getTextfieldDescription().getConditionalStyles().add(value);
         }


### PR DESCRIPTION
They are only re-generated when running the backend tests (`mvn verify`), so we often miss them when making changes to the View DSL.
