### PR TITLE
[doc] Add ADR for dynamic widgets support in Forms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: vscode
-          path: vscode-extension/sirius-web-2023.8.1.vsix
+          path: vscode-extension/sirius-web-2023.8.2.vsix
           retention-days: 20
 
       - name: Compress the code coverage results

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,8 @@
 
 === Architectural decision records
 
+- [ADR-107] Add support for dynamic and conditional widgets in Forms
+
 
 === Breaking changes
 

--- a/doc/adrs/107_dynamic_widgets.adoc
+++ b/doc/adrs/107_dynamic_widgets.adoc
@@ -1,0 +1,50 @@
+= [ADR-107] Add support for dynamic and conditional widgets in Forms
+
+== Context
+
+The set of widgets displayed by a _Form_ is currently hard-coded statically in the structure of the corresponding _FormDescription_.
+Each _WidgetDescription_ will produce one, and only one, concrete widget when the form is rendered.
+
+On the desktop side, EEF overcame this limitation by introducing https://eclipse.dev/sirius/doc/specifier/properties/Properties_View_Description.html#dynamic_mappings[dynamic mappings], based on two new configuration elements: `DynamicFor` and `DynamicIf`.
+
+The core rendering algorithm of the Sirius Web Forms already implements these mechanisms to support the compatibility layer with Sirius Desktop VSMs, but they are not exposed when creating a _FormDescription_ using the View DSL.
+
+== Decision
+
+We will add support for `DynamicFor` and `DynamicIf` to the Forms DSL.
+
+In this first version, we will only support the same case as in EEF desktop, namely widgets inside a _Group_.
+
+A _GroupDescription_ currently has a _widgets: WidgetDescription_ reference.
+As is the case in EEF desktop, we will introduce a new _ControlDescription_ type as a generalization of _WidgetDescription_, and _GroupDescription.widgets_ will now contain _ControlDescriptions_.
+We will not change the name of the _widgets_ reference to avoid breaking existing models.
+
+_FlexboxContainer_, which also acts as a container for widgets, will also be modified in a similar way so that it's _children_ are _ControlDescriptions_.
+
+The new _DynamicFor_ element will also extends _ControlDescription_, so that a group can contain both actual widgets and _DynamicFor_.
+
+_DynamicFor_ will have two attributes:
+
+* `iterationExpression`: an AQL expression to be evaluated when rendering the form, which should return a collection of (arbitrary) elements;
+* `iterator`: a (fixed) variable name.
+
+It will also _contain_ an arbitrary number if _DynamicIf_, which has a `predicateExpression` attribute and a `control: ControlDescription[1]` containment reference.
+
+The semantics will be the same as in EEF desktop.
+
+When rendering a _FormDescription_ which uses _DynamicFor_ & _DynamicIfs_, in the context of a _FormDescription Editor_ these elements will not be visible.
+The Form will display as if all the widgets inside all the _DynamicIfs_ of a _DynamicFor_ were defined directly inside the parent _GroupDescription_.
+
+== Status
+
+Accepted.
+
+== Consequences
+
+* Any custom widget's metamodel will need to be regenerated.
+This is required for the custom widget's child creation extender to be able to be created inside the new _DynamicIf_ elements.
+* With this, it will become possible to express more generic and dynamic form descriptions, including the equivalent of https://github.com/eclipse-sirius/sirius-desktop/blob/master/plugins/org.eclipse.sirius.properties.defaultrules/model/properties.odesign[Sirius Desktop defaults properties rules].
+* With _DynamicIf_ containing _ControlDescriptions_ instead of actual widgets, it should be possible to create nested loops.
+* The first version if the mechanism introduced here will be generalized to allow For/If in as many places as possible (and meaningful) in the Forms DSL, notable on Groups and Pages.
+Note that pages already support `semanticCandidatesExpression` which cover part of the same uses cases but is less powerful.
+* We will also investigate generalizing this mechanism to the diagrams DSL if/where it can make sense.

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sirius-web-integration-tests",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sirius-web-integration-tests",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "dependencies": {
         "prettier": "2.7.1"

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sirius-web-integration-tests",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "license": "EPL-2.0",
   "private": true,
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components-parent",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components-parent",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "workspaces": [
         "./packages/*/frontend/*"
@@ -5669,7 +5669,7 @@
     },
     "packages/charts/frontend/sirius-components-charts": {
       "name": "@eclipse-sirius/sirius-components-charts",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@eclipse-sirius/sirius-components-tsconfig": "~2023.8.0",
@@ -5702,7 +5702,7 @@
     },
     "packages/core/frontend/sirius-components-core": {
       "name": "@eclipse-sirius/sirius-components-core",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.8.1",
@@ -5834,7 +5834,7 @@
     },
     "packages/diagrams/frontend/sirius-components-diagrams": {
       "name": "@eclipse-sirius/sirius-components-diagrams",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.8.1",
@@ -5876,7 +5876,7 @@
     },
     "packages/diagrams/frontend/sirius-components-diagrams-reactflow": {
       "name": "@eclipse-sirius/sirius-components-diagrams-reactflow",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.8.1",
@@ -6113,7 +6113,7 @@
     },
     "packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors": {
       "name": "@eclipse-sirius/sirius-components-formdescriptioneditors",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.8.1",
@@ -6252,7 +6252,7 @@
     },
     "packages/forms/frontend/sirius-components-forms": {
       "name": "@eclipse-sirius/sirius-components-forms",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.8.1",
@@ -6400,7 +6400,7 @@
     },
     "packages/forms/frontend/sirius-components-widget-reference": {
       "name": "@eclipse-sirius/sirius-components-widget-reference",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.8.1",
@@ -6552,12 +6552,12 @@
     },
     "packages/releng/frontend/sirius-components-tsconfig": {
       "name": "@eclipse-sirius/sirius-components-tsconfig",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0"
     },
     "packages/selection/frontend/sirius-components-selection": {
       "name": "@eclipse-sirius/sirius-components-selection",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.8.1",
@@ -6688,7 +6688,7 @@
     },
     "packages/sirius-web/frontend/sirius-web": {
       "name": "@eclipse-sirius/sirius-web",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "dependencies": {
         "@apollo/client": "3.8.1",
@@ -7075,7 +7075,7 @@
     },
     "packages/tools/frontend/sirius-components-specification-layout": {
       "name": "@eclipse-sirius/sirius-components-specification-layout",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@material-ui/core": "4.12.4",
@@ -7108,7 +7108,7 @@
     },
     "packages/trees/frontend/sirius-components-trees": {
       "name": "@eclipse-sirius/sirius-components-trees",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.8.1",
@@ -7242,7 +7242,7 @@
     },
     "packages/validation/frontend/sirius-components-validation": {
       "name": "@eclipse-sirius/sirius-components-validation",
-      "version": "2023.8.1",
+      "version": "2023.8.2",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-parent",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/charts/backend/pom.xml
+++ b/packages/charts/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-charts-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-charts-parent</name>
 	<description>Sirius Components Charts Parent</description>

--- a/packages/charts/backend/sirius-components-charts/pom.xml
+++ b/packages/charts/backend/sirius-components-charts/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-charts</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-charts</name>
 	<description>Sirius Components Charts</description>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/charts/backend/sirius-components-collaborative-charts/pom.xml
+++ b/packages/charts/backend/sirius-components-collaborative-charts/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-charts</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-collaborative-charts</name>
 	<description>Sirius Components Collaborative Charts</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/charts/frontend/sirius-components-charts/package.json
+++ b/packages/charts/frontend/sirius-components-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-charts",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/compatibility/backend/pom.xml
+++ b/packages/compatibility/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-compatibility-parent</name>
 	<description>Sirius Components Compatibility Parent</description>

--- a/packages/compatibility/backend/sirius-components-compatibility-emf/pom.xml
+++ b/packages/compatibility/backend/sirius-components-compatibility-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility-emf</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-compatibility-emf</name>
 	<description>Sirius Components Compatibility EMF</description>
 
@@ -58,22 +58,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -83,19 +83,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/compatibility/backend/sirius-components-compatibility/pom.xml
+++ b/packages/compatibility/backend/sirius-components-compatibility/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-compatibility</name>
 	<description>Sirius Components Compatibility</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -74,48 +74,48 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/packages/core/backend/pom.xml
+++ b/packages/core/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-core-parent</name>
 	<description>Sirius Components Core Parent</description>

--- a/packages/core/backend/sirius-components-annotations-spring/pom.xml
+++ b/packages/core/backend/sirius-components-annotations-spring/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations-spring</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-annotations-spring</name>
 	<description>Sirius Components Annotations Spring</description>
 

--- a/packages/core/backend/sirius-components-annotations/pom.xml
+++ b/packages/core/backend/sirius-components-annotations/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-annotations</name>
 	<description>Sirius Components Annotations</description>
 

--- a/packages/core/backend/sirius-components-collaborative/pom.xml
+++ b/packages/core/backend/sirius-components-collaborative/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-collaborative</name>
 	<description>Sirius Components Collaborative</description>
 
@@ -67,23 +67,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/core/backend/sirius-components-core/pom.xml
+++ b/packages/core/backend/sirius-components-core/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-core</name>
 	<description>Sirius Components Core</description>
 
@@ -52,17 +52,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/core/backend/sirius-components-graphql-api/pom.xml
+++ b/packages/core/backend/sirius-components-graphql-api/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-api</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-graphql-api</name>
 	<description>Sirius Components GraphQL API</description>
 
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/core/backend/sirius-components-representations/pom.xml
+++ b/packages/core/backend/sirius-components-representations/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-representations</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-representations</name>
 	<description>Sirius Components Representations</description>
 
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/core/frontend/sirius-components-core/package.json
+++ b/packages/core/frontend/sirius-components-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-core",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/diagrams/backend/pom.xml
+++ b/packages/diagrams/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-diagrams-parent</name>
 	<description>Sirius Components Diagrams Parent</description>

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/pom.xml
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-diagrams</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-collaborative-diagrams</name>
 	<description>Sirius Components Collaborative Diagrams</description>
 
@@ -51,34 +51,34 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-graphql</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-diagrams-graphql</name>
 	<description>Sirius Components Diagrams GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/diagrams/backend/sirius-components-diagrams-layout-api/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout-api/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout-api</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-diagrams-layout-api</name>
 	<description>Sirius Components Diagrams Layout API</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/packages/diagrams/backend/sirius-components-diagrams-layout/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-layout/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-diagrams-layout</name>
 	<description>Sirius Components Diagrams layout</description>
 
@@ -66,17 +66,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -128,18 +128,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-tests</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-diagrams-tests</name>
 	<description>Sirius Components Diagrams Tests</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/packages/diagrams/backend/sirius-components-diagrams/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-diagrams</name>
 	<description>Sirius Components Diagrams</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/package.json
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-diagrams-reactflow",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/diagrams/frontend/sirius-components-diagrams/package.json
+++ b/packages/diagrams/frontend/sirius-components-diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-diagrams",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/domain/backend/pom.xml
+++ b/packages/domain/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-domain-parent</name>
 	<description>Sirius Components Domain Parent</description>

--- a/packages/domain/backend/sirius-components-domain-design/pom.xml
+++ b/packages/domain/backend/sirius-components-domain-design/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-design</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-domain-design</name>
 	<description>Sirius Components Domain Definition DSL - Graphical Modeler Definition</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/domain/backend/sirius-components-domain-edit/pom.xml
+++ b/packages/domain/backend/sirius-components-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-edit</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-domain-edit</name>
 	<description>Sirius Components Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/domain/backend/sirius-components-domain-emf/pom.xml
+++ b/packages/domain/backend/sirius-components-domain-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-emf</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-domain-emf</name>
 	<description>Sirius Components Domain EMF</description>
 
@@ -54,12 +54,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -69,13 +69,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/domain/backend/sirius-components-domain/pom.xml
+++ b/packages/domain/backend/sirius-components-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-domain</name>
 	<description>Sirius Components Domain Definition DSL</description>
 

--- a/packages/emf/backend/pom.xml
+++ b/packages/emf/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-emf-parent</name>
 	<description>Sirius Components EMF Parent</description>

--- a/packages/emf/backend/sirius-components-emf/pom.xml
+++ b/packages/emf/backend/sirius-components-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-emf</name>
 	<description>Sirius Components EMF</description>
 
@@ -58,17 +58,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -117,19 +117,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/emf/backend/sirius-components-interpreter/pom.xml
+++ b/packages/emf/backend/sirius-components-interpreter/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-interpreter</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-interpreter</name>
 	<description>Sirius Components Intepreter</description>
 

--- a/packages/formdescriptioneditors/backend/pom.xml
+++ b/packages/formdescriptioneditors/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-formdescriptioneditors-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-formdescriptioneditors-parent</name>
 	<description>Sirius Components FormDescription Editors Parent</description>

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-collaborative-formdescriptioneditors</name>
 	<description>Sirius Components Collaborative FormDescriptionEditors</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors-graphql/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-formdescriptioneditors-graphql</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-formdescriptioneditors-graphql</name>
 	<description>Sirius Components FormDescription Editors GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-formdescriptioneditors</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-formdescriptioneditors</name>
 	<description>Sirius Components FormDescriptionEditors</description>
 
@@ -47,27 +47,27 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/package.json
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-formdescriptioneditors",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/forms/backend/pom.xml
+++ b/packages/forms/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-forms-parent</name>
 	<description>Sirius Components Forms Parent</description>

--- a/packages/forms/backend/sirius-components-collaborative-forms/pom.xml
+++ b/packages/forms/backend/sirius-components-collaborative-forms/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-forms</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-collaborative-forms</name>
 	<description>Sirius Components Collaborative Forms</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/backend/sirius-components-forms-graphql/pom.xml
+++ b/packages/forms/backend/sirius-components-forms-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-graphql</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-forms-graphql</name>
 	<description>Sirius Components Forms GraphQL</description>
 
@@ -51,27 +51,27 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/backend/sirius-components-forms-tests/pom.xml
+++ b/packages/forms/backend/sirius-components-forms-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-tests</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-forms-tests</name>
 	<description>Sirius Components Forms Tests</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/packages/forms/backend/sirius-components-forms/pom.xml
+++ b/packages/forms/backend/sirius-components-forms/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-forms</name>
 	<description>Sirius Components Forms</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/backend/sirius-components-widget-reference-view-edit/pom.xml
+++ b/packages/forms/backend/sirius-components-widget-reference-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-widget-reference-view-edit</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-widget-reference-view-edit</name>
 	<description>View support for the reference custom widget :: edit support</description>
 
@@ -69,17 +69,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form-edit</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/forms/backend/sirius-components-widget-reference-view/pom.xml
+++ b/packages/forms/backend/sirius-components-widget-reference-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-widget-reference-view</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-widget-reference-view</name>
 	<description>View support for the reference custom widget</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/forms/backend/sirius-components-widget-reference/pom.xml
+++ b/packages/forms/backend/sirius-components-widget-reference/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-widget-reference</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-widget-reference</name>
 	<description>Sirius Components Forms :: Reference Widget</description>
 
@@ -47,52 +47,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view-edit</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -114,7 +114,7 @@
 			<artifactId>
 				sirius-components-formdescriptioneditors
 			</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/forms/frontend/sirius-components-forms/package.json
+++ b/packages/forms/frontend/sirius-components-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-forms",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/forms/frontend/sirius-components-widget-reference/package.json
+++ b/packages/forms/frontend/sirius-components-widget-reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-widget-reference",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/pom.xml
+++ b/packages/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/packages/releng/backend/pom.xml
+++ b/packages/releng/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-releng-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-releng-parent</name>
 	<description>Sirius Components Releng Parent</description>

--- a/packages/releng/backend/sirius-components-test-coverage/pom.xml
+++ b/packages/releng/backend/sirius-components-test-coverage/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-test-coverage</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-test-coverage-aggregation</name>
 	<description>Sirius Components Test Coverage Aggregation</description>
 
@@ -43,227 +43,227 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility-emf</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-design</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-charts</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-graphql</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-persistence</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-spring</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-sample-application</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/releng/frontend/sirius-components-tsconfig/package.json
+++ b/packages/releng/frontend/sirius-components-tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-tsconfig",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/selection/backend/pom.xml
+++ b/packages/selection/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-selection-parent</name>
 	<description>Sirius Components Selection Parent</description>

--- a/packages/selection/backend/sirius-components-collaborative-selection/pom.xml
+++ b/packages/selection/backend/sirius-components-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-selection</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-collaborative-selection</name>
 	<description>Sirius Components Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,18 +56,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/selection/backend/sirius-components-selection-graphql/pom.xml
+++ b/packages/selection/backend/sirius-components-selection-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection-graphql</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-selection-graphql</name>
 	<description>Sirius Components Selection GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/selection/backend/sirius-components-selection/pom.xml
+++ b/packages/selection/backend/sirius-components-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-selection</name>
 	<description>Sirius Components Selection</description>
 
@@ -43,17 +43,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/selection/frontend/sirius-components-selection/package.json
+++ b/packages/selection/frontend/sirius-components-selection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-selection",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/sirius-web/backend/pom.xml
+++ b/packages/sirius-web/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-web-parent</name>
 	<description>Sirius Web Parent</description>

--- a/packages/sirius-web/backend/sirius-web-customwidgets-edit/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-customwidgets-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-customwidgets-edit</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-web-customwidgets-edit</name>
 	<description>Support for additional widgets - edit support</description>
 
@@ -69,12 +69,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-customwidgets</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form-edit</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/sirius-web/backend/sirius-web-customwidgets/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-customwidgets/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-customwidgets</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-web-customwidgets</name>
 	<description>Support for additional widgets</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/sirius-web/backend/sirius-web-frontend/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-frontend/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-frontend</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-web-frontend</name>
 	<description>Sirius Web Frontend</description>
 

--- a/packages/sirius-web/backend/sirius-web-graphql/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-graphql</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-web-graphql</name>
 	<description>Sirius Web GraphQL</description>
 
@@ -43,57 +43,57 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -103,13 +103,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/sirius-web/backend/sirius-web-persistence/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-persistence/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-persistence</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-web-persistence</name>
 	<description>Sirius Web Persistence</description>
 
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -70,13 +70,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/sirius-web/backend/sirius-web-sample-application/Dockerfile
+++ b/packages/sirius-web/backend/sirius-web-sample-application/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:17-jre
-COPY target/sirius-web-sample-application-2023.8.1.jar ./app.jar
+COPY target/sirius-web-sample-application-2023.8.2.jar ./app.jar
 EXPOSE 8080
 RUN adduser --disabled-password myuser
 USER myuser

--- a/packages/sirius-web/backend/sirius-web-sample-application/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-sample-application/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-sample-application</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-web-sample-application</name>
 	<description>Sirius Web Sample Application</description>
 
@@ -82,57 +82,57 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-starter</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-spring</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-frontend</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphiql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-voyager</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-design</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-edit</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-builder</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.obeo.dsl.designer.sample.flow</groupId>
@@ -177,21 +177,21 @@
  		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-customwidgets</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
  		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-customwidgets-edit</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
  		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
  		<dependency><groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -219,13 +219,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/sirius-web/backend/sirius-web-services-api/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-services-api/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-services-api</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-web-services-api</name>
 	<description>Sirius Web Services API</description>
 
@@ -47,27 +47,27 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/sirius-web/backend/sirius-web-services/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-services/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-services</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-web-services</name>
 	<description>Sirius Web Services</description>
 
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>xml-apis</groupId>
@@ -67,32 +67,32 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-persistence</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/sirius-web/backend/sirius-web-spring/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-spring/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-spring</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-web-spring</name>
 	<description>Sirius Web Spring</description>
 
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -71,13 +71,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/sirius-web/frontend/sirius-web/package.json
+++ b/packages/sirius-web/frontend/sirius-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eclipse-sirius/sirius-web",
   "author": "Eclipse Sirius",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "license": "EPL-2.0",
   "repository": {
     "type": "git",

--- a/packages/starters/backend/pom.xml
+++ b/packages/starters/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-starter-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-starter-parent</name>
 	<description>Sirius Components Starter Parent</description>

--- a/packages/starters/backend/sirius-components-starter/pom.xml
+++ b/packages/starters/backend/sirius-components-starter/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-starter</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-starter</name>
 	<description>Sirius Components Starter</description>
 
@@ -63,112 +63,112 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-web</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-charts</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-graphql</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation-graphql</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/tests/backend/pom.xml
+++ b/packages/tests/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-tests-parent</name>
 	<description>Sirius Components Tests Parent</description>

--- a/packages/tests/backend/sirius-components-spring-tests/pom.xml
+++ b/packages/tests/backend/sirius-components-spring-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-spring-tests</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-spring-tests</name>
 	<description>Sirius Components Spring Tests</description>
 
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/packages/tests/backend/sirius-components-tests/pom.xml
+++ b/packages/tests/backend/sirius-components-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-tests</name>
 	<description>Sirius Components Tests</description>
 
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/tools/backend/pom.xml
+++ b/packages/tools/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tools-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-tools-parent</name>
 	<description>Sirius Components Tools Parent</description>

--- a/packages/tools/backend/sirius-components-graphiql/pom.xml
+++ b/packages/tools/backend/sirius-components-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphiql</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-graphiql</name>
 	<description>Sirius Components Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/packages/tools/backend/sirius-components-graphql-voyager/pom.xml
+++ b/packages/tools/backend/sirius-components-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-voyager</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-graphql-voyager</name>
 	<description>Sirius Components Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/packages/tools/frontend/sirius-components-specification-layout/package.json
+++ b/packages/tools/frontend/sirius-components-specification-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-specification-layout",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/trees/backend/pom.xml
+++ b/packages/trees/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-trees-parent</name>
 	<description>Sirius Components Trees Parent</description>

--- a/packages/trees/backend/sirius-components-collaborative-trees/pom.xml
+++ b/packages/trees/backend/sirius-components-collaborative-trees/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-trees</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-collaborative-trees</name>
 	<description>Sirius Components Collaborative Trees</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -65,13 +65,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/trees/backend/sirius-components-trees-graphql/pom.xml
+++ b/packages/trees/backend/sirius-components-trees-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees-graphql</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-trees-graphql</name>
 	<description>Sirius Components Trees GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/trees/backend/sirius-components-trees/pom.xml
+++ b/packages/trees/backend/sirius-components-trees/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-trees</name>
 	<description>Sirius Components Trees</description>
 
@@ -43,17 +43,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/trees/frontend/sirius-components-trees/package.json
+++ b/packages/trees/frontend/sirius-components-trees/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-trees",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/validation/backend/pom.xml
+++ b/packages/validation/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-validation-parent</name>
 	<description>Sirius Components Validation Parent</description>

--- a/packages/validation/backend/sirius-components-collaborative-validation/pom.xml
+++ b/packages/validation/backend/sirius-components-collaborative-validation/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-validation</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-collaborative-validation</name>
 	<description>Sirius Components Collaborative Validation</description>
 
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -62,13 +62,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/validation/backend/sirius-components-validation-graphql/pom.xml
+++ b/packages/validation/backend/sirius-components-validation-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation-graphql</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-validation-graphql</name>
 	<description>Sirius Components Validation GraphQL</description>
 
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/validation/backend/sirius-components-validation/pom.xml
+++ b/packages/validation/backend/sirius-components-validation/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-validation</name>
 	<description>Sirius Components Validation</description>
 
@@ -48,12 +48,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/validation/frontend/sirius-components-validation/package.json
+++ b/packages/validation/frontend/sirius-components-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-validation",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/view/backend/pom.xml
+++ b/packages/view/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-view-parent</name>
 	<description>Sirius Components View Parent</description>

--- a/packages/view/backend/sirius-components-view-builder/pom.xml
+++ b/packages/view/backend/sirius-components-view-builder/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-builder</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-view-builder</name>
 	<description>Sirius View Builder</description>
 	
@@ -64,17 +64,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/view/backend/sirius-components-view-diagram-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-diagram-edit/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-diagram-edit</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-view-diagram-edit</name>
 	<description>Sirius Components Diagram View Definition DSL - Edit Support</description>
 	<properties>
@@ -49,12 +49,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-diagram/pom.xml
+++ b/packages/view/backend/sirius-components-view-diagram/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-diagram</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-view-diagram</name>
 	<description>Sirius Components Diagram View Definition DSL</description>
 	<properties>
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-edit</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-view-edit</name>
 	<description>Sirius Components View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-emf/pom.xml
+++ b/packages/view/backend/sirius-components-view-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-emf</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-view-emf</name>
 	<description>Sirius Components View EMF</description>
 
@@ -54,32 +54,32 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility-emf</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -89,19 +89,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/view/backend/sirius-components-view-form-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-form-edit/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-form-edit</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-view-form-edit</name>
 	<description>Sirius Components Form View Definition DSL - Edit Support</description>
 	<properties>
@@ -49,12 +49,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-form/pom.xml
+++ b/packages/view/backend/sirius-components-view-form/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-form</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-view-form</name>
 	<description>Sirius Components Form View Definition DSL</description>
 	<properties>
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view/pom.xml
+++ b/packages/view/backend/sirius-components-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-view</name>
 	<description>Sirius Components View Definition DSL</description>
 

--- a/packages/web/backend/pom.xml
+++ b/packages/web/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-web-parent</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 
 	<name>sirius-components-web-parent</name>
 	<description>Sirius Components Web Parent</description>

--- a/packages/web/backend/sirius-components-graphql/pom.xml
+++ b/packages/web/backend/sirius-components-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-graphql</name>
 	<description>Sirius Components GraphQL</description>
 
@@ -63,23 +63,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/web/backend/sirius-components-web/pom.xml
+++ b/packages/web/backend/sirius-components-web/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-web</artifactId>
-	<version>2023.8.1</version>
+	<version>2023.8.2</version>
 	<name>sirius-components-web</name>
 	<description>Sirius Components Web</description>
 
@@ -47,18 +47,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2023.8.0</version>
+			<version>2023.8.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2023.8.1</version>
+			<version>2023.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -4,7 +4,7 @@
   "description": "Sirius Web extension for VSCode",
   "publisher": "eclipse-sirius",
   "license": "EPL-2.0",
-  "version": "2023.8.1",
+  "version": "2023.8.2",
   "homepage": "https://www.eclipse.org/sirius/sirius-web.html",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Known issues which needs to be addressed:
* Now that a single WidgetDescription can produce 0, 1 or many instances, the widgets' id, as provided by the `WidgetIdCounter`, can not be relied upon. Between two successive renders of the same Form, the widget with id `#4` can be completely different ones (different instances of the same widget description, or instance of completely different widgets; maybe of the same kind maybe not).
* FormDescriptionEditor support: rendering is easy, but the result does not actually support all the FDE operations (add/remove/move widgets). A FormDescriptionEditor normally display a plain Form instance, with the actual widgets rendered on sample/preview data, but DynamicFor & DynamicIf, while they exist on the FormDescription, do not exist as widgets in the actual rendered Form. I guess it would be possible to create dedicated widgets for them (rendered how? as containers?) and only render them when some flag/variable is present, but that makes the core Form dialect know about a "special mode" just for the FDE).
