### PR TITLE
[enh] Preview colors when configuring a node style

### DIFF
--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/NodeStylePropertiesConfigurer.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/NodeStylePropertiesConfigurer.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.sirius.components.view.emf.diagram;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -54,6 +56,7 @@ import org.eclipse.sirius.components.representations.IStatus;
 import org.eclipse.sirius.components.representations.Success;
 import org.eclipse.sirius.components.representations.VariableManager;
 import org.eclipse.sirius.components.view.ColorPalette;
+import org.eclipse.sirius.components.view.FixedColor;
 import org.eclipse.sirius.components.view.LabelStyle;
 import org.eclipse.sirius.components.view.UserColor;
 import org.eclipse.sirius.components.view.View;
@@ -376,7 +379,12 @@ public class NodeStylePropertiesConfigurer implements IPropertiesDescriptionRegi
                 .itemIdProvider(variableManager -> this.getItem(variableManager).map(this.objectService::getId).orElse(""))
                 .itemKindProvider(variableManager -> this.getItem(variableManager).map(this.objectService::getKind).orElse(""))
                 .itemLabelProvider(variableManager -> this.getItem(variableManager).map(this.objectService::getLabel).orElse(""))
-                .itemImageURLProvider(variableManager -> this.getItem(variableManager).map(this.objectService::getImagePath).orElse(""))
+                .itemImageURLProvider(variableManager -> {
+                    return variableManager.get(ReferenceWidgetComponent.ITEM_VARIABLE, FixedColor.class).map(color -> {
+                        String urlSafeValue = URLEncoder.encode(color.getValue(), StandardCharsets.UTF_8);
+                        return "/color/%s".formatted(urlSafeValue);
+                    }).orElse("");
+                })
                 .settingProvider(variableManager -> this.resolveSetting(variableManager, feature))
                 .styleProvider(variableManager -> null)
                 .ownerIdProvider(variableManager -> variableManager.get(VariableManager.SELF, EObject.class).map(this.objectService::getId).orElse(""))


### PR DESCRIPTION
https://github.com/eclipse-sirius/sirius-web/assets/10608/5d31b4d8-69b6-4872-9a94-7c095bede5af

What's missing:
- a proper ticket and changelog entry;
- this only works for the very specific case of Node styles, where we override the Details definition with `NodeStylePropertiesConfigurer`. Colors on edge styles or in forms are not impacted;
- the actual color *definition* in the explorer is not impacted either;
- there is zero validation/sanitation on the raw color value we insert into the generated SVG. could defining a color as `blue'/> INJECT ANYTHING HERE <rect style='fill:'` has bad side effects?
