### PR TITLE
[2183] Add some data-testid to help cypress tests redaction

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -126,6 +126,7 @@ Use the same style properties as the list widget.
 - https://github.com/eclipse-sirius/sirius-components/issues/2175[#2175] [tree] Change tree behavior to reveal the current value(s) in the model browser.
 - https://github.com/eclipse-sirius/sirius-components/issues/2171[#2171] [tree] Remove from model browser subtrees with no compatible values.
 - https://github.com/eclipse-sirius/sirius-components/issues/2168[#2168] [tree] Add option on tree to disable multiple selection.
+- https://github.com/eclipse-sirius/sirius-components/issues/2183[#2183] [form] Add some data-testid to help cypress tests redaction.
 
 == v2023.6.0
 

--- a/integration-tests/cypress/e2e/project/edit/explorer-toolbar.cy.js
+++ b/integration-tests/cypress/e2e/project/edit/explorer-toolbar.cy.js
@@ -90,28 +90,26 @@ describe('/projects/:projectId/edit - Tree toolbar', () => {
   });
 
   it('can open the upload document modal', () => {
-    cy.getByTestId('upload-document').click();
+    cy.getByTestId('upload-document-icon').click();
 
     cy.get('.MuiDialog-container').should('be.visible');
 
     cy.get('.MuiDialog-container').type('{esc}');
     cy.get('.MuiDialog-container').should('not.exist');
   });
-});
 
-//The upload function doesn't exist anymore.
-it.skip('can upload an existing document', () => {
-  cy.getByTestId('upload-document').click();
+  it('can upload an existing document', () => {
+    cy.getByTestId('upload-document-icon').click();
 
-  cy.fixture('Robot.xmi').then((fileContent) => {
-    cy.getByTestId('file').upload({
-      fileContent,
-      fileName: 'robot',
-      mimeType: 'text/xml',
-      encoding: 'utf8',
-    });
+    cy.getByTestId('file').selectFile(
+      {
+        contents: 'cypress/fixtures/Robot.xmi',
+        fileName: 'robot',
+      },
+      { force: true }
+    );
 
-    cy.getByTestId('upload-document').click();
+    cy.getByTestId('upload-document-submit').click();
 
     cy.get('.MuiDialog-container').should('not.exist');
     cy.getByTestId('explorer://').contains('robot');

--- a/packages/forms/frontend/sirius-components-forms/src/form/Form.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/form/Form.tsx
@@ -10,9 +10,9 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
+import { makeStyles } from '@material-ui/core/styles';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
-import { makeStyles } from '@material-ui/core/styles';
 import React, { useEffect, useState } from 'react';
 import { Page } from '../pages/Page';
 import { ToolbarAction } from '../toolbaraction/ToolbarAction';
@@ -143,6 +143,7 @@ export const Form = ({ editingContextId, form, widgetSubscriptions, setSelection
                   </div>
                 }
                 key={page.id}
+                data-testid={`page-tab-${page.label}`}
               />
             );
           })}

--- a/packages/forms/frontend/sirius-components-forms/src/groups/Group.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/groups/Group.tsx
@@ -130,7 +130,7 @@ export const Group = ({ editingContextId, formId, group, widgetSubscriptions, se
   }
 
   return (
-    <div className={classes.group}>
+    <div className={classes.group} data-testid={`group-${group.label}`}>
       <div className={classes.groupLabelAndToolbar}>
         {group.displayMode === 'TOGGLEABLE_AREAS' ? (
           widgetSelector

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/FlexboxContainerPropertySection.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/FlexboxContainerPropertySection.tsx
@@ -72,7 +72,7 @@ export const FlexboxContainerPropertySection = ({
   ));
 
   return (
-    <div className={classes.containerAndLabel}>
+    <div className={classes.containerAndLabel} data-testid={`flexbox-${widget.label}`}>
       <PropertySectionLabel editingContextId={editingContextId} formId={formId} widget={widget} subscribers={[]} />
       <div className={classes.container}>{children}</div>
     </div>

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/ListPropertySection.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/ListPropertySection.tsx
@@ -239,14 +239,14 @@ export const ListPropertySection = ({
           className={`${readOnly || widget.readOnly ? '' : classes.canBeSelectedItem} ${classes.style}`}
           onClick={() => (readOnly || widget.readOnly ? {} : clickHandler(item))}
           color="textPrimary"
-          data-testid={`representation-${item.id}`}>
+          data-testid={`representation-${item.label}`}>
           {item.label}
         </Typography>
         <IconButton
           aria-label="deleteListItem"
           onClick={(event) => onDelete(event, item)}
           disabled={readOnly || !item.deletable || widget.readOnly}
-          data-testid={`delete-representation-${item.id}`}>
+          data-testid={`delete-representation-${item.label}`}>
           <DeleteIcon />
         </IconButton>
       </>
@@ -261,7 +261,7 @@ export const ListPropertySection = ({
         widget={widget}
         subscribers={subscribers}
       />
-      <Table size="small">
+      <Table size="small" data-testid={`table-${widget.label}`}>
         <TableBody>
           {items.map((item) => (
             <TableRow key={item.id}>

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/ListPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/ListPropertySection.test.tsx
@@ -16,7 +16,7 @@ import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, expect, test, vi } from 'vitest';
 import { GQLList, GQLListItem } from '../../form/FormEventFragments.types';
-import { ListPropertySection, clickListItemMutation } from '../ListPropertySection';
+import { clickListItemMutation, ListPropertySection } from '../ListPropertySection';
 import {
   GQLClickListItemMutationData,
   GQLClickListItemMutationVariables,
@@ -181,7 +181,7 @@ test('should the click event sent on item click', async () => {
     </MockedProvider>
   );
   expect(container).toMatchSnapshot();
-  const element: HTMLElement = screen.getByTestId('representation-item3');
+  const element: HTMLElement = screen.getByTestId('representation-item3Label');
   expect(element.textContent).toBe('item3Label');
 
   await act(async () => {

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/__snapshots__/FlexboxContainerPropertySection.test.tsx.snap
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/__snapshots__/FlexboxContainerPropertySection.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`should render the flexbox container with border style 1`] = `
 <div>
   <div
     class="makeStyles-containerAndLabel-1 makeStyles-containerAndLabel-10"
+    data-testid="flexbox-label"
   >
     <div
       class="makeStyles-propertySectionLabel-7"
@@ -28,6 +29,7 @@ exports[`should render the flexbox container without style 1`] = `
 <div>
   <div
     class="makeStyles-containerAndLabel-1 makeStyles-containerAndLabel-4"
+    data-testid="flexbox-label"
   >
     <div
       class="makeStyles-propertySectionLabel-7"

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/__snapshots__/ListPropertySection.test.tsx.snap
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/__snapshots__/ListPropertySection.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`render list widget 1`] = `
     </div>
     <table
       class="MuiTable-root"
+      data-testid="table-myList"
     >
       <tbody
         class="MuiTableBody-root"
@@ -31,14 +32,14 @@ exports[`render list widget 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-3 makeStyles-style-4 makeStyles-style-5 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item1"
+              data-testid="representation-item1Label"
             >
               item1Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item1"
+              data-testid="delete-representation-item1Label"
               tabindex="0"
               type="button"
             >
@@ -70,14 +71,14 @@ exports[`render list widget 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-3 makeStyles-style-4 makeStyles-style-5 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item2"
+              data-testid="representation-item2Label"
             >
               item2Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item2"
+              data-testid="delete-representation-item2Label"
               tabindex="0"
               type="button"
             >
@@ -109,14 +110,14 @@ exports[`render list widget 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-3 makeStyles-style-4 makeStyles-style-5 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item3"
+              data-testid="representation-item3Label"
             >
               item3Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item3"
+              data-testid="delete-representation-item3Label"
               tabindex="0"
               type="button"
             >
@@ -180,6 +181,7 @@ exports[`render list widget with help hint 1`] = `
     </div>
     <table
       class="MuiTable-root"
+      data-testid="table-myList"
     >
       <tbody
         class="MuiTableBody-root"
@@ -192,14 +194,14 @@ exports[`render list widget with help hint 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-27 makeStyles-style-28 makeStyles-style-29 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item1"
+              data-testid="representation-item1Label"
             >
               item1Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item1"
+              data-testid="delete-representation-item1Label"
               tabindex="0"
               type="button"
             >
@@ -231,14 +233,14 @@ exports[`render list widget with help hint 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-27 makeStyles-style-28 makeStyles-style-29 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item2"
+              data-testid="representation-item2Label"
             >
               item2Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item2"
+              data-testid="delete-representation-item2Label"
               tabindex="0"
               type="button"
             >
@@ -270,14 +272,14 @@ exports[`render list widget with help hint 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-27 makeStyles-style-28 makeStyles-style-29 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item3"
+              data-testid="representation-item3Label"
             >
               item3Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item3"
+              data-testid="delete-representation-item3Label"
               tabindex="0"
               type="button"
             >
@@ -329,6 +331,7 @@ exports[`render list widget with style 1`] = `
     </div>
     <table
       class="MuiTable-root"
+      data-testid="table-myList"
     >
       <tbody
         class="MuiTableBody-root"
@@ -341,14 +344,14 @@ exports[`render list widget with style 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-11 makeStyles-style-12 makeStyles-style-13 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item1"
+              data-testid="representation-item1Label"
             >
               item1Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item1"
+              data-testid="delete-representation-item1Label"
               tabindex="0"
               type="button"
             >
@@ -380,14 +383,14 @@ exports[`render list widget with style 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-11 makeStyles-style-12 makeStyles-style-13 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item2"
+              data-testid="representation-item2Label"
             >
               item2Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item2"
+              data-testid="delete-representation-item2Label"
               tabindex="0"
               type="button"
             >
@@ -419,14 +422,14 @@ exports[`render list widget with style 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-11 makeStyles-style-12 makeStyles-style-13 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item3"
+              data-testid="representation-item3Label"
             >
               item3Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item3"
+              data-testid="delete-representation-item3Label"
               tabindex="0"
               type="button"
             >
@@ -478,6 +481,7 @@ exports[`should render a readOnly list from widget properties 1`] = `
     </div>
     <table
       class="MuiTable-root"
+      data-testid="table-myList"
     >
       <tbody
         class="MuiTableBody-root"
@@ -490,14 +494,14 @@ exports[`should render a readOnly list from widget properties 1`] = `
           >
             <p
               class="MuiTypography-root  makeStyles-style-36 makeStyles-style-37 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item1"
+              data-testid="representation-item1Label"
             >
               item1Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
-              data-testid="delete-representation-item1"
+              data-testid="delete-representation-item1Label"
               disabled=""
               tabindex="-1"
               type="button"
@@ -527,14 +531,14 @@ exports[`should render a readOnly list from widget properties 1`] = `
           >
             <p
               class="MuiTypography-root  makeStyles-style-36 makeStyles-style-37 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item2"
+              data-testid="representation-item2Label"
             >
               item2Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
-              data-testid="delete-representation-item2"
+              data-testid="delete-representation-item2Label"
               disabled=""
               tabindex="-1"
               type="button"
@@ -564,14 +568,14 @@ exports[`should render a readOnly list from widget properties 1`] = `
           >
             <p
               class="MuiTypography-root  makeStyles-style-36 makeStyles-style-37 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item3"
+              data-testid="representation-item3Label"
             >
               item3Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
-              data-testid="delete-representation-item3"
+              data-testid="delete-representation-item3Label"
               disabled=""
               tabindex="-1"
               type="button"
@@ -621,6 +625,7 @@ exports[`should the click event sent on item click 1`] = `
     </div>
     <table
       class="MuiTable-root"
+      data-testid="table-myList"
     >
       <tbody
         class="MuiTableBody-root"
@@ -633,14 +638,14 @@ exports[`should the click event sent on item click 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-19 makeStyles-style-20 makeStyles-style-21 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item1"
+              data-testid="representation-item1Label"
             >
               item1Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item1"
+              data-testid="delete-representation-item1Label"
               tabindex="0"
               type="button"
             >
@@ -672,14 +677,14 @@ exports[`should the click event sent on item click 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-19 makeStyles-style-20 makeStyles-style-21 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item2"
+              data-testid="representation-item2Label"
             >
               item2Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item2"
+              data-testid="delete-representation-item2Label"
               tabindex="0"
               type="button"
             >
@@ -711,14 +716,14 @@ exports[`should the click event sent on item click 1`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-19 makeStyles-style-20 makeStyles-style-21 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item3"
+              data-testid="representation-item3Label"
             >
               item3Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item3"
+              data-testid="delete-representation-item3Label"
               tabindex="0"
               type="button"
             >
@@ -770,6 +775,7 @@ exports[`should the click event sent on item click 2`] = `
     </div>
     <table
       class="MuiTable-root"
+      data-testid="table-myList"
     >
       <tbody
         class="MuiTableBody-root"
@@ -782,14 +788,14 @@ exports[`should the click event sent on item click 2`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-19 makeStyles-style-20 makeStyles-style-21 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item1"
+              data-testid="representation-item1Label"
             >
               item1Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item1"
+              data-testid="delete-representation-item1Label"
               tabindex="0"
               type="button"
             >
@@ -821,14 +827,14 @@ exports[`should the click event sent on item click 2`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-19 makeStyles-style-20 makeStyles-style-21 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item2"
+              data-testid="representation-item2Label"
             >
               item2Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item2"
+              data-testid="delete-representation-item2Label"
               tabindex="0"
               type="button"
             >
@@ -860,14 +866,14 @@ exports[`should the click event sent on item click 2`] = `
           >
             <p
               class="MuiTypography-root makeStyles-canBeSelectedItem-19 makeStyles-style-20 makeStyles-style-21 MuiTypography-body1 MuiTypography-colorTextPrimary"
-              data-testid="representation-item3"
+              data-testid="representation-item3Label"
             >
               item3Label
             </p>
             <button
               aria-label="deleteListItem"
               class="MuiButtonBase-root MuiIconButton-root"
-              data-testid="delete-representation-item3"
+              data-testid="delete-representation-item3Label"
               tabindex="0"
               type="button"
             >

--- a/packages/trees/frontend/sirius-components-trees/src/modals/upload-document/UploadDocumentModal.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/modals/upload-document/UploadDocumentModal.tsx
@@ -142,7 +142,7 @@ export const UploadDocumentModal = ({ editingContextId, onDocumentUploaded, onCl
             color="primary"
             type="submit"
             form="upload-form-id"
-            data-testid="upload-document">
+            data-testid="upload-document-submit">
             Upload
           </Button>
         </DialogActions>

--- a/packages/trees/frontend/sirius-components-trees/src/toolbar/TreeToolBar.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/toolbar/TreeToolBar.tsx
@@ -18,6 +18,7 @@ import { useState } from 'react';
 import { NewDocumentModal } from '../modals/new-document/NewDocumentModal';
 import { UploadDocumentModal } from '../modals/upload-document/UploadDocumentModal';
 import { TreeToolBarProps, TreeToolBarState } from './TreeToolBar.types';
+
 const useTreeToolbarStyles = makeStyles((theme) => ({
   toolbar: {
     display: 'flex',
@@ -63,7 +64,7 @@ export const TreeToolBar = ({ editingContextId, onSynchronizedClick, synchronize
           aria-label="Upload model"
           title="Upload model"
           onClick={openUploadDocumentModal}
-          data-testid="upload-document">
+          data-testid="upload-document-icon">
           <PublishIcon />
         </IconButton>
         <IconButton


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/2183

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [x] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?