### PR TITLE
[2044] Custom icons to edges and nodes label in view dsl

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -92,6 +92,8 @@ This will be fixed in the next version.
 - https://github.com/eclipse-sirius/sirius-web/issues/2254[#2254] [diagram] Add the possibility to specify precondition on diagram tools
 - https://github.com/eclipse-sirius/sirius-web/issues/2252[#2252] [diagram] It's now possible to contribute custom frontend-defined tools in a React Flow diagram palette.
 To illustrate this new feature, we contribute a new tool on the _Papaya Diagram_, it's available only on _OperationalActivity_ and it simply opens a dialog with the node label content.
+- https://github.com/eclipse-sirius/sirius-web/issues/2044[#2044] [view] Add custom icons to edges and nodes label in view dsl.
+
 
 === Improvements
 

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ConditionalEdgeStyleBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ConditionalEdgeStyleBuilder.java
@@ -151,5 +151,15 @@ public class ConditionalEdgeStyleBuilder {
         return this;
     }
 
+    /**
+     * Setter for LabelIcon.
+     *
+     * @generated
+     */
+    public ConditionalEdgeStyleBuilder labelIcon(java.lang.String value) {
+        this.getConditionalEdgeStyle().setLabelIcon(value);
+        return this;
+    }
+
 }
 

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/EdgeStyleBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/EdgeStyleBuilder.java
@@ -142,5 +142,15 @@ public class EdgeStyleBuilder {
         return this;
     }
 
+    /**
+     * Setter for LabelIcon.
+     *
+     * @generated
+     */
+    public EdgeStyleBuilder labelIcon(java.lang.String value) {
+        this.getEdgeStyle().setLabelIcon(value);
+        return this;
+    }
+
 }
 

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/IconLabelNodeStyleDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/IconLabelNodeStyleDescriptionBuilder.java
@@ -169,5 +169,15 @@ public class IconLabelNodeStyleDescriptionBuilder {
         return this;
     }
 
+    /**
+     * Setter for LabelIcon.
+     *
+     * @generated
+     */
+    public IconLabelNodeStyleDescriptionBuilder labelIcon(java.lang.String value) {
+        this.getIconLabelNodeStyleDescription().setLabelIcon(value);
+        return this;
+    }
+
 }
 

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ImageNodeStyleDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/ImageNodeStyleDescriptionBuilder.java
@@ -169,6 +169,16 @@ public class ImageNodeStyleDescriptionBuilder {
         return this;
     }
     /**
+     * Setter for LabelIcon.
+     *
+     * @generated
+     */
+    public ImageNodeStyleDescriptionBuilder labelIcon(java.lang.String value) {
+        this.getImageNodeStyleDescription().setLabelIcon(value);
+        return this;
+    }
+
+    /**
      * Setter for Shape.
      *
      * @generated

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/NodeStyleDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/NodeStyleDescriptionBuilder.java
@@ -153,5 +153,15 @@ public abstract class NodeStyleDescriptionBuilder {
         return this;
     }
 
+    /**
+     * Setter for LabelIcon.
+     *
+     * @generated
+     */
+    public NodeStyleDescriptionBuilder labelIcon(java.lang.String value) {
+        this.getNodeStyleDescription().setLabelIcon(value);
+        return this;
+    }
+
 }
 

--- a/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/RectangularNodeStyleDescriptionBuilder.java
+++ b/packages/view/backend/sirius-components-view-builder/src/main/java/org/eclipse/sirius/components/view/builder/generated/RectangularNodeStyleDescriptionBuilder.java
@@ -169,6 +169,16 @@ public class RectangularNodeStyleDescriptionBuilder {
         return this;
     }
     /**
+     * Setter for LabelIcon.
+     *
+     * @generated
+     */
+    public RectangularNodeStyleDescriptionBuilder labelIcon(java.lang.String value) {
+        this.getRectangularNodeStyleDescription().setLabelIcon(value);
+        return this;
+    }
+
+    /**
      * Setter for WithHeader.
      *
      * @generated

--- a/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/ConditionalEdgeStyleItemProvider.java
+++ b/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/ConditionalEdgeStyleItemProvider.java
@@ -64,6 +64,7 @@ public class ConditionalEdgeStyleItemProvider extends ConditionalItemProvider {
             this.addTargetArrowStylePropertyDescriptor(object);
             this.addEdgeWidthPropertyDescriptor(object);
             this.addShowIconPropertyDescriptor(object);
+            this.addLabelIconPropertyDescriptor(object);
         }
         return this.itemPropertyDescriptors;
     }
@@ -190,6 +191,17 @@ public class ConditionalEdgeStyleItemProvider extends ConditionalItemProvider {
     }
 
     /**
+     * This adds a property descriptor for the Label Icon feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    protected void addLabelIconPropertyDescriptor(Object object) {
+        this.itemPropertyDescriptors.add(this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(),
+                this.getString("_UI_EdgeStyle_labelIcon_feature"), this.getString("_UI_PropertyDescriptor_description", "_UI_EdgeStyle_labelIcon_feature", "_UI_EdgeStyle_type"),
+                DiagramPackage.Literals.EDGE_STYLE__LABEL_ICON, true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
+    }
+
+    /**
      * This returns ConditionalEdgeStyle.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @generated NOT
@@ -243,6 +255,7 @@ public class ConditionalEdgeStyleItemProvider extends ConditionalItemProvider {
             case DiagramPackage.CONDITIONAL_EDGE_STYLE__TARGET_ARROW_STYLE:
             case DiagramPackage.CONDITIONAL_EDGE_STYLE__EDGE_WIDTH:
             case DiagramPackage.CONDITIONAL_EDGE_STYLE__SHOW_ICON:
+            case DiagramPackage.CONDITIONAL_EDGE_STYLE__LABEL_ICON:
                 this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
                 return;
         }

--- a/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/EdgeStyleItemProvider.java
+++ b/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/EdgeStyleItemProvider.java
@@ -61,6 +61,7 @@ public class EdgeStyleItemProvider extends StyleItemProvider {
             this.addTargetArrowStylePropertyDescriptor(object);
             this.addEdgeWidthPropertyDescriptor(object);
             this.addShowIconPropertyDescriptor(object);
+            this.addLabelIconPropertyDescriptor(object);
         }
         return this.itemPropertyDescriptors;
     }
@@ -176,6 +177,17 @@ public class EdgeStyleItemProvider extends StyleItemProvider {
     }
 
     /**
+     * This adds a property descriptor for the Label Icon feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    protected void addLabelIconPropertyDescriptor(Object object) {
+        this.itemPropertyDescriptors.add(this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(),
+                this.getString("_UI_EdgeStyle_labelIcon_feature"), this.getString("_UI_PropertyDescriptor_description", "_UI_EdgeStyle_labelIcon_feature", "_UI_EdgeStyle_type"),
+                DiagramPackage.Literals.EDGE_STYLE__LABEL_ICON, true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
+    }
+
+    /**
      * This returns EdgeStyle.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @generated
@@ -228,6 +240,7 @@ public class EdgeStyleItemProvider extends StyleItemProvider {
             case DiagramPackage.EDGE_STYLE__TARGET_ARROW_STYLE:
             case DiagramPackage.EDGE_STYLE__EDGE_WIDTH:
             case DiagramPackage.EDGE_STYLE__SHOW_ICON:
+            case DiagramPackage.EDGE_STYLE__LABEL_ICON:
                 this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
                 return;
         }

--- a/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/IconLabelNodeStyleDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/IconLabelNodeStyleDescriptionItemProvider.java
@@ -65,6 +65,7 @@ public class IconLabelNodeStyleDescriptionItemProvider extends StyleItemProvider
             this.addWidthComputationExpressionPropertyDescriptor(object);
             this.addHeightComputationExpressionPropertyDescriptor(object);
             this.addShowIconPropertyDescriptor(object);
+            this.addLabelIconPropertyDescriptor(object);
         }
         return this.itemPropertyDescriptors;
     }
@@ -219,6 +220,18 @@ public class IconLabelNodeStyleDescriptionItemProvider extends StyleItemProvider
     }
 
     /**
+     * This adds a property descriptor for the Label Icon feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    protected void addLabelIconPropertyDescriptor(Object object) {
+        this.itemPropertyDescriptors.add(this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(),
+                this.getString("_UI_NodeStyleDescription_labelIcon_feature"),
+                this.getString("_UI_PropertyDescriptor_description", "_UI_NodeStyleDescription_labelIcon_feature", "_UI_NodeStyleDescription_type"),
+                DiagramPackage.Literals.NODE_STYLE_DESCRIPTION__LABEL_ICON, true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
+    }
+
+    /**
      * This returns IconLabelNodeStyleDescription.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @generated NOT
@@ -274,6 +287,7 @@ public class IconLabelNodeStyleDescriptionItemProvider extends StyleItemProvider
             case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__WIDTH_COMPUTATION_EXPRESSION:
             case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__HEIGHT_COMPUTATION_EXPRESSION:
             case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__SHOW_ICON:
+            case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__LABEL_ICON:
                 this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
                 return;
         }

--- a/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/ImageNodeStyleDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/ImageNodeStyleDescriptionItemProvider.java
@@ -64,6 +64,7 @@ public class ImageNodeStyleDescriptionItemProvider extends StyleItemProvider {
             this.addWidthComputationExpressionPropertyDescriptor(object);
             this.addHeightComputationExpressionPropertyDescriptor(object);
             this.addShowIconPropertyDescriptor(object);
+            this.addLabelIconPropertyDescriptor(object);
             this.addShapePropertyDescriptor(object);
         }
         return this.itemPropertyDescriptors;
@@ -219,6 +220,18 @@ public class ImageNodeStyleDescriptionItemProvider extends StyleItemProvider {
     }
 
     /**
+     * This adds a property descriptor for the Label Icon feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    protected void addLabelIconPropertyDescriptor(Object object) {
+        this.itemPropertyDescriptors.add(this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(),
+                this.getString("_UI_NodeStyleDescription_labelIcon_feature"),
+                this.getString("_UI_PropertyDescriptor_description", "_UI_NodeStyleDescription_labelIcon_feature", "_UI_NodeStyleDescription_type"),
+                DiagramPackage.Literals.NODE_STYLE_DESCRIPTION__LABEL_ICON, true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
+    }
+
+    /**
      * This adds a property descriptor for the Shape feature. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @generated
@@ -286,6 +299,7 @@ public class ImageNodeStyleDescriptionItemProvider extends StyleItemProvider {
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__WIDTH_COMPUTATION_EXPRESSION:
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__HEIGHT_COMPUTATION_EXPRESSION:
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__SHOW_ICON:
+            case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__LABEL_ICON:
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__SHAPE:
                 this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
                 return;

--- a/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/RectangularNodeStyleDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/RectangularNodeStyleDescriptionItemProvider.java
@@ -65,6 +65,7 @@ public class RectangularNodeStyleDescriptionItemProvider extends StyleItemProvid
             this.addWidthComputationExpressionPropertyDescriptor(object);
             this.addHeightComputationExpressionPropertyDescriptor(object);
             this.addShowIconPropertyDescriptor(object);
+            this.addLabelIconPropertyDescriptor(object);
             this.addWithHeaderPropertyDescriptor(object);
         }
         return this.itemPropertyDescriptors;
@@ -220,6 +221,18 @@ public class RectangularNodeStyleDescriptionItemProvider extends StyleItemProvid
     }
 
     /**
+     * This adds a property descriptor for the Label Icon feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    protected void addLabelIconPropertyDescriptor(Object object) {
+        this.itemPropertyDescriptors.add(this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(),
+                this.getString("_UI_NodeStyleDescription_labelIcon_feature"),
+                this.getString("_UI_PropertyDescriptor_description", "_UI_NodeStyleDescription_labelIcon_feature", "_UI_NodeStyleDescription_type"),
+                DiagramPackage.Literals.NODE_STYLE_DESCRIPTION__LABEL_ICON, true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
+    }
+
+    /**
      * This adds a property descriptor for the With Header feature. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @generated
@@ -287,6 +300,7 @@ public class RectangularNodeStyleDescriptionItemProvider extends StyleItemProvid
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__WIDTH_COMPUTATION_EXPRESSION:
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__HEIGHT_COMPUTATION_EXPRESSION:
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__SHOW_ICON:
+            case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__LABEL_ICON:
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__WITH_HEADER:
                 this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
                 return;

--- a/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/DiagramPackage.java
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/DiagramPackage.java
@@ -881,13 +881,21 @@ public interface DiagramPackage extends EPackage {
     int NODE_STYLE_DESCRIPTION__SHOW_ICON = STYLE_FEATURE_COUNT + 12;
 
     /**
+     * The feature id for the '<em><b>Label Icon</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int NODE_STYLE_DESCRIPTION__LABEL_ICON = STYLE_FEATURE_COUNT + 13;
+
+    /**
      * The number of structural features of the '<em>Node Style Description</em>' class. <!-- begin-user-doc --> <!--
      * end-user-doc -->
      *
      * @generated
      * @ordered
      */
-    int NODE_STYLE_DESCRIPTION_FEATURE_COUNT = STYLE_FEATURE_COUNT + 13;
+    int NODE_STYLE_DESCRIPTION_FEATURE_COUNT = STYLE_FEATURE_COUNT + 14;
 
     /**
      * The number of operations of the '<em>Node Style Description</em>' class. <!-- begin-user-doc --> <!--
@@ -1070,6 +1078,14 @@ public interface DiagramPackage extends EPackage {
     int RECTANGULAR_NODE_STYLE_DESCRIPTION__SHOW_ICON = NODE_STYLE_DESCRIPTION__SHOW_ICON;
 
     /**
+     * The feature id for the '<em><b>Label Icon</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int RECTANGULAR_NODE_STYLE_DESCRIPTION__LABEL_ICON = NODE_STYLE_DESCRIPTION__LABEL_ICON;
+
+    /**
      * The feature id for the '<em><b>With Header</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @generated
@@ -1219,6 +1235,14 @@ public interface DiagramPackage extends EPackage {
      * @ordered
      */
     int IMAGE_NODE_STYLE_DESCRIPTION__SHOW_ICON = NODE_STYLE_DESCRIPTION__SHOW_ICON;
+
+    /**
+     * The feature id for the '<em><b>Label Icon</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int IMAGE_NODE_STYLE_DESCRIPTION__LABEL_ICON = NODE_STYLE_DESCRIPTION__LABEL_ICON;
 
     /**
      * The feature id for the '<em><b>Shape</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1373,6 +1397,14 @@ public interface DiagramPackage extends EPackage {
     int ICON_LABEL_NODE_STYLE_DESCRIPTION__SHOW_ICON = NODE_STYLE_DESCRIPTION__SHOW_ICON;
 
     /**
+     * The feature id for the '<em><b>Label Icon</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int ICON_LABEL_NODE_STYLE_DESCRIPTION__LABEL_ICON = NODE_STYLE_DESCRIPTION__LABEL_ICON;
+
+    /**
      * The number of structural features of the '<em>Icon Label Node Style Description</em>' class. <!-- begin-user-doc
      * --> <!-- end-user-doc -->
      *
@@ -1491,13 +1523,21 @@ public interface DiagramPackage extends EPackage {
     int EDGE_STYLE__SHOW_ICON = STYLE_FEATURE_COUNT + 9;
 
     /**
+     * The feature id for the '<em><b>Label Icon</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int EDGE_STYLE__LABEL_ICON = STYLE_FEATURE_COUNT + 10;
+
+    /**
      * The number of structural features of the '<em>Edge Style</em>' class. <!-- begin-user-doc --> <!-- end-user-doc
      * -->
      *
      * @generated
      * @ordered
      */
-    int EDGE_STYLE_FEATURE_COUNT = STYLE_FEATURE_COUNT + 10;
+    int EDGE_STYLE_FEATURE_COUNT = STYLE_FEATURE_COUNT + 11;
 
     /**
      * The number of operations of the '<em>Edge Style</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1616,13 +1656,21 @@ public interface DiagramPackage extends EPackage {
     int CONDITIONAL_EDGE_STYLE__SHOW_ICON = ViewPackage.CONDITIONAL_FEATURE_COUNT + 10;
 
     /**
+     * The feature id for the '<em><b>Label Icon</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int CONDITIONAL_EDGE_STYLE__LABEL_ICON = ViewPackage.CONDITIONAL_FEATURE_COUNT + 11;
+
+    /**
      * The number of structural features of the '<em>Conditional Edge Style</em>' class. <!-- begin-user-doc --> <!--
      * end-user-doc -->
      *
      * @generated
      * @ordered
      */
-    int CONDITIONAL_EDGE_STYLE_FEATURE_COUNT = ViewPackage.CONDITIONAL_FEATURE_COUNT + 11;
+    int CONDITIONAL_EDGE_STYLE_FEATURE_COUNT = ViewPackage.CONDITIONAL_FEATURE_COUNT + 12;
 
     /**
      * The number of operations of the '<em>Conditional Edge Style</em>' class. <!-- begin-user-doc --> <!--
@@ -3322,6 +3370,18 @@ public interface DiagramPackage extends EPackage {
     EAttribute getNodeStyleDescription_ShowIcon();
 
     /**
+     * Returns the meta object for the attribute
+     * '{@link org.eclipse.sirius.components.view.diagram.NodeStyleDescription#getLabelIcon <em>Label Icon</em>}'. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the meta object for the attribute '<em>Label Icon</em>'.
+     * @see org.eclipse.sirius.components.view.diagram.NodeStyleDescription#getLabelIcon()
+     * @see #getNodeStyleDescription()
+     * @generated
+     */
+    EAttribute getNodeStyleDescription_LabelIcon();
+
+    /**
      * Returns the meta object for class '{@link org.eclipse.sirius.components.view.diagram.ConditionalNodeStyle
      * <em>Conditional Node Style</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
@@ -3467,6 +3527,18 @@ public interface DiagramPackage extends EPackage {
      * @generated
      */
     EAttribute getEdgeStyle_ShowIcon();
+
+    /**
+     * Returns the meta object for the attribute
+     * '{@link org.eclipse.sirius.components.view.diagram.EdgeStyle#getLabelIcon <em>Label Icon</em>}'. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the meta object for the attribute '<em>Label Icon</em>'.
+     * @see org.eclipse.sirius.components.view.diagram.EdgeStyle#getLabelIcon()
+     * @see #getEdgeStyle()
+     * @generated
+     */
+    EAttribute getEdgeStyle_LabelIcon();
 
     /**
      * Returns the meta object for class '{@link org.eclipse.sirius.components.view.diagram.ConditionalEdgeStyle
@@ -4565,6 +4637,14 @@ public interface DiagramPackage extends EPackage {
         EAttribute NODE_STYLE_DESCRIPTION__SHOW_ICON = eINSTANCE.getNodeStyleDescription_ShowIcon();
 
         /**
+         * The meta object literal for the '<em><b>Label Icon</b></em>' attribute feature. <!-- begin-user-doc --> <!--
+         * end-user-doc -->
+         *
+         * @generated
+         */
+        EAttribute NODE_STYLE_DESCRIPTION__LABEL_ICON = eINSTANCE.getNodeStyleDescription_LabelIcon();
+
+        /**
          * The meta object literal for the
          * '{@link org.eclipse.sirius.components.view.diagram.impl.ConditionalNodeStyleImpl <em>Conditional Node
          * Style</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -4681,6 +4761,14 @@ public interface DiagramPackage extends EPackage {
          * @generated
          */
         EAttribute EDGE_STYLE__SHOW_ICON = eINSTANCE.getEdgeStyle_ShowIcon();
+
+        /**
+         * The meta object literal for the '<em><b>Label Icon</b></em>' attribute feature. <!-- begin-user-doc --> <!--
+         * end-user-doc -->
+         *
+         * @generated
+         */
+        EAttribute EDGE_STYLE__LABEL_ICON = eINSTANCE.getEdgeStyle_LabelIcon();
 
         /**
          * The meta object literal for the

--- a/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/EdgeStyle.java
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/EdgeStyle.java
@@ -26,6 +26,7 @@ import org.eclipse.sirius.components.view.LabelStyle;
  * <li>{@link org.eclipse.sirius.components.view.diagram.EdgeStyle#getTargetArrowStyle <em>Target Arrow Style</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.EdgeStyle#getEdgeWidth <em>Edge Width</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.EdgeStyle#isShowIcon <em>Show Icon</em>}</li>
+ * <li>{@link org.eclipse.sirius.components.view.diagram.EdgeStyle#getLabelIcon <em>Label Icon</em>}</li>
  * </ul>
  *
  * @see org.eclipse.sirius.components.view.diagram.DiagramPackage#getEdgeStyle()
@@ -156,5 +157,27 @@ public interface EdgeStyle extends Style, LabelStyle {
      * @generated
      */
     void setShowIcon(boolean value);
+
+    /**
+     * Returns the value of the '<em><b>Label Icon</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the value of the '<em>Label Icon</em>' attribute.
+     * @see #setLabelIcon(String)
+     * @see org.eclipse.sirius.components.view.diagram.DiagramPackage#getEdgeStyle_LabelIcon()
+     * @model
+     * @generated
+     */
+    String getLabelIcon();
+
+    /**
+     * Sets the value of the '{@link org.eclipse.sirius.components.view.diagram.EdgeStyle#getLabelIcon <em>Label
+     * Icon</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @param value
+     *            the new value of the '<em>Label Icon</em>' attribute.
+     * @see #getLabelIcon()
+     * @generated
+     */
+    void setLabelIcon(String value);
 
 } // EdgeStyle

--- a/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/NodeStyleDescription.java
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/NodeStyleDescription.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.components.view.UserColor;
  * <li>{@link org.eclipse.sirius.components.view.diagram.NodeStyleDescription#getHeightComputationExpression <em>Height
  * Computation Expression</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.NodeStyleDescription#isShowIcon <em>Show Icon</em>}</li>
+ * <li>{@link org.eclipse.sirius.components.view.diagram.NodeStyleDescription#getLabelIcon <em>Label Icon</em>}</li>
  * </ul>
  *
  * @see org.eclipse.sirius.components.view.diagram.DiagramPackage#getNodeStyleDescription()
@@ -127,5 +128,27 @@ public interface NodeStyleDescription extends Style, LabelStyle, BorderStyle {
      * @generated
      */
     void setShowIcon(boolean value);
+
+    /**
+     * Returns the value of the '<em><b>Label Icon</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the value of the '<em>Label Icon</em>' attribute.
+     * @see #setLabelIcon(String)
+     * @see org.eclipse.sirius.components.view.diagram.DiagramPackage#getNodeStyleDescription_LabelIcon()
+     * @model
+     * @generated
+     */
+    String getLabelIcon();
+
+    /**
+     * Sets the value of the '{@link org.eclipse.sirius.components.view.diagram.NodeStyleDescription#getLabelIcon
+     * <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @param value
+     *            the new value of the '<em>Label Icon</em>' attribute.
+     * @see #getLabelIcon()
+     * @generated
+     */
+    void setLabelIcon(String value);
 
 } // NodeStyleDescription

--- a/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/ConditionalEdgeStyleImpl.java
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/ConditionalEdgeStyleImpl.java
@@ -53,6 +53,8 @@ import org.eclipse.sirius.components.view.impl.ConditionalImpl;
  * Width</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.impl.ConditionalEdgeStyleImpl#isShowIcon <em>Show
  * Icon</em>}</li>
+ * <li>{@link org.eclipse.sirius.components.view.diagram.impl.ConditionalEdgeStyleImpl#getLabelIcon <em>Label
+ * Icon</em>}</li>
  * </ul>
  *
  * @generated
@@ -267,6 +269,26 @@ public class ConditionalEdgeStyleImpl extends ConditionalImpl implements Conditi
      * @ordered
      */
     protected boolean showIcon = SHOW_ICON_EDEFAULT;
+
+    /**
+     * The default value of the '{@link #getLabelIcon() <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getLabelIcon()
+     * @generated
+     * @ordered
+     */
+    protected static final String LABEL_ICON_EDEFAULT = null;
+
+    /**
+     * The cached value of the '{@link #getLabelIcon() <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getLabelIcon()
+     * @generated
+     * @ordered
+     */
+    protected String labelIcon = LABEL_ICON_EDEFAULT;
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -563,6 +585,29 @@ public class ConditionalEdgeStyleImpl extends ConditionalImpl implements Conditi
      * @generated
      */
     @Override
+    public String getLabelIcon() {
+        return this.labelIcon;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void setLabelIcon(String newLabelIcon) {
+        String oldLabelIcon = this.labelIcon;
+        this.labelIcon = newLabelIcon;
+        if (this.eNotificationRequired())
+            this.eNotify(new ENotificationImpl(this, Notification.SET, DiagramPackage.CONDITIONAL_EDGE_STYLE__LABEL_ICON, oldLabelIcon, this.labelIcon));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
         switch (featureID) {
             case DiagramPackage.CONDITIONAL_EDGE_STYLE__COLOR:
@@ -589,6 +634,8 @@ public class ConditionalEdgeStyleImpl extends ConditionalImpl implements Conditi
                 return this.getEdgeWidth();
             case DiagramPackage.CONDITIONAL_EDGE_STYLE__SHOW_ICON:
                 return this.isShowIcon();
+            case DiagramPackage.CONDITIONAL_EDGE_STYLE__LABEL_ICON:
+                return this.getLabelIcon();
         }
         return super.eGet(featureID, resolve, coreType);
     }
@@ -633,6 +680,9 @@ public class ConditionalEdgeStyleImpl extends ConditionalImpl implements Conditi
                 return;
             case DiagramPackage.CONDITIONAL_EDGE_STYLE__SHOW_ICON:
                 this.setShowIcon((Boolean) newValue);
+                return;
+            case DiagramPackage.CONDITIONAL_EDGE_STYLE__LABEL_ICON:
+                this.setLabelIcon((String) newValue);
                 return;
         }
         super.eSet(featureID, newValue);
@@ -679,6 +729,9 @@ public class ConditionalEdgeStyleImpl extends ConditionalImpl implements Conditi
             case DiagramPackage.CONDITIONAL_EDGE_STYLE__SHOW_ICON:
                 this.setShowIcon(SHOW_ICON_EDEFAULT);
                 return;
+            case DiagramPackage.CONDITIONAL_EDGE_STYLE__LABEL_ICON:
+                this.setLabelIcon(LABEL_ICON_EDEFAULT);
+                return;
         }
         super.eUnset(featureID);
     }
@@ -713,6 +766,8 @@ public class ConditionalEdgeStyleImpl extends ConditionalImpl implements Conditi
                 return this.edgeWidth != EDGE_WIDTH_EDEFAULT;
             case DiagramPackage.CONDITIONAL_EDGE_STYLE__SHOW_ICON:
                 return this.showIcon != SHOW_ICON_EDEFAULT;
+            case DiagramPackage.CONDITIONAL_EDGE_STYLE__LABEL_ICON:
+                return LABEL_ICON_EDEFAULT == null ? this.labelIcon != null : !LABEL_ICON_EDEFAULT.equals(this.labelIcon);
         }
         return super.eIsSet(featureID);
     }
@@ -760,6 +815,8 @@ public class ConditionalEdgeStyleImpl extends ConditionalImpl implements Conditi
                     return DiagramPackage.EDGE_STYLE__EDGE_WIDTH;
                 case DiagramPackage.CONDITIONAL_EDGE_STYLE__SHOW_ICON:
                     return DiagramPackage.EDGE_STYLE__SHOW_ICON;
+                case DiagramPackage.CONDITIONAL_EDGE_STYLE__LABEL_ICON:
+                    return DiagramPackage.EDGE_STYLE__LABEL_ICON;
                 default:
                     return -1;
             }
@@ -810,6 +867,8 @@ public class ConditionalEdgeStyleImpl extends ConditionalImpl implements Conditi
                     return DiagramPackage.CONDITIONAL_EDGE_STYLE__EDGE_WIDTH;
                 case DiagramPackage.EDGE_STYLE__SHOW_ICON:
                     return DiagramPackage.CONDITIONAL_EDGE_STYLE__SHOW_ICON;
+                case DiagramPackage.EDGE_STYLE__LABEL_ICON:
+                    return DiagramPackage.CONDITIONAL_EDGE_STYLE__LABEL_ICON;
                 default:
                     return -1;
             }
@@ -848,6 +907,8 @@ public class ConditionalEdgeStyleImpl extends ConditionalImpl implements Conditi
         result.append(this.edgeWidth);
         result.append(", showIcon: ");
         result.append(this.showIcon);
+        result.append(", labelIcon: ");
+        result.append(this.labelIcon);
         result.append(')');
         return result.toString();
     }

--- a/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/DiagramPackageImpl.java
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/DiagramPackageImpl.java
@@ -908,6 +908,16 @@ public class DiagramPackageImpl extends EPackageImpl implements DiagramPackage {
      * @generated
      */
     @Override
+    public EAttribute getNodeStyleDescription_LabelIcon() {
+        return (EAttribute) this.nodeStyleDescriptionEClass.getEStructuralFeatures().get(4);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public EClass getConditionalNodeStyle() {
         return this.conditionalNodeStyleEClass;
     }
@@ -1030,6 +1040,16 @@ public class DiagramPackageImpl extends EPackageImpl implements DiagramPackage {
     @Override
     public EAttribute getEdgeStyle_ShowIcon() {
         return (EAttribute) this.edgeStyleEClass.getEStructuralFeatures().get(4);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public EAttribute getEdgeStyle_LabelIcon() {
+        return (EAttribute) this.edgeStyleEClass.getEStructuralFeatures().get(5);
     }
 
     /**
@@ -1709,6 +1729,7 @@ public class DiagramPackageImpl extends EPackageImpl implements DiagramPackage {
         this.createEAttribute(this.nodeStyleDescriptionEClass, NODE_STYLE_DESCRIPTION__WIDTH_COMPUTATION_EXPRESSION);
         this.createEAttribute(this.nodeStyleDescriptionEClass, NODE_STYLE_DESCRIPTION__HEIGHT_COMPUTATION_EXPRESSION);
         this.createEAttribute(this.nodeStyleDescriptionEClass, NODE_STYLE_DESCRIPTION__SHOW_ICON);
+        this.createEAttribute(this.nodeStyleDescriptionEClass, NODE_STYLE_DESCRIPTION__LABEL_ICON);
 
         this.conditionalNodeStyleEClass = this.createEClass(CONDITIONAL_NODE_STYLE);
         this.createEReference(this.conditionalNodeStyleEClass, CONDITIONAL_NODE_STYLE__STYLE);
@@ -1727,6 +1748,7 @@ public class DiagramPackageImpl extends EPackageImpl implements DiagramPackage {
         this.createEAttribute(this.edgeStyleEClass, EDGE_STYLE__TARGET_ARROW_STYLE);
         this.createEAttribute(this.edgeStyleEClass, EDGE_STYLE__EDGE_WIDTH);
         this.createEAttribute(this.edgeStyleEClass, EDGE_STYLE__SHOW_ICON);
+        this.createEAttribute(this.edgeStyleEClass, EDGE_STYLE__LABEL_ICON);
 
         this.conditionalEdgeStyleEClass = this.createEClass(CONDITIONAL_EDGE_STYLE);
 
@@ -1970,6 +1992,8 @@ public class DiagramPackageImpl extends EPackageImpl implements DiagramPackage {
                 !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         this.initEAttribute(this.getNodeStyleDescription_ShowIcon(), this.ecorePackage.getEBoolean(), "showIcon", null, 0, 1, NodeStyleDescription.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
                 !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getNodeStyleDescription_LabelIcon(), this.ecorePackage.getEString(), "labelIcon", null, 0, 1, NodeStyleDescription.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
+                !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.conditionalNodeStyleEClass, ConditionalNodeStyle.class, "ConditionalNodeStyle", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
         this.initEReference(this.getConditionalNodeStyle_Style(), this.getNodeStyleDescription(), null, "style", null, 0, 1, ConditionalNodeStyle.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
@@ -1996,6 +2020,8 @@ public class DiagramPackageImpl extends EPackageImpl implements DiagramPackage {
                 IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         this.initEAttribute(this.getEdgeStyle_ShowIcon(), this.ecorePackage.getEBoolean(), "showIcon", "false", 0, 1, EdgeStyle.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE,
                 !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getEdgeStyle_LabelIcon(), this.ecorePackage.getEString(), "labelIcon", null, 0, 1, EdgeStyle.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID,
+                IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.conditionalEdgeStyleEClass, ConditionalEdgeStyle.class, "ConditionalEdgeStyle", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 

--- a/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/EdgeStyleImpl.java
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/EdgeStyleImpl.java
@@ -41,6 +41,7 @@ import org.eclipse.sirius.components.view.diagram.LineStyle;
  * Style</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.impl.EdgeStyleImpl#getEdgeWidth <em>Edge Width</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.impl.EdgeStyleImpl#isShowIcon <em>Show Icon</em>}</li>
+ * <li>{@link org.eclipse.sirius.components.view.diagram.impl.EdgeStyleImpl#getLabelIcon <em>Label Icon</em>}</li>
  * </ul>
  *
  * @generated
@@ -245,6 +246,26 @@ public class EdgeStyleImpl extends StyleImpl implements EdgeStyle {
      * @ordered
      */
     protected boolean showIcon = SHOW_ICON_EDEFAULT;
+
+    /**
+     * The default value of the '{@link #getLabelIcon() <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getLabelIcon()
+     * @generated
+     * @ordered
+     */
+    protected static final String LABEL_ICON_EDEFAULT = null;
+
+    /**
+     * The cached value of the '{@link #getLabelIcon() <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getLabelIcon()
+     * @generated
+     * @ordered
+     */
+    protected String labelIcon = LABEL_ICON_EDEFAULT;
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -501,6 +522,29 @@ public class EdgeStyleImpl extends StyleImpl implements EdgeStyle {
      * @generated
      */
     @Override
+    public String getLabelIcon() {
+        return this.labelIcon;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void setLabelIcon(String newLabelIcon) {
+        String oldLabelIcon = this.labelIcon;
+        this.labelIcon = newLabelIcon;
+        if (this.eNotificationRequired())
+            this.eNotify(new ENotificationImpl(this, Notification.SET, DiagramPackage.EDGE_STYLE__LABEL_ICON, oldLabelIcon, this.labelIcon));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
         switch (featureID) {
             case DiagramPackage.EDGE_STYLE__FONT_SIZE:
@@ -523,6 +567,8 @@ public class EdgeStyleImpl extends StyleImpl implements EdgeStyle {
                 return this.getEdgeWidth();
             case DiagramPackage.EDGE_STYLE__SHOW_ICON:
                 return this.isShowIcon();
+            case DiagramPackage.EDGE_STYLE__LABEL_ICON:
+                return this.getLabelIcon();
         }
         return super.eGet(featureID, resolve, coreType);
     }
@@ -564,6 +610,9 @@ public class EdgeStyleImpl extends StyleImpl implements EdgeStyle {
                 return;
             case DiagramPackage.EDGE_STYLE__SHOW_ICON:
                 this.setShowIcon((Boolean) newValue);
+                return;
+            case DiagramPackage.EDGE_STYLE__LABEL_ICON:
+                this.setLabelIcon((String) newValue);
                 return;
         }
         super.eSet(featureID, newValue);
@@ -607,6 +656,9 @@ public class EdgeStyleImpl extends StyleImpl implements EdgeStyle {
             case DiagramPackage.EDGE_STYLE__SHOW_ICON:
                 this.setShowIcon(SHOW_ICON_EDEFAULT);
                 return;
+            case DiagramPackage.EDGE_STYLE__LABEL_ICON:
+                this.setLabelIcon(LABEL_ICON_EDEFAULT);
+                return;
         }
         super.eUnset(featureID);
     }
@@ -639,6 +691,8 @@ public class EdgeStyleImpl extends StyleImpl implements EdgeStyle {
                 return this.edgeWidth != EDGE_WIDTH_EDEFAULT;
             case DiagramPackage.EDGE_STYLE__SHOW_ICON:
                 return this.showIcon != SHOW_ICON_EDEFAULT;
+            case DiagramPackage.EDGE_STYLE__LABEL_ICON:
+                return LABEL_ICON_EDEFAULT == null ? this.labelIcon != null : !LABEL_ICON_EDEFAULT.equals(this.labelIcon);
         }
         return super.eIsSet(featureID);
     }
@@ -726,6 +780,8 @@ public class EdgeStyleImpl extends StyleImpl implements EdgeStyle {
         result.append(this.edgeWidth);
         result.append(", showIcon: ");
         result.append(this.showIcon);
+        result.append(", labelIcon: ");
+        result.append(this.labelIcon);
         result.append(')');
         return result.toString();
     }

--- a/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/IconLabelNodeStyleDescriptionImpl.java
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/IconLabelNodeStyleDescriptionImpl.java
@@ -57,6 +57,8 @@ import org.eclipse.sirius.components.view.diagram.LineStyle;
  * <em>Height Computation Expression</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.impl.IconLabelNodeStyleDescriptionImpl#isShowIcon <em>Show
  * Icon</em>}</li>
+ * <li>{@link org.eclipse.sirius.components.view.diagram.impl.IconLabelNodeStyleDescriptionImpl#getLabelIcon <em>Label
+ * Icon</em>}</li>
  * </ul>
  *
  * @generated
@@ -301,6 +303,26 @@ public class IconLabelNodeStyleDescriptionImpl extends StyleImpl implements Icon
      * @ordered
      */
     protected boolean showIcon = SHOW_ICON_EDEFAULT;
+
+    /**
+     * The default value of the '{@link #getLabelIcon() <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getLabelIcon()
+     * @generated
+     * @ordered
+     */
+    protected static final String LABEL_ICON_EDEFAULT = null;
+
+    /**
+     * The cached value of the '{@link #getLabelIcon() <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getLabelIcon()
+     * @generated
+     * @ordered
+     */
+    protected String labelIcon = LABEL_ICON_EDEFAULT;
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -662,6 +684,29 @@ public class IconLabelNodeStyleDescriptionImpl extends StyleImpl implements Icon
      * @generated
      */
     @Override
+    public String getLabelIcon() {
+        return this.labelIcon;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void setLabelIcon(String newLabelIcon) {
+        String oldLabelIcon = this.labelIcon;
+        this.labelIcon = newLabelIcon;
+        if (this.eNotificationRequired())
+            this.eNotify(new ENotificationImpl(this, Notification.SET, DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__LABEL_ICON, oldLabelIcon, this.labelIcon));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
         switch (featureID) {
             case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__FONT_SIZE:
@@ -694,6 +739,8 @@ public class IconLabelNodeStyleDescriptionImpl extends StyleImpl implements Icon
                 return this.getHeightComputationExpression();
             case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 return this.isShowIcon();
+            case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                return this.getLabelIcon();
         }
         return super.eGet(featureID, resolve, coreType);
     }
@@ -744,6 +791,9 @@ public class IconLabelNodeStyleDescriptionImpl extends StyleImpl implements Icon
                 return;
             case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 this.setShowIcon((Boolean) newValue);
+                return;
+            case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                this.setLabelIcon((String) newValue);
                 return;
         }
         super.eSet(featureID, newValue);
@@ -796,6 +846,9 @@ public class IconLabelNodeStyleDescriptionImpl extends StyleImpl implements Icon
             case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 this.setShowIcon(SHOW_ICON_EDEFAULT);
                 return;
+            case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                this.setLabelIcon(LABEL_ICON_EDEFAULT);
+                return;
         }
         super.eUnset(featureID);
     }
@@ -834,6 +887,8 @@ public class IconLabelNodeStyleDescriptionImpl extends StyleImpl implements Icon
                 return HEIGHT_COMPUTATION_EXPRESSION_EDEFAULT == null ? this.heightComputationExpression != null : !HEIGHT_COMPUTATION_EXPRESSION_EDEFAULT.equals(this.heightComputationExpression);
             case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 return this.showIcon != SHOW_ICON_EDEFAULT;
+            case DiagramPackage.ICON_LABEL_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                return LABEL_ICON_EDEFAULT == null ? this.labelIcon != null : !LABEL_ICON_EDEFAULT.equals(this.labelIcon);
         }
         return super.eIsSet(featureID);
     }
@@ -951,6 +1006,8 @@ public class IconLabelNodeStyleDescriptionImpl extends StyleImpl implements Icon
         result.append(this.heightComputationExpression);
         result.append(", showIcon: ");
         result.append(this.showIcon);
+        result.append(", labelIcon: ");
+        result.append(this.labelIcon);
         result.append(')');
         return result.toString();
     }

--- a/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/ImageNodeStyleDescriptionImpl.java
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/ImageNodeStyleDescriptionImpl.java
@@ -56,6 +56,8 @@ import org.eclipse.sirius.components.view.diagram.LineStyle;
  * <em>Height Computation Expression</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.impl.ImageNodeStyleDescriptionImpl#isShowIcon <em>Show
  * Icon</em>}</li>
+ * <li>{@link org.eclipse.sirius.components.view.diagram.impl.ImageNodeStyleDescriptionImpl#getLabelIcon <em>Label
+ * Icon</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.impl.ImageNodeStyleDescriptionImpl#getShape
  * <em>Shape</em>}</li>
  * </ul>
@@ -302,6 +304,26 @@ public class ImageNodeStyleDescriptionImpl extends StyleImpl implements ImageNod
      * @ordered
      */
     protected boolean showIcon = SHOW_ICON_EDEFAULT;
+
+    /**
+     * The default value of the '{@link #getLabelIcon() <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getLabelIcon()
+     * @generated
+     * @ordered
+     */
+    protected static final String LABEL_ICON_EDEFAULT = null;
+
+    /**
+     * The cached value of the '{@link #getLabelIcon() <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getLabelIcon()
+     * @generated
+     * @ordered
+     */
+    protected String labelIcon = LABEL_ICON_EDEFAULT;
 
     /**
      * The default value of the '{@link #getShape() <em>Shape</em>}' attribute. <!-- begin-user-doc --> <!--
@@ -683,6 +705,29 @@ public class ImageNodeStyleDescriptionImpl extends StyleImpl implements ImageNod
      * @generated
      */
     @Override
+    public String getLabelIcon() {
+        return this.labelIcon;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void setLabelIcon(String newLabelIcon) {
+        String oldLabelIcon = this.labelIcon;
+        this.labelIcon = newLabelIcon;
+        if (this.eNotificationRequired())
+            this.eNotify(new ENotificationImpl(this, Notification.SET, DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__LABEL_ICON, oldLabelIcon, this.labelIcon));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public String getShape() {
         return this.shape;
     }
@@ -738,6 +783,8 @@ public class ImageNodeStyleDescriptionImpl extends StyleImpl implements ImageNod
                 return this.getHeightComputationExpression();
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 return this.isShowIcon();
+            case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                return this.getLabelIcon();
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__SHAPE:
                 return this.getShape();
         }
@@ -790,6 +837,9 @@ public class ImageNodeStyleDescriptionImpl extends StyleImpl implements ImageNod
                 return;
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 this.setShowIcon((Boolean) newValue);
+                return;
+            case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                this.setLabelIcon((String) newValue);
                 return;
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__SHAPE:
                 this.setShape((String) newValue);
@@ -845,6 +895,9 @@ public class ImageNodeStyleDescriptionImpl extends StyleImpl implements ImageNod
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 this.setShowIcon(SHOW_ICON_EDEFAULT);
                 return;
+            case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                this.setLabelIcon(LABEL_ICON_EDEFAULT);
+                return;
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__SHAPE:
                 this.setShape(SHAPE_EDEFAULT);
                 return;
@@ -886,6 +939,8 @@ public class ImageNodeStyleDescriptionImpl extends StyleImpl implements ImageNod
                 return HEIGHT_COMPUTATION_EXPRESSION_EDEFAULT == null ? this.heightComputationExpression != null : !HEIGHT_COMPUTATION_EXPRESSION_EDEFAULT.equals(this.heightComputationExpression);
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 return this.showIcon != SHOW_ICON_EDEFAULT;
+            case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                return LABEL_ICON_EDEFAULT == null ? this.labelIcon != null : !LABEL_ICON_EDEFAULT.equals(this.labelIcon);
             case DiagramPackage.IMAGE_NODE_STYLE_DESCRIPTION__SHAPE:
                 return SHAPE_EDEFAULT == null ? this.shape != null : !SHAPE_EDEFAULT.equals(this.shape);
         }
@@ -1005,6 +1060,8 @@ public class ImageNodeStyleDescriptionImpl extends StyleImpl implements ImageNod
         result.append(this.heightComputationExpression);
         result.append(", showIcon: ");
         result.append(this.showIcon);
+        result.append(", labelIcon: ");
+        result.append(this.labelIcon);
         result.append(", shape: ");
         result.append(this.shape);
         result.append(')');

--- a/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/RectangularNodeStyleDescriptionImpl.java
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/java/org/eclipse/sirius/components/view/diagram/impl/RectangularNodeStyleDescriptionImpl.java
@@ -57,6 +57,8 @@ import org.eclipse.sirius.components.view.diagram.RectangularNodeStyleDescriptio
  * <em>Height Computation Expression</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.impl.RectangularNodeStyleDescriptionImpl#isShowIcon <em>Show
  * Icon</em>}</li>
+ * <li>{@link org.eclipse.sirius.components.view.diagram.impl.RectangularNodeStyleDescriptionImpl#getLabelIcon <em>Label
+ * Icon</em>}</li>
  * <li>{@link org.eclipse.sirius.components.view.diagram.impl.RectangularNodeStyleDescriptionImpl#isWithHeader <em>With
  * Header</em>}</li>
  * </ul>
@@ -303,6 +305,26 @@ public class RectangularNodeStyleDescriptionImpl extends StyleImpl implements Re
      * @ordered
      */
     protected boolean showIcon = SHOW_ICON_EDEFAULT;
+
+    /**
+     * The default value of the '{@link #getLabelIcon() <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getLabelIcon()
+     * @generated
+     * @ordered
+     */
+    protected static final String LABEL_ICON_EDEFAULT = null;
+
+    /**
+     * The cached value of the '{@link #getLabelIcon() <em>Label Icon</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getLabelIcon()
+     * @generated
+     * @ordered
+     */
+    protected String labelIcon = LABEL_ICON_EDEFAULT;
 
     /**
      * The default value of the '{@link #isWithHeader() <em>With Header</em>}' attribute. <!-- begin-user-doc --> <!--
@@ -684,6 +706,29 @@ public class RectangularNodeStyleDescriptionImpl extends StyleImpl implements Re
      * @generated
      */
     @Override
+    public String getLabelIcon() {
+        return this.labelIcon;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void setLabelIcon(String newLabelIcon) {
+        String oldLabelIcon = this.labelIcon;
+        this.labelIcon = newLabelIcon;
+        if (this.eNotificationRequired())
+            this.eNotify(new ENotificationImpl(this, Notification.SET, DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__LABEL_ICON, oldLabelIcon, this.labelIcon));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public boolean isWithHeader() {
         return this.withHeader;
     }
@@ -739,6 +784,8 @@ public class RectangularNodeStyleDescriptionImpl extends StyleImpl implements Re
                 return this.getHeightComputationExpression();
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 return this.isShowIcon();
+            case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                return this.getLabelIcon();
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__WITH_HEADER:
                 return this.isWithHeader();
         }
@@ -791,6 +838,9 @@ public class RectangularNodeStyleDescriptionImpl extends StyleImpl implements Re
                 return;
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 this.setShowIcon((Boolean) newValue);
+                return;
+            case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                this.setLabelIcon((String) newValue);
                 return;
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__WITH_HEADER:
                 this.setWithHeader((Boolean) newValue);
@@ -846,6 +896,9 @@ public class RectangularNodeStyleDescriptionImpl extends StyleImpl implements Re
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 this.setShowIcon(SHOW_ICON_EDEFAULT);
                 return;
+            case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                this.setLabelIcon(LABEL_ICON_EDEFAULT);
+                return;
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__WITH_HEADER:
                 this.setWithHeader(WITH_HEADER_EDEFAULT);
                 return;
@@ -887,6 +940,8 @@ public class RectangularNodeStyleDescriptionImpl extends StyleImpl implements Re
                 return HEIGHT_COMPUTATION_EXPRESSION_EDEFAULT == null ? this.heightComputationExpression != null : !HEIGHT_COMPUTATION_EXPRESSION_EDEFAULT.equals(this.heightComputationExpression);
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__SHOW_ICON:
                 return this.showIcon != SHOW_ICON_EDEFAULT;
+            case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__LABEL_ICON:
+                return LABEL_ICON_EDEFAULT == null ? this.labelIcon != null : !LABEL_ICON_EDEFAULT.equals(this.labelIcon);
             case DiagramPackage.RECTANGULAR_NODE_STYLE_DESCRIPTION__WITH_HEADER:
                 return this.withHeader != WITH_HEADER_EDEFAULT;
         }
@@ -1006,6 +1061,8 @@ public class RectangularNodeStyleDescriptionImpl extends StyleImpl implements Re
         result.append(this.heightComputationExpression);
         result.append(", showIcon: ");
         result.append(this.showIcon);
+        result.append(", labelIcon: ");
+        result.append(this.labelIcon);
         result.append(", withHeader: ");
         result.append(this.withHeader);
         result.append(')');

--- a/packages/view/backend/sirius-components-view-diagram/src/main/resources/model/diagram.ecore
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/resources/model/diagram.ecore
@@ -131,6 +131,7 @@
         eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"
         defaultValueLiteral="1"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="showIcon" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="labelIcon" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ConditionalNodeStyle" eSuperTypes="../../../../../sirius-components-view/src/main/resources/model/view.ecore#//Conditional">
     <eStructuralFeatures xsi:type="ecore:EReference" name="style" eType="#//NodeStyleDescription"
@@ -155,6 +156,7 @@
         defaultValueLiteral="1"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="showIcon" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
         defaultValueLiteral="false"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="labelIcon" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ConditionalEdgeStyle" eSuperTypes="../../../../../sirius-components-view/src/main/resources/model/view.ecore#//Conditional #//EdgeStyle"/>
   <eClassifiers xsi:type="ecore:EClass" name="DiagramPalette">

--- a/packages/view/backend/sirius-components-view-diagram/src/main/resources/model/diagram.genmodel
+++ b/packages/view/backend/sirius-components-view-diagram/src/main/resources/model/diagram.genmodel
@@ -104,6 +104,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute diagram.ecore#//NodeStyleDescription/widthComputationExpression"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute diagram.ecore#//NodeStyleDescription/heightComputationExpression"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute diagram.ecore#//NodeStyleDescription/showIcon"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute diagram.ecore#//NodeStyleDescription/labelIcon"/>
     </genClasses>
     <genClasses ecoreClass="diagram.ecore#//ConditionalNodeStyle">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference diagram.ecore#//ConditionalNodeStyle/style"/>
@@ -121,6 +122,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute diagram.ecore#//EdgeStyle/targetArrowStyle"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute diagram.ecore#//EdgeStyle/edgeWidth"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute diagram.ecore#//EdgeStyle/showIcon"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute diagram.ecore#//EdgeStyle/labelIcon"/>
     </genClasses>
     <genClasses ecoreClass="diagram.ecore#//ConditionalEdgeStyle"/>
     <genClasses ecoreClass="diagram.ecore#//DiagramPalette">

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/ViewPropertiesDescriptionRegistryConfigurer.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/ViewPropertiesDescriptionRegistryConfigurer.java
@@ -73,7 +73,8 @@ public class ViewPropertiesDescriptionRegistryConfigurer implements IPropertiesD
     private static final List<EClass> TYPES_WITH_CUSTOM_PROPERTIES = List.of(
             DiagramPackage.Literals.IMAGE_NODE_STYLE_DESCRIPTION,
             DiagramPackage.Literals.ICON_LABEL_NODE_STYLE_DESCRIPTION,
-            DiagramPackage.Literals.RECTANGULAR_NODE_STYLE_DESCRIPTION
+            DiagramPackage.Literals.RECTANGULAR_NODE_STYLE_DESCRIPTION,
+            DiagramPackage.Literals.EDGE_STYLE
     );
 
     private final IObjectService objectService;

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/compatibility/IPropertiesConfigurerService.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/compatibility/IPropertiesConfigurerService.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.view.emf.compatibility;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.eclipse.sirius.components.representations.VariableManager;
+
+/**
+ * Configuration for the properties view for some of the View DSL elements.
+ *
+ * @author mcharfadi
+ */
+public interface IPropertiesConfigurerService {
+
+    Function<VariableManager, String> getSemanticTargetIdProvider();
+    Function<VariableManager, List<?>> getSemanticElementsProvider();
+    Function<VariableManager, List<?>> getDiagnosticsProvider(Object feature);
+    Function<Object, String> getKindProvider();
+    Function<Object, String> getMessageProvider();
+}

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/compatibility/IPropertiesWidgetCreationService.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/compatibility/IPropertiesWidgetCreationService.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.view.emf.compatibility;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.eclipse.sirius.components.forms.description.AbstractControlDescription;
+import org.eclipse.sirius.components.forms.description.CheckboxDescription;
+import org.eclipse.sirius.components.forms.description.GroupDescription;
+import org.eclipse.sirius.components.forms.description.PageDescription;
+import org.eclipse.sirius.components.forms.description.TextareaDescription;
+import org.eclipse.sirius.components.forms.description.TextfieldDescription;
+import org.eclipse.sirius.components.representations.VariableManager;
+import org.eclipse.sirius.components.widget.reference.ReferenceWidgetDescription;
+
+/**
+ * Customizes the properties view for some of the View DSL elements.
+ *
+ * @author mcharfadi
+ */
+public interface IPropertiesWidgetCreationService {
+
+    PageDescription createSimplePageDescription(String id, GroupDescription groupDescription, Predicate<VariableManager> canCreatePredicate);
+
+    GroupDescription createSimpleGroupDescription(List<AbstractControlDescription> controls);
+
+    CheckboxDescription createCheckbox(String id, String title, Function<Object, Boolean> reader, BiConsumer<Object, Boolean> writer, Object feature,  Optional<Function<VariableManager, String>> helpTextProvider);
+
+    TextareaDescription createExpressionField(String id, String title, Function<Object, String> reader, BiConsumer<Object, String> writer, Object feature);
+
+    TextfieldDescription createTextField(String id, String title, Function<Object, String> reader, BiConsumer<Object, String> writer, Object feature);
+
+    ReferenceWidgetDescription createReferenceWidget(String id, String label, Object feature, Function<VariableManager, List<?>> optionsProvider);
+
+}

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/compatibility/PropertiesConfigurerService.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/compatibility/PropertiesConfigurerService.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.view.emf.compatibility;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.components.collaborative.validation.api.IValidationService;
+import org.eclipse.sirius.components.core.api.IObjectService;
+import org.eclipse.sirius.components.representations.VariableManager;
+import org.springframework.stereotype.Service;
+
+/**
+ * Configuration for the properties view for some of the View DSL elements.
+ *
+ * @author mcharfadi
+ */
+@Service
+public class PropertiesConfigurerService implements IPropertiesConfigurerService {
+
+    private final IValidationService validationService;
+
+    private final Function<VariableManager, List<?>> semanticElementsProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class).stream().toList();
+
+    private final Function<VariableManager, String> semanticTargetIdProvider;
+
+    private final IObjectService objectService;
+
+    public PropertiesConfigurerService(IValidationService validationService, IObjectService objectService) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.validationService = Objects.requireNonNull(validationService);
+        this.semanticTargetIdProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class).map(objectService::getId).orElse(null);
+    }
+
+    @Override
+    public Function<VariableManager, List<?>> getSemanticElementsProvider() {
+        return semanticElementsProvider;
+    }
+
+    @Override
+    public Function<VariableManager, String> getSemanticTargetIdProvider() {
+        return semanticTargetIdProvider;
+    }
+    @Override
+    public Function<VariableManager, List<?>> getDiagnosticsProvider(Object feature) {
+        return variableManager -> {
+            var optionalSelf = variableManager.get(VariableManager.SELF, EObject.class);
+
+            if (optionalSelf.isPresent()) {
+                EObject self = optionalSelf.get();
+                return this.validationService.validate(self, feature);
+            }
+
+            return List.of();
+        };
+    }
+
+    @Override
+    public Function<Object, String> getKindProvider() {
+        return object -> {
+            String kind = "Unknown";
+            if (object instanceof Diagnostic diagnostic) {
+                switch (diagnostic.getSeverity()) {
+                    case org.eclipse.emf.common.util.Diagnostic.ERROR:
+                        kind = "Error";
+                        break;
+                    case org.eclipse.emf.common.util.Diagnostic.WARNING:
+                        kind = "Warning";
+                        break;
+                    case org.eclipse.emf.common.util.Diagnostic.INFO:
+                        kind = "Info";
+                        break;
+                    default:
+                        kind = "Unknown";
+                        break;
+                }
+            }
+            return kind;
+        };
+    }
+
+    @Override
+    public Function<Object, String> getMessageProvider() {
+        return object -> {
+            if (object instanceof Diagnostic diagnostic) {
+                return diagnostic.getMessage();
+            }
+            return "";
+        };
+    }
+}

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/compatibility/PropertiesWidgetCreationService.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/compatibility/PropertiesWidgetCreationService.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.view.emf.compatibility;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.sirius.components.core.api.IObjectService;
+import org.eclipse.sirius.components.forms.description.AbstractControlDescription;
+import org.eclipse.sirius.components.forms.description.CheckboxDescription;
+import org.eclipse.sirius.components.forms.description.GroupDescription;
+import org.eclipse.sirius.components.forms.description.PageDescription;
+import org.eclipse.sirius.components.forms.description.TextareaDescription;
+import org.eclipse.sirius.components.forms.description.TextfieldDescription;
+import org.eclipse.sirius.components.representations.Failure;
+import org.eclipse.sirius.components.representations.IStatus;
+import org.eclipse.sirius.components.representations.Success;
+import org.eclipse.sirius.components.representations.VariableManager;
+import org.eclipse.sirius.components.view.emf.AQLTextfieldCustomizer;
+import org.eclipse.sirius.components.widget.reference.ReferenceWidgetComponent;
+import org.eclipse.sirius.components.widget.reference.ReferenceWidgetDescription;
+import org.springframework.stereotype.Service;
+
+/**
+ * Customizes the properties view for some of the View DSL elements.
+ *
+ * @author mcharfadi
+ */
+@Service
+public class PropertiesWidgetCreationService implements IPropertiesWidgetCreationService {
+
+    private static final String EMPTY = "";
+    private final IPropertiesConfigurerService propertiesConfigurerService;
+    private final IObjectService objectService;
+    private final AQLTextfieldCustomizer aqlTextfieldCustomizer;
+    public PropertiesWidgetCreationService(IPropertiesConfigurerService propertiesConfigurerService, IObjectService objectService, AQLTextfieldCustomizer aqlTextfieldCustomizer) {
+        this.propertiesConfigurerService = Objects.requireNonNull(propertiesConfigurerService);
+        this.objectService = Objects.requireNonNull(objectService);
+        this.aqlTextfieldCustomizer = Objects.requireNonNull(aqlTextfieldCustomizer);
+    }
+
+    @Override
+    public PageDescription createSimplePageDescription(String id, GroupDescription groupDescription, Predicate<VariableManager> canCreatePredicate) {
+        return PageDescription.newPageDescription(id)
+                .idProvider(variableManager -> "page")
+                .labelProvider(variableManager -> "Properties")
+                .semanticElementsProvider(this.propertiesConfigurerService.getSemanticElementsProvider())
+                .canCreatePredicate(canCreatePredicate)
+                .groupDescriptions(List.of(groupDescription))
+                .build();
+    }
+
+    @Override
+    public GroupDescription createSimpleGroupDescription(List<AbstractControlDescription> controls) {
+        return GroupDescription.newGroupDescription("group")
+                .idProvider(variableManager -> "group")
+                .labelProvider(variableManager -> "General")
+                .semanticElementsProvider(this.propertiesConfigurerService.getSemanticElementsProvider())
+                .controlDescriptions(controls)
+                .build();
+    }
+
+    @Override
+    public CheckboxDescription createCheckbox(String id, String title, Function<Object, Boolean> reader, BiConsumer<Object, Boolean> writer, Object feature,  Optional<Function<VariableManager, String>> helpTextProvider) {
+        Function<VariableManager, Boolean> valueProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class).map(reader).orElse(Boolean.FALSE);
+        BiFunction<VariableManager, Boolean, IStatus> newValueHandler = (variableManager, newValue) -> {
+            var optionalDiagramMapping = variableManager.get(VariableManager.SELF, Object.class);
+            if (optionalDiagramMapping.isPresent()) {
+                writer.accept(optionalDiagramMapping.get(), newValue);
+                return new Success();
+            } else {
+                return new Failure("");
+            }
+        };
+
+        var builder = CheckboxDescription.newCheckboxDescription(id)
+                .idProvider(variableManager -> id)
+                .targetObjectIdProvider(this.propertiesConfigurerService.getSemanticTargetIdProvider())
+                .labelProvider(variableManager -> title)
+                .valueProvider(valueProvider)
+                .newValueHandler(newValueHandler)
+                .diagnosticsProvider(this.propertiesConfigurerService.getDiagnosticsProvider(feature))
+                .kindProvider(this.propertiesConfigurerService.getKindProvider())
+                .messageProvider(this.propertiesConfigurerService.getMessageProvider());
+        helpTextProvider.ifPresent(builder::helpTextProvider);
+        return builder.build();
+    }
+
+    public TextareaDescription createExpressionField(String id, String title, Function<Object, String> reader, BiConsumer<Object, String> writer, Object feature) {
+        Function<VariableManager, String> valueProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class).map(reader).orElse(EMPTY);
+        BiFunction<VariableManager, String, IStatus> newValueHandler = (variableManager, newValue) -> {
+            var optionalDiagramMapping = variableManager.get(VariableManager.SELF, Object.class);
+            if (optionalDiagramMapping.isPresent()) {
+                writer.accept(optionalDiagramMapping.get(), newValue);
+                return new Success();
+            } else {
+                return new Failure("");
+            }
+        };
+
+        return TextareaDescription.newTextareaDescription(id)
+                .idProvider(variableManager -> id)
+                .targetObjectIdProvider(this.propertiesConfigurerService.getSemanticTargetIdProvider())
+                .labelProvider(variableManager -> title)
+                .valueProvider(valueProvider)
+                .newValueHandler(newValueHandler)
+                .diagnosticsProvider(this.propertiesConfigurerService.getDiagnosticsProvider(feature))
+                .completionProposalsProvider(aqlTextfieldCustomizer.getCompletionProposalsProvider())
+                .styleProvider(aqlTextfieldCustomizer.getStyleProvider())
+                .kindProvider(this.propertiesConfigurerService.getKindProvider())
+                .messageProvider(this.propertiesConfigurerService.getMessageProvider())
+                .build();
+    }
+
+    public TextfieldDescription createTextField(String id, String title, Function<Object, String> reader, BiConsumer<Object, String> writer, Object feature) {
+        Function<VariableManager, String> valueProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class).map(reader).orElse(EMPTY);
+        BiFunction<VariableManager, String, IStatus> newValueHandler = (variableManager, newValue) -> {
+            var optionalDiagramMapping = variableManager.get(VariableManager.SELF, Object.class);
+            if (optionalDiagramMapping.isPresent()) {
+                writer.accept(optionalDiagramMapping.get(), newValue);
+                return new Success();
+            } else {
+                return new Failure("");
+            }
+        };
+
+        return TextfieldDescription.newTextfieldDescription(id)
+                .idProvider(variableManager -> id)
+                .targetObjectIdProvider(this.propertiesConfigurerService.getSemanticTargetIdProvider())
+                .labelProvider(variableManager -> title)
+                .valueProvider(valueProvider)
+                .newValueHandler(newValueHandler)
+                .diagnosticsProvider(this.propertiesConfigurerService.getDiagnosticsProvider(feature))
+                .kindProvider(this.propertiesConfigurerService.getKindProvider())
+                .messageProvider(this.propertiesConfigurerService.getMessageProvider())
+                .build();
+    }
+
+    public ReferenceWidgetDescription createReferenceWidget(String id, String label, Object feature, Function<VariableManager, List<?>> optionsProvider) {
+        return ReferenceWidgetDescription.newReferenceWidgetDescription(id)
+                .targetObjectIdProvider(this.propertiesConfigurerService.getSemanticTargetIdProvider())
+                .idProvider(variableManager -> id)
+                .labelProvider(variableManager -> label)
+                .optionsProvider(optionsProvider)
+                .iconURLProvider(variableManager -> "")
+                .itemsProvider(variableManager -> this.getReferenceValue(variableManager, feature))
+                .itemIdProvider(variableManager -> this.getItem(variableManager).map(this.objectService::getId).orElse(""))
+                .itemKindProvider(variableManager -> this.getItem(variableManager).map(this.objectService::getKind).orElse(""))
+                .itemLabelProvider(variableManager -> this.getItem(variableManager).map(this.objectService::getLabel).orElse(""))
+                .itemImageURLProvider(variableManager -> this.getItem(variableManager).map(this.objectService::getImagePath).orElse(""))
+                .settingProvider(variableManager -> this.resolveSetting(variableManager, feature))
+                .styleProvider(variableManager -> null)
+                .ownerIdProvider(variableManager -> variableManager.get(VariableManager.SELF, EObject.class).map(this.objectService::getId).orElse(""))
+                .diagnosticsProvider(this.propertiesConfigurerService.getDiagnosticsProvider(feature))
+                .kindProvider(this.propertiesConfigurerService.getKindProvider())
+                .messageProvider(this.propertiesConfigurerService.getMessageProvider())
+                .build();
+    }
+
+    private Optional<Object> getItem(VariableManager variableManager) {
+        return variableManager.get(ReferenceWidgetComponent.ITEM_VARIABLE, Object.class);
+    }
+
+    private List<?> getReferenceValue(VariableManager variableManager, Object feature) {
+        List<?> value = List.of();
+        EStructuralFeature.Setting setting = this.resolveSetting(variableManager, feature);
+        if (setting != null) {
+            var rawValue = setting.get(true);
+            if (rawValue != null) {
+                value = List.of(rawValue);
+            } else {
+                value = List.of();
+            }
+        }
+        return value;
+    }
+
+    private EStructuralFeature.Setting resolveSetting(VariableManager variableManager, Object feature) {
+        EObject referenceOwner = variableManager.get(VariableManager.SELF, EObject.class).orElse(null);
+        if (referenceOwner != null && feature instanceof EReference reference) {
+            return ((InternalEObject) referenceOwner).eSetting(reference);
+        } else {
+            return null;
+        }
+    }
+}

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/EdgeStylePropertiesConfigurer.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/EdgeStylePropertiesConfigurer.java
@@ -1,0 +1,342 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.view.emf.diagram;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.sirius.components.collaborative.forms.services.api.IPropertiesDescriptionRegistry;
+import org.eclipse.sirius.components.collaborative.forms.services.api.IPropertiesDescriptionRegistryConfigurer;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.emf.services.EditingContext;
+import org.eclipse.sirius.components.forms.SelectStyle;
+import org.eclipse.sirius.components.forms.components.SelectComponent;
+import org.eclipse.sirius.components.forms.description.AbstractControlDescription;
+import org.eclipse.sirius.components.forms.description.GroupDescription;
+import org.eclipse.sirius.components.forms.description.SelectDescription;
+import org.eclipse.sirius.components.representations.Failure;
+import org.eclipse.sirius.components.representations.IStatus;
+import org.eclipse.sirius.components.representations.Success;
+import org.eclipse.sirius.components.representations.VariableManager;
+import org.eclipse.sirius.components.view.ColorPalette;
+import org.eclipse.sirius.components.view.LabelStyle;
+import org.eclipse.sirius.components.view.UserColor;
+import org.eclipse.sirius.components.view.View;
+import org.eclipse.sirius.components.view.ViewPackage;
+import org.eclipse.sirius.components.view.diagram.ArrowStyle;
+import org.eclipse.sirius.components.view.diagram.DiagramPackage;
+import org.eclipse.sirius.components.view.diagram.EdgeStyle;
+import org.eclipse.sirius.components.view.diagram.LineStyle;
+import org.eclipse.sirius.components.view.emf.CustomImageMetadata;
+import org.eclipse.sirius.components.view.emf.ICustomImageMetadataSearchService;
+import org.eclipse.sirius.components.view.emf.compatibility.IPropertiesConfigurerService;
+import org.eclipse.sirius.components.view.emf.compatibility.IPropertiesWidgetCreationService;
+import org.eclipse.sirius.components.view.emf.compatibility.PropertiesConfigurerService;
+import org.springframework.stereotype.Component;
+
+/**
+ * Customizes the properties view for some of the View DSL elements.
+ *
+ * @author mcharfadi
+ */
+@Component
+public class EdgeStylePropertiesConfigurer implements IPropertiesDescriptionRegistryConfigurer {
+
+    private static final String EMPTY = "";
+    private static final String INT_PATTERN = "\\d+";
+    private final ICustomImageMetadataSearchService customImageSearchService;
+    private final IPropertiesConfigurerService propertiesConfigurerService;
+    private final IPropertiesWidgetCreationService propertiesWidgetCreationService;
+
+    public EdgeStylePropertiesConfigurer(ICustomImageMetadataSearchService customImageSearchService,
+            PropertiesConfigurerService propertiesConfigurerService, IPropertiesWidgetCreationService propertiesWidgetCreationService) {
+        this.customImageSearchService = Objects.requireNonNull(customImageSearchService);
+        this.propertiesConfigurerService = Objects.requireNonNull(propertiesConfigurerService);
+        this.propertiesWidgetCreationService = Objects.requireNonNull(propertiesWidgetCreationService);
+    }
+
+    @Override
+    public void addPropertiesDescriptions(IPropertiesDescriptionRegistry registry) {
+
+        String formDescriptionId = UUID.nameUUIDFromBytes("edgestyle".getBytes()).toString();
+
+        List<AbstractControlDescription> controls = new ArrayList<>(this.getGeneralControlDescription());
+
+        Predicate<VariableManager> canCreatePagePredicate = variableManager ->  variableManager.get(VariableManager.SELF, Object.class)
+                .filter(EdgeStyle.class::isInstance)
+                .isPresent();
+
+        GroupDescription groupDescription = this.propertiesWidgetCreationService.createSimpleGroupDescription(controls);
+
+        registry.add(this.propertiesWidgetCreationService.createSimplePageDescription(formDescriptionId, groupDescription, canCreatePagePredicate));
+
+    }
+
+    private List<AbstractControlDescription> getGeneralControlDescription() {
+        List<AbstractControlDescription> controls = new ArrayList<>();
+
+        var fontSize = this.propertiesWidgetCreationService.createTextField("nodestyle.fontSize", "Font Size",
+                style -> String.valueOf(((LabelStyle) style).getFontSize()),
+                (style, newColor) -> {
+                    try {
+                        ((LabelStyle) style).setFontSize(Integer.parseInt(newColor));
+                    } catch (NumberFormatException nfe) {
+                        // Ignore.
+                    }
+                },
+                ViewPackage.Literals.LABEL_STYLE__FONT_SIZE);
+        controls.add(fontSize);
+
+        var italic = this.propertiesWidgetCreationService.createCheckbox("nodestyle.italic", "Italic",
+                style -> ((LabelStyle) style).isItalic(),
+                (style, newItalic) -> ((LabelStyle) style).setItalic(newItalic),
+                ViewPackage.Literals.LABEL_STYLE__ITALIC, Optional.empty());
+        controls.add(italic);
+
+        var bold = this.propertiesWidgetCreationService.createCheckbox("nodestyle.bold", "Bold",
+                style -> ((LabelStyle) style).isBold(),
+                (style, newBold) -> ((LabelStyle) style).setBold(newBold),
+                ViewPackage.Literals.LABEL_STYLE__BOLD, Optional.empty());
+        controls.add(bold);
+
+        var underline = this.propertiesWidgetCreationService.createCheckbox("nodestyle.underline", "Underline",
+                style -> ((LabelStyle) style).isUnderline(),
+                (style, newUnderline) -> ((LabelStyle) style).setUnderline(newUnderline),
+                ViewPackage.Literals.LABEL_STYLE__UNDERLINE, Optional.empty());
+        controls.add(underline);
+
+        var strikeThrough = this.propertiesWidgetCreationService.createCheckbox("nodestyle.strikeThrough", "Strike Through",
+                style -> ((LabelStyle) style).isStrikeThrough(),
+                (style, newStrikeThrough) -> ((LabelStyle) style).setStrikeThrough(newStrikeThrough),
+                ViewPackage.Literals.LABEL_STYLE__STRIKE_THROUGH, Optional.empty());
+        controls.add(strikeThrough);
+
+        var showIcon = this.propertiesWidgetCreationService.createCheckbox("nodestyle.showIcon", "Show Icon",
+                style -> ((EdgeStyle) style).isShowIcon(),
+                (style, newValue) -> ((EdgeStyle) style).setShowIcon(newValue),
+                DiagramPackage.Literals.EDGE_STYLE__SHOW_ICON,
+                Optional.of(variableManager -> "Show an icon near the label, use the default one if no custom icon is set."));
+        controls.add(showIcon);
+
+
+        controls.add(this.createIconSelectionField());
+        controls.add(this.createLineStyleSelectionField());
+        controls.add(this.createSourceArrowStyleSelectionField());
+        controls.add(this.createTargetArrowStyleSelectionField());
+
+        Function<VariableManager, List<?>> colorOptionsProvider = variableManager -> this.getColorsFromColorPalettesStream(variableManager).toList();
+        var userColor = this.propertiesWidgetCreationService.createReferenceWidget("edgestyle.Color", "Color", DiagramPackage.Literals.STYLE__COLOR, colorOptionsProvider);
+        controls.add(userColor);
+
+        return controls;
+    }
+
+    private Stream<UserColor> getColorsFromColorPalettesStream(VariableManager variableManager) {
+        return variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class)
+                              .filter(EditingContext.class::isInstance)
+                              .map(EditingContext.class::cast)
+                              .map(EditingContext::getDomain)
+                              .map(EditingDomain::getResourceSet)
+                              .map(ResourceSet::getResources)
+                              .stream()
+                              .flatMap(EList::stream)
+                              .map(Resource::getContents)
+                              .flatMap(EList::stream)
+                              .filter(View.class::isInstance)
+                              .map(View.class::cast)
+                              .map(View::getColorPalettes)
+                              .flatMap(EList::stream)
+                              .map(ColorPalette::getColors)
+                              .flatMap(EList::stream);
+    }
+
+    private SelectDescription createSourceArrowStyleSelectionField() {
+        return SelectDescription.newSelectDescription("edgestyle.sourceArrowStyleSelector")
+                .idProvider(variableManager -> "edgestyle.sourceArrowStyleSelector")
+                .targetObjectIdProvider(this.propertiesConfigurerService.getSemanticTargetIdProvider())
+                .labelProvider(variableManager -> "Source Arrow Syle")
+                .styleProvider(vm -> SelectStyle.newSelectStyle().showIcon(true).build())
+                .valueProvider(variableManager -> variableManager.get(VariableManager.SELF, EdgeStyle.class).map(EdgeStyle::getSourceArrowStyle)
+                        .map(ArrowStyle::getValue)
+                        .map(String::valueOf)
+                        .orElse(EMPTY))
+                .optionsProvider(variableManager -> ArrowStyle.VALUES)
+                .optionIdProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, ArrowStyle.class)
+                        .map(ArrowStyle::getValue)
+                        .map(String::valueOf)
+                        .orElse(EMPTY))
+                .optionLabelProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, ArrowStyle.class)
+                        .map(Enumerator::getName)
+                        .orElse(EMPTY))
+                .optionIconURLProvider(variableManager -> "")
+                .newValueHandler(this.getSourceArrowValueHandler())
+                .diagnosticsProvider(this.propertiesConfigurerService.getDiagnosticsProvider(DiagramPackage.Literals.EDGE_STYLE__SOURCE_ARROW_STYLE))
+                .kindProvider(this.propertiesConfigurerService.getKindProvider())
+                .messageProvider(this.propertiesConfigurerService.getMessageProvider())
+                .build();
+    }
+
+    private BiFunction<VariableManager, String, IStatus> getSourceArrowValueHandler() {
+        return (variableManager, newValue) -> {
+            var optionalEdgeStyle = variableManager.get(VariableManager.SELF, EdgeStyle.class);
+            if (optionalEdgeStyle.isPresent() && newValue != null && newValue.matches(INT_PATTERN)) {
+                int newArrowStyle = Integer.parseInt(newValue);
+                ArrowStyle arrowStyle = ArrowStyle.get(newArrowStyle);
+                if (arrowStyle != null) {
+                    optionalEdgeStyle.get().setSourceArrowStyle(arrowStyle);
+                    return new Success();
+                }
+            }
+            return new Failure("");
+        };
+    }
+
+    private SelectDescription createTargetArrowStyleSelectionField() {
+        return SelectDescription.newSelectDescription("edgestyle.targetArrowStyleSelector")
+                .idProvider(variableManager -> "edgestyle.targetArrowStyleSelector")
+                .targetObjectIdProvider(this.propertiesConfigurerService.getSemanticTargetIdProvider())
+                .labelProvider(variableManager -> "Target Arrow Syle")
+                .styleProvider(vm -> SelectStyle.newSelectStyle().showIcon(true).build())
+                .valueProvider(variableManager -> variableManager.get(VariableManager.SELF, EdgeStyle.class).map(EdgeStyle::getTargetArrowStyle)
+                        .map(ArrowStyle::getValue)
+                        .map(String::valueOf)
+                        .orElse(EMPTY))
+                .optionsProvider(variableManager -> ArrowStyle.VALUES)
+                .optionIdProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, ArrowStyle.class)
+                        .map(ArrowStyle::getValue)
+                        .map(String::valueOf)
+                        .orElse(EMPTY))
+                .optionLabelProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, ArrowStyle.class)
+                        .map(Enumerator::getName)
+                        .orElse(EMPTY))
+                .optionIconURLProvider(variableManager -> "")
+                .newValueHandler(this.getTargetArrowValueHandler())
+                .diagnosticsProvider(this.propertiesConfigurerService.getDiagnosticsProvider(DiagramPackage.Literals.EDGE_STYLE__TARGET_ARROW_STYLE))
+                .kindProvider(this.propertiesConfigurerService.getKindProvider())
+                .messageProvider(this.propertiesConfigurerService.getMessageProvider())
+                .build();
+    }
+
+    private BiFunction<VariableManager, String, IStatus> getTargetArrowValueHandler() {
+        return (variableManager, newValue) -> {
+            var optionalEdgeStyle = variableManager.get(VariableManager.SELF, EdgeStyle.class);
+            if (optionalEdgeStyle.isPresent() && newValue != null && newValue.matches(INT_PATTERN)) {
+                int newArrowStyle = Integer.parseInt(newValue);
+                ArrowStyle arrowStyle = ArrowStyle.get(newArrowStyle);
+                if (arrowStyle != null) {
+                    optionalEdgeStyle.get().setTargetArrowStyle(arrowStyle);
+                    return new Success();
+                }
+            }
+            return new Failure("");
+        };
+    }
+
+    private SelectDescription createLineStyleSelectionField() {
+        return SelectDescription.newSelectDescription("edgestyle.lineStyleSelector")
+                .idProvider(variableManager -> "edgestyle.lineStyleSelector")
+                .targetObjectIdProvider(this.propertiesConfigurerService.getSemanticTargetIdProvider())
+                .labelProvider(variableManager -> "Line Syle")
+                .styleProvider(vm -> SelectStyle.newSelectStyle().showIcon(true).build())
+                .valueProvider(variableManager -> variableManager.get(VariableManager.SELF, EdgeStyle.class).map(EdgeStyle::getLineStyle)
+                        .map(LineStyle::getValue)
+                        .map(String::valueOf)
+                        .orElse(EMPTY))
+                .optionsProvider(variableManager -> LineStyle.VALUES)
+                .optionIdProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, LineStyle.class)
+                        .map(LineStyle::getValue)
+                        .map(String::valueOf)
+                        .orElse(EMPTY))
+                .optionLabelProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, LineStyle.class)
+                        .map(Enumerator::getName)
+                        .orElse(EMPTY))
+                .optionIconURLProvider(variableManager -> "")
+                .newValueHandler(this.getLineStyleValueHandler())
+                .diagnosticsProvider(this.propertiesConfigurerService.getDiagnosticsProvider(DiagramPackage.Literals.LINE_STYLE))
+                .kindProvider(this.propertiesConfigurerService.getKindProvider())
+                .messageProvider(this.propertiesConfigurerService.getMessageProvider())
+                .build();
+    }
+
+    private BiFunction<VariableManager, String, IStatus> getLineStyleValueHandler() {
+        return (variableManager, newValue) -> {
+            var optionalEdgeStyle = variableManager.get(VariableManager.SELF, EdgeStyle.class);
+            if (optionalEdgeStyle.isPresent() && newValue != null && newValue.matches(INT_PATTERN)) {
+                int newLineStyle = Integer.parseInt(newValue);
+                LineStyle lineStyle = LineStyle.get(newLineStyle);
+                if (lineStyle != null) {
+                    optionalEdgeStyle.get().setLineStyle(lineStyle);
+                    return new Success();
+                }
+            }
+            return new Failure("");
+        };
+    }
+
+    private SelectDescription createIconSelectionField() {
+        return SelectDescription.newSelectDescription("edgestyle.iconLabelSelector")
+                .idProvider(variableManager -> "edgestyle.iconLabelSelector")
+                .targetObjectIdProvider(this.propertiesConfigurerService.getSemanticTargetIdProvider())
+                .labelProvider(variableManager -> "Custom Icon")
+                .styleProvider(vm -> SelectStyle.newSelectStyle().showIcon(true).build())
+                .valueProvider(variableManager -> variableManager.get(VariableManager.SELF, EdgeStyle.class).map(EdgeStyle::getLabelIcon).orElse(EMPTY))
+                .optionsProvider(variableManager -> variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class)
+                        .map(IEditingContext::getId)
+                        .map(this.customImageSearchService::getAvailableImages)
+                        .orElse(List.of())
+                )
+                .optionIdProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, CustomImageMetadata.class)
+                        .map(customImageMetadataEntity -> String.format("/custom/%s", customImageMetadataEntity.getId().toString()))
+                        .orElse(EMPTY))
+                .optionLabelProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, CustomImageMetadata.class)
+                        .map(CustomImageMetadata::getLabel)
+                        .orElse(EMPTY))
+                .optionIconURLProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, CustomImageMetadata.class)
+                        .map(customImageMetadataEntity -> String.format("/custom/%s", customImageMetadataEntity.getId().toString()))
+                        .orElse(EMPTY))
+                .newValueHandler(this.getIconLabelValueHandler())
+                .diagnosticsProvider(this.propertiesConfigurerService.getDiagnosticsProvider(DiagramPackage.Literals.NODE_STYLE_DESCRIPTION__LABEL_ICON))
+                .kindProvider(this.propertiesConfigurerService.getKindProvider())
+                .messageProvider(this.propertiesConfigurerService.getMessageProvider())
+                .helpTextProvider(variableManager -> "Set a custom icon for the label, use in association with Show Icon property")
+                .build();
+    }
+
+    private BiFunction<VariableManager, String, IStatus> getIconLabelValueHandler() {
+        return (variableManager, newValue) -> {
+            var optionalEdgeStyle = variableManager.get(VariableManager.SELF, EdgeStyle.class);
+            if (optionalEdgeStyle.isPresent()) {
+                String newIcon = newValue;
+                if (newValue != null && newValue.isBlank()) {
+                    newIcon = null;
+                }
+                optionalEdgeStyle.get().setLabelIcon(newIcon);
+                return new Success();
+            }
+            return new Failure("");
+        };
+    }
+
+}

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/StylesFactory.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/StylesFactory.java
@@ -65,8 +65,11 @@ public final class StylesFactory {
                                     .strikeThroughProvider(variableManager -> nodeStyle.isStrikeThrough())
                                     .iconURLProvider(variableManager -> {
                                         String iconURL = "";
-                                        if (nodeStyle.isShowIcon()) {
+                                        if (nodeStyle.isShowIcon() && nodeStyle.getLabelIcon() == null) {
                                             iconURL = variableManager.get(VariableManager.SELF, Object.class).map(this.objectService::getImagePath).orElse("");
+                                        }
+                                        if (nodeStyle.isShowIcon() && !(nodeStyle.getLabelIcon() == null)) {
+                                            iconURL = nodeStyle.getLabelIcon();
                                         }
                                         return iconURL;
                                     })
@@ -87,8 +90,11 @@ public final class StylesFactory {
                                     .strikeThroughProvider(variableManager -> edgeStyle.isStrikeThrough())
                                     .iconURLProvider(variableManager -> {
                                         String iconURL = "";
-                                        if (edgeStyle.isShowIcon()) {
+                                        if (edgeStyle.isShowIcon() && edgeStyle.getLabelIcon() == null) {
                                             iconURL = variableManager.get(VariableManager.SELF, Object.class).map(this.objectService::getImagePath).orElse("");
+                                        }
+                                        if (edgeStyle.isShowIcon() && !(edgeStyle.getLabelIcon() == null)) {
+                                            iconURL = edgeStyle.getLabelIcon();
                                         }
                                         return iconURL;
                                     })


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/2044
OLD PR was https://github.com/eclipse-sirius/sirius-web/pull/2045
# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?