### PR TITLE
[288] Only change the diagram's backgound when it is the actual drop target

### DIFF
--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/DropNodeContext.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/DropNodeContext.tsx
@@ -17,6 +17,7 @@ import { NodeDropData } from './useDropNode.types';
 
 const defaultValue: DropNodeContextValue = {
   dropData: {
+    initialParentId: null,
     draggedNodeId: null,
     targetNodeId: null,
     compatibleNodeIds: [],

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.tsx
@@ -160,6 +160,7 @@ export const useDropNode = (): UseDropNodeValue => {
       .map((n) => n.id);
 
     setDropData({
+      initialParentId: null,
       draggedNodeId: null,
       targetNodeId: node.parentNode || null,
       compatibleNodeIds: compatibleNodes,
@@ -182,6 +183,7 @@ export const useDropNode = (): UseDropNodeValue => {
         });
       const newParentId = intersections[0]?.id || null;
       setDropData({
+        initialParentId: node.parentNode || null,
         draggedNodeId: node.id,
         targetNodeId: newParentId,
         compatibleNodeIds: dropData.compatibleNodeIds,
@@ -202,7 +204,13 @@ export const useDropNode = (): UseDropNodeValue => {
       }
     }
     setDraggedNode(null);
-    setDropData({ draggedNodeId: null, targetNodeId: null, droppableOnDiagram: false, compatibleNodeIds: [] });
+    setDropData({
+      initialParentId: null,
+      draggedNodeId: null,
+      targetNodeId: null,
+      droppableOnDiagram: false,
+      compatibleNodeIds: [],
+    });
   };
 
   const theme = useTheme();
@@ -232,9 +240,11 @@ export const useDropNode = (): UseDropNodeValue => {
 
     getDiagramBackgroundStyle(): DiagramBackgroundStyle {
       const diagramForbidden = dropData.draggedNodeId !== null && !dropData.droppableOnDiagram;
-      const backgroundColor = diagramForbidden
-        ? theme.palette.action.disabledBackground
-        : theme.palette.background.default;
+      const diagramTargeted = dropData.targetNodeId === null && dropData.initialParentId !== null;
+      const backgroundColor =
+        diagramTargeted && diagramForbidden
+          ? theme.palette.action.disabledBackground
+          : theme.palette.background.default;
       return {
         backgroundColor,
         smallGridColor: diagramForbidden ? backgroundColor : '#f1f1f1',

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.types.ts
@@ -34,6 +34,7 @@ export interface DiagramBackgroundStyle {
 }
 
 export interface NodeDropData {
+  initialParentId: string | null;
   draggedNodeId: string | null;
   targetNodeId: string | null;
   compatibleNodeIds: string[];


### PR DESCRIPTION
https://github.com/eclipse-sirius/sirius-web/assets/10608/b57a0b44-5c10-4193-8b7a-53fcc4243d47

Bug: https://github.com/eclipse-sirius/sirius-web/issues/288
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>