### PR TITLE
[288] Reset dragged node's position if dropped on an invalid target

### DIFF
--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/DiagramRenderer.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/DiagramRenderer.tsx
@@ -21,6 +21,7 @@ import {
   EdgeSelectionChange,
   Node,
   NodeChange,
+  NodePositionChange,
   NodeSelectionChange,
   OnEdgesChange,
   OnNodesChange,
@@ -260,7 +261,15 @@ export const DiagramRenderer = ({ diagramRefreshedEventPayload, selection, setSe
       onDragOver={onDragOver}
       onNodeDrag={onNodeDrag}
       onNodeDragStart={onNodeDragStart}
-      onNodeDragStop={onNodeDragStop}
+      onNodeDragStop={onNodeDragStop((node: Node) => {
+        const resetPosition: NodePositionChange = {
+          id: node.id,
+          type: 'position',
+          position: node.position,
+          positionAbsolute: node.positionAbsolute,
+        };
+        onNodesChange([resetPosition]);
+      })}
       maxZoom={40}
       minZoom={0.1}
       snapToGrid={state.snapToGrid}

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.tsx
@@ -192,25 +192,31 @@ export const useDropNode = (): UseDropNodeValue => {
     }
   };
 
-  const onNodeDragStop: NodeDragHandler = (_event, _node) => {
-    if (draggedNode && draggedNode.id === dropData.draggedNodeId) {
-      const oldParentId: string | null = draggedNode.parentNode || null;
-      const newParentId: string | null = dropData.targetNodeId;
-      const validNewParent =
-        (newParentId === null && dropData.droppableOnDiagram) ||
-        (newParentId !== null && dropData.compatibleNodeIds.includes(newParentId));
-      if (oldParentId !== newParentId && validNewParent) {
-        onDropNode(dropData.draggedNodeId, newParentId);
+  const onNodeDragStop: (onDragCancelled: (node: Node) => void) => NodeDragHandler = (onDragCancelled) => {
+    return (_event, _node) => {
+      if (draggedNode && draggedNode.id === dropData.draggedNodeId) {
+        const oldParentId: string | null = draggedNode.parentNode || null;
+        const newParentId: string | null = dropData.targetNodeId;
+        const validNewParent =
+          (newParentId === null && dropData.droppableOnDiagram) ||
+          (newParentId !== null && dropData.compatibleNodeIds.includes(newParentId));
+        if (oldParentId !== newParentId) {
+          if (validNewParent) {
+            onDropNode(dropData.draggedNodeId, newParentId);
+          } else {
+            onDragCancelled(draggedNode);
+          }
+        }
       }
-    }
-    setDraggedNode(null);
-    setDropData({
-      initialParentId: null,
-      draggedNodeId: null,
-      targetNodeId: null,
-      droppableOnDiagram: false,
-      compatibleNodeIds: [],
-    });
+      setDraggedNode(null);
+      setDropData({
+        initialParentId: null,
+        draggedNodeId: null,
+        targetNodeId: null,
+        droppableOnDiagram: false,
+        compatibleNodeIds: [],
+      });
+    };
   };
 
   const theme = useTheme();

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.types.ts
@@ -11,12 +11,12 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { NodeDragHandler } from 'reactflow';
+import { Node, NodeDragHandler } from 'reactflow';
 
 export interface UseDropNodeValue {
   onNodeDragStart: NodeDragHandler;
   onNodeDrag: NodeDragHandler;
-  onNodeDragStop: NodeDragHandler;
+  onNodeDragStop: (onDragCancelled: (node: Node) => void) => NodeDragHandler;
   dropData: NodeDropData;
   dropFeedbackStyleProvider: StyleProvider;
 }


### PR DESCRIPTION
https://github.com/eclipse-sirius/sirius-web/assets/10608/ca30d920-8cb1-4fdd-9beb-89c9afb7d094

Bug: https://github.com/eclipse-sirius/sirius-web/issues/288
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
