### PR TITLE
[fix] Fix potential NPE on missing DiagramDescription.palette

### DIFF
--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewToolSectionsProvider.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewToolSectionsProvider.java
@@ -137,20 +137,22 @@ public class ViewToolSectionsProvider implements IToolSectionsProvider {
 
     private List<ITool> createDiagramPaletteTools(org.eclipse.sirius.components.view.diagram.DiagramDescription viewDiagramDescription) {
         List<ITool> diagramTools = new ArrayList<>();
-        for (NodeTool nodeTool : viewDiagramDescription.getPalette().getNodeTools()) {
-            String toolId = this.idProvider.apply(nodeTool).toString();
-            String selectionDescriptionId = "";
-            if (nodeTool.getSelectionDescription() != null) {
-                selectionDescriptionId = this.objectService.getId(nodeTool.getSelectionDescription());
+        if (viewDiagramDescription.getPalette() != null) {
+            for (NodeTool nodeTool : viewDiagramDescription.getPalette().getNodeTools()) {
+                String toolId = this.idProvider.apply(nodeTool).toString();
+                String selectionDescriptionId = "";
+                if (nodeTool.getSelectionDescription() != null) {
+                    selectionDescriptionId = this.objectService.getId(nodeTool.getSelectionDescription());
+                }
+                var tool = SingleClickOnDiagramElementTool.newSingleClickOnDiagramElementTool(toolId)
+                        .label(nodeTool.getName())
+                        .imageURL(ViewToolImageProvider.NODE_CREATION_TOOL_ICON)
+                        .selectionDescriptionId(selectionDescriptionId)
+                        .targetDescriptions(List.of())
+                        .appliesToDiagramRoot(true)
+                        .build();
+                diagramTools.add(tool);
             }
-            var tool = SingleClickOnDiagramElementTool.newSingleClickOnDiagramElementTool(toolId)
-                    .label(nodeTool.getName())
-                    .imageURL(ViewToolImageProvider.NODE_CREATION_TOOL_ICON)
-                    .selectionDescriptionId(selectionDescriptionId)
-                    .targetDescriptions(List.of())
-                    .appliesToDiagramRoot(true)
-                    .build();
-            diagramTools.add(tool);
         }
         return diagramTools;
     }


### PR DESCRIPTION
It's pretty easy to create a DiagramDescription without a palette:
* from the "View" onboard area action (invokes `EditingContextActionHandler.createEmptyViewResource()`)
* from the "New model" explorer action (invokes `StereotypeDescriptionRegistryConfigurer.getEmptyViewContent()`)

Both locations could be fixed/improved, but it will always be possible to end up in such a state, so the View conversion should not crash in this case.
