### PR TITLE
[2460] Separates the management of element creation from the reference widget in specific services

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -31,6 +31,7 @@ For example, Diagram & Form domains are not root domains because `DiagramDescrip
 - https://github.com/eclipse-sirius/sirius-web/issues/2456[#2456] [sirius-web] The GraphQL field `CreateChildSuccessPayload` now expects to have a list of messages.
 - https://github.com/eclipse-sirius/sirius-web/issues/1982[#1982] [diagram] Change the diagram structure. The Node's 'label' attribute has been renamed into 'insideLabel' and its type changed from `Label` to `InsideLabel` (which is currently identical to `Label` except for the name).
 - https://github.com/eclipse-sirius/sirius-web/issues/2388[#2388] [core] The `IObjectService.getImagePath` API changed and now must return a list containing all the image paths to compose/overlay.
+- https://github.com/eclipse-sirius/sirius-web/issues/2460[#2460] [form] The reference widget no longer declares a `createElementHandlerProvider`, this feature is delegated to the new service `IReferenceWidgetCreateElementHandler`.
 
 === Dependency update
 

--- a/packages/compatibility/backend/sirius-components-compatibility-emf/src/main/java/org/eclipse/sirius/components/compatibility/emf/properties/NonContainmentReferenceIfDescriptionProvider.java
+++ b/packages/compatibility/backend/sirius-components-compatibility-emf/src/main/java/org/eclipse/sirius/components/compatibility/emf/properties/NonContainmentReferenceIfDescriptionProvider.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Function;
 
 import org.eclipse.emf.common.util.EList;
@@ -29,8 +28,6 @@ import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.compatibility.emf.properties.api.IPropertiesValidationProvider;
 import org.eclipse.sirius.components.compatibility.forms.WidgetIdProvider;
-import org.eclipse.sirius.components.core.api.IEditService;
-import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.emf.services.api.IEMFKindService;
@@ -67,13 +64,11 @@ public class NonContainmentReferenceIfDescriptionProvider {
 
     private final IFeedbackMessageService feedbackMessageService;
 
-    private final IEditService editService;
 
-    public NonContainmentReferenceIfDescriptionProvider(ComposedAdapterFactory composedAdapterFactory, IObjectService objectService, IEditService editService, IEMFKindService emfKindService,
+    public NonContainmentReferenceIfDescriptionProvider(ComposedAdapterFactory composedAdapterFactory, IObjectService objectService, IEMFKindService emfKindService,
             IFeedbackMessageService feedbackMessageService, IPropertiesValidationProvider propertiesValidationProvider, Function<VariableManager, String> semanticTargetIdProvider) {
         this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
         this.objectService = Objects.requireNonNull(objectService);
-        this.editService = Objects.requireNonNull(editService);
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
         this.semanticTargetIdProvider = Objects.requireNonNull(semanticTargetIdProvider);
         this.emfKindService = Objects.requireNonNull(emfKindService);
@@ -120,7 +115,6 @@ public class NonContainmentReferenceIfDescriptionProvider {
                 .itemRemoveHandlerProvider(this::handleRemoveValue)
                 .setHandlerProvider(this::handleSetReference)
                 .addHandlerProvider(this::handleAddReferenceValues)
-                .createElementHandlerProvider(this::handleCreateElement)
                 .moveHandlerProvider(this::handleMoveReferenceValue)
                 .build();
     }
@@ -304,24 +298,6 @@ public class NonContainmentReferenceIfDescriptionProvider {
             result = this.createErrorStatus("Something went wrong while adding reference values.");
         }
         return result;
-    }
-
-    private Object handleCreateElement(VariableManager variableManager) {
-        Optional<Object> result = Optional.empty();
-        Optional<Boolean> optionalIsChild = variableManager.get(ReferenceWidgetComponent.IS_CHILD_CREATION_VARIABLE, Boolean.class);
-        var optionalEditingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class);
-        String creationDescriptionId = variableManager.get(ReferenceWidgetComponent.CREATION_DESCRIPTION_ID_VARIABLE, String.class).orElse("");
-        if (optionalIsChild.isPresent() && optionalEditingContext.isPresent()) {
-            if (optionalIsChild.get()) {
-                EObject parent = variableManager.get(ReferenceWidgetComponent.PARENT_VARIABLE, EObject.class).orElse(null);
-                result = this.editService.createChild(optionalEditingContext.get(), parent, creationDescriptionId);
-            } else {
-                UUID documentId = variableManager.get(ReferenceWidgetComponent.DOCUMENT_ID_VARIABLE, UUID.class).orElse(UUID.randomUUID());
-                String domainId = variableManager.get(ReferenceWidgetComponent.DOMAIN_ID_VARIABLE, String.class).orElse("");
-                result = this.editService.createRootObject(optionalEditingContext.get(), documentId, domainId, creationDescriptionId);
-            }
-        }
-        return result.orElse(null);
     }
 
     private IStatus handleMoveReferenceValue(VariableManager variableManager) {

--- a/packages/compatibility/backend/sirius-components-compatibility-emf/src/main/java/org/eclipse/sirius/components/compatibility/emf/properties/PropertiesDefaultDescriptionProvider.java
+++ b/packages/compatibility/backend/sirius-components-compatibility-emf/src/main/java/org/eclipse/sirius/components/compatibility/emf/properties/PropertiesDefaultDescriptionProvider.java
@@ -29,7 +29,6 @@ import org.eclipse.emf.edit.provider.IItemPropertySource;
 import org.eclipse.sirius.components.collaborative.forms.PropertiesEventProcessorFactory;
 import org.eclipse.sirius.components.collaborative.forms.api.IPropertiesDefaultDescriptionProvider;
 import org.eclipse.sirius.components.compatibility.emf.properties.api.IPropertiesValidationProvider;
-import org.eclipse.sirius.components.core.api.IEditService;
 import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.emf.services.api.IEMFKindService;
@@ -55,8 +54,6 @@ public class PropertiesDefaultDescriptionProvider implements IPropertiesDefaultD
 
     private final IObjectService objectService;
 
-    private final IEditService editService;
-
     private final IEMFKindService emfKindService;
 
     private final IFeedbackMessageService feedbackMessageService;
@@ -69,10 +66,9 @@ public class PropertiesDefaultDescriptionProvider implements IPropertiesDefaultD
 
     private final Function<VariableManager, String> semanticTargetIdProvider;
 
-    public PropertiesDefaultDescriptionProvider(IObjectService objectService, IEditService editService, IEMFKindService emfKindService, IFeedbackMessageService feedbackMessageService, ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider,
+    public PropertiesDefaultDescriptionProvider(IObjectService objectService, IEMFKindService emfKindService, IFeedbackMessageService feedbackMessageService, ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider,
             IEMFMessageService emfMessageService) {
         this.objectService = Objects.requireNonNull(objectService);
-        this.editService = Objects.requireNonNull(editService);
         this.emfKindService = Objects.requireNonNull(emfKindService);
         this.feedbackMessageService = Objects.requireNonNull(feedbackMessageService);
         this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
@@ -173,7 +169,7 @@ public class PropertiesDefaultDescriptionProvider implements IPropertiesDefaultD
         ifDescriptions.add(new EBooleanIfDescriptionProvider(this.composedAdapterFactory, this.propertiesValidationProvider, this.semanticTargetIdProvider).getIfDescription());
         ifDescriptions.add(new EEnumIfDescriptionProvider(this.composedAdapterFactory, this.propertiesValidationProvider, this.semanticTargetIdProvider).getIfDescription());
 
-        ifDescriptions.add(new NonContainmentReferenceIfDescriptionProvider(this.composedAdapterFactory, this.objectService, this.editService, this.emfKindService, this.feedbackMessageService, this.propertiesValidationProvider, this.semanticTargetIdProvider).getIfDescription());
+        ifDescriptions.add(new NonContainmentReferenceIfDescriptionProvider(this.composedAdapterFactory, this.objectService, this.emfKindService, this.feedbackMessageService, this.propertiesValidationProvider, this.semanticTargetIdProvider).getIfDescription());
 
         // @formatter:off
         var numericDataTypes = List.of(

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/ReferenceWidgetDefaultCreateElementHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/ReferenceWidgetDefaultCreateElementHandler.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.widget.reference;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.core.api.ChildCreationDescription;
+import org.eclipse.sirius.components.core.api.IEditService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.widget.reference.IReferenceWidgetCreateElementHandler;
+import org.springframework.stereotype.Service;
+
+/**
+ * * Default implementation of {@link IReferenceWidgetCreateElementHandler}.
+ * * This implementation use {@link IEditService}.
+ *
+ * @author frouene
+ */
+@Service
+public class ReferenceWidgetDefaultCreateElementHandler implements IReferenceWidgetCreateElementHandler {
+
+    private final IEditService editService;
+
+    public ReferenceWidgetDefaultCreateElementHandler(IEditService editService) {
+        this.editService = Objects.requireNonNull(editService);
+    }
+
+    @Override
+    public boolean canHandle(String descriptionId) {
+        return false; // Default implementation, it'll be used if no other service can handle the descriptionId
+    }
+
+    @Override
+    public List<ChildCreationDescription> getRootCreationDescriptions(IEditingContext editingContext, String domainId, String referenceKind, String descriptionId) {
+        return this.editService.getRootCreationDescriptions(editingContext, domainId, false, referenceKind);
+    }
+
+    @Override
+    public List<ChildCreationDescription> getChildCreationDescriptions(IEditingContext editingContext, String kind, String referenceKind, String descriptionId) {
+        return this.editService.getChildCreationDescriptions(editingContext, kind, referenceKind);
+    }
+
+    @Override
+    public Optional<Object> createRootObject(IEditingContext editingContext, UUID documentId, String domainId, String rootObjectCreationDescriptionId, String descriptionId) {
+        return this.editService.createRootObject(editingContext, documentId, domainId, rootObjectCreationDescriptionId);
+    }
+
+    @Override
+    public Optional<Object> createChild(IEditingContext editingContext, Object object, String childCreationDescriptionId, String descriptionId) {
+        return this.editService.createChild(editingContext, object, childCreationDescriptionId);
+    }
+}

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/ReferenceWidgetDescriptionConverterSwitch.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/ReferenceWidgetDescriptionConverterSwitch.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Function;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
@@ -36,7 +35,6 @@ import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.compatibility.forms.WidgetIdProvider;
 import org.eclipse.sirius.components.compatibility.utils.StringValueProvider;
 import org.eclipse.sirius.components.core.api.IEditService;
-import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.emf.services.api.IEMFKindService;
@@ -135,7 +133,6 @@ public class ReferenceWidgetDescriptionConverterSwitch extends ReferenceSwitch<A
                 .itemRemoveHandlerProvider(variableManager -> this.handleItemRemove(variableManager, referenceDescription))
                 .setHandlerProvider(variableManager -> this.handleSetReference(variableManager, referenceDescription))
                 .addHandlerProvider(variableManager -> this.handleAddReference(variableManager, referenceDescription))
-                .createElementHandlerProvider(variableManager -> this.handleCreateElement(variableManager, referenceDescription)).styleProvider(styleProvider)
                 .moveHandlerProvider(variableManager -> this.handleMoveReferenceValue(variableManager, referenceDescription));
 
         if (referenceDescription.getHelpExpression() != null && !referenceDescription.getHelpExpression().isBlank()) {
@@ -355,24 +352,6 @@ public class ReferenceWidgetDescriptionConverterSwitch extends ReferenceSwitch<A
             result = this.createErrorStatus("Something went wrong while adding reference values.");
         }
         return result;
-    }
-
-    private Object handleCreateElement(VariableManager variableManager, ReferenceWidgetDescription referenceDescription) {
-        Optional<Object> result = Optional.empty();
-        Optional<Boolean> optionalIsChild = variableManager.get(ReferenceWidgetComponent.IS_CHILD_CREATION_VARIABLE, Boolean.class);
-        var optionalEditingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class);
-        String creationDescriptionId = variableManager.get(ReferenceWidgetComponent.CREATION_DESCRIPTION_ID_VARIABLE, String.class).orElse("");
-        if (optionalIsChild.isPresent() && optionalEditingContext.isPresent()) {
-            if (optionalIsChild.get()) {
-                EObject parent = variableManager.get(ReferenceWidgetComponent.PARENT_VARIABLE, EObject.class).orElse(null);
-                result = this.editService.createChild(optionalEditingContext.get(), parent, creationDescriptionId);
-            } else {
-                UUID documentId = variableManager.get(ReferenceWidgetComponent.DOCUMENT_ID_VARIABLE, UUID.class).orElse(UUID.randomUUID());
-                String domainId = variableManager.get(ReferenceWidgetComponent.DOMAIN_ID_VARIABLE, String.class).orElse("");
-                result = this.editService.createRootObject(optionalEditingContext.get(), documentId, domainId, creationDescriptionId);
-            }
-        }
-        return result.orElse(null);
     }
 
     private IStatus handleMoveReferenceValue(VariableManager variableManager, ReferenceWidgetDescription referenceDescription) {

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/browser/ReferenceWidgetDefaultCandidateSearchProvider.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/browser/ReferenceWidgetDefaultCandidateSearchProvider.java
@@ -25,7 +25,6 @@ import org.eclipse.sirius.components.widget.reference.IReferenceWidgetRootCandid
 import org.springframework.stereotype.Service;
 
 /**
- *
  * Default implementation of {@link IReferenceWidgetRootCandidateSearchProvider}.
  * This implementation returns all root resources from the current model.
  *
@@ -36,7 +35,7 @@ public class ReferenceWidgetDefaultCandidateSearchProvider implements IReference
 
     @Override
     public boolean canHandle(String descriptionId) {
-        return true;
+        return false; // Default implementation, it'll be used if no other service can handle the descriptionId
     }
 
     @Override

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/dto/ReferenceWidgetChildCreationDescriptionsInput.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/dto/ReferenceWidgetChildCreationDescriptionsInput.java
@@ -10,17 +10,17 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.components.widget.reference.dto;
+package org.eclipse.sirius.components.collaborative.widget.reference.dto;
 
 import java.util.UUID;
 
-import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.components.core.api.IInput;
 
 /**
- * Input object to pass inputs to the createElementInReferenceHandler field of ReferenceWidget.
+ * Input object for the query to retrieve the child creation descriptions.
  *
- * @author Jerome Gout
+ * @author frouene
  */
-public record CreateElementInReferenceHandlerParameters(UUID documentId, String domainId, EObject parent, String creationDescriptionId) {
+public record ReferenceWidgetChildCreationDescriptionsInput(UUID id, String editingContextId, String kind, String referenceKind, String descriptionId) implements IInput {
 
 }

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/dto/ReferenceWidgetRootCreationDescriptionsInput.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/dto/ReferenceWidgetRootCreationDescriptionsInput.java
@@ -14,14 +14,13 @@ package org.eclipse.sirius.components.collaborative.widget.reference.dto;
 
 import java.util.UUID;
 
-import org.eclipse.sirius.components.collaborative.forms.api.IFormInput;
+import org.eclipse.sirius.components.core.api.IInput;
 
 /**
- * Input object for the mutation to create new element in model.
+ * Input object for the query to retrieve the root creation descriptions.
  *
- * @author Jerome Gout
+ * @author frouene
  */
-public record CreateElementInput(UUID id, String editingContextId, String representationId, String referenceWidgetId, String containerId, String domainId,
-                                 String creationDescriptionId, String descriptionId) implements IFormInput {
+public record ReferenceWidgetRootCreationDescriptionsInput(UUID id, String editingContextId, String domainId, String referenceKind, String descriptionId) implements IInput {
 
 }

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/ReferenceWidgetChildCreationDescriptionsEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/ReferenceWidgetChildCreationDescriptionsEventHandler.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.widget.reference.handlers;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
+import org.eclipse.sirius.components.collaborative.api.IEditingContextEventHandler;
+import org.eclipse.sirius.components.collaborative.api.Monitoring;
+import org.eclipse.sirius.components.collaborative.dto.EditingContextChildObjectCreationDescriptionsPayload;
+import org.eclipse.sirius.components.collaborative.widget.reference.ReferenceWidgetDefaultCreateElementHandler;
+import org.eclipse.sirius.components.collaborative.widget.reference.dto.ReferenceWidgetChildCreationDescriptionsInput;
+import org.eclipse.sirius.components.core.api.ChildCreationDescription;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IInput;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.widget.reference.IReferenceWidgetCreateElementHandler;
+import org.springframework.stereotype.Service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Handler used to retrieve the child creation descriptions from a reference widget.
+ *
+ * @author frouene
+ */
+@Service
+public class ReferenceWidgetChildCreationDescriptionsEventHandler implements IEditingContextEventHandler {
+
+    private final List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers;
+
+    private final ReferenceWidgetDefaultCreateElementHandler defaultReferenceWidgetCreateElementHandler;
+
+    private final Counter counter;
+
+    public ReferenceWidgetChildCreationDescriptionsEventHandler(List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers, ReferenceWidgetDefaultCreateElementHandler defaultReferenceWidgetCreateElementHandler, MeterRegistry meterRegistry) {
+        this.referenceWidgetCreateElementHandlers = Objects.requireNonNull(referenceWidgetCreateElementHandlers);
+        this.defaultReferenceWidgetCreateElementHandler = Objects.requireNonNull(defaultReferenceWidgetCreateElementHandler);
+        this.counter = Counter.builder(Monitoring.EVENT_HANDLER).tag(Monitoring.NAME, this.getClass().getSimpleName()).register(meterRegistry);
+    }
+
+    @Override
+    public boolean canHandle(IEditingContext editingContext, IInput input) {
+        return input instanceof ReferenceWidgetChildCreationDescriptionsInput;
+    }
+
+    @Override
+    public void handle(Sinks.One<IPayload> payloadSink, Sinks.Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, IInput input) {
+        this.counter.increment();
+
+        List<ChildCreationDescription> childCreationDescriptions = List.of();
+        if (input instanceof ReferenceWidgetChildCreationDescriptionsInput castInput) {
+
+            childCreationDescriptions = this.referenceWidgetCreateElementHandlers.stream()
+                    .filter(provider -> provider.canHandle(castInput.descriptionId()))
+                    .findFirst()
+                    .orElse(this.defaultReferenceWidgetCreateElementHandler)
+                    .getChildCreationDescriptions(editingContext, castInput.kind(), castInput.referenceKind(), castInput.descriptionId());
+        }
+        payloadSink.tryEmitValue(new EditingContextChildObjectCreationDescriptionsPayload(input.id(), childCreationDescriptions));
+    }
+
+}

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/ReferenceWidgetRootCreationDescriptionsEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/ReferenceWidgetRootCreationDescriptionsEventHandler.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.widget.reference.handlers;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
+import org.eclipse.sirius.components.collaborative.api.IEditingContextEventHandler;
+import org.eclipse.sirius.components.collaborative.api.Monitoring;
+import org.eclipse.sirius.components.collaborative.dto.EditingContextRootObjectCreationDescriptionsPayload;
+import org.eclipse.sirius.components.collaborative.widget.reference.ReferenceWidgetDefaultCreateElementHandler;
+import org.eclipse.sirius.components.collaborative.widget.reference.dto.ReferenceWidgetRootCreationDescriptionsInput;
+import org.eclipse.sirius.components.core.api.ChildCreationDescription;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IInput;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.widget.reference.IReferenceWidgetCreateElementHandler;
+import org.springframework.stereotype.Service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Handler used to retrieve the root creation descriptions from a reference widget.
+ *
+ * @author frouene
+ */
+@Service
+public class ReferenceWidgetRootCreationDescriptionsEventHandler implements IEditingContextEventHandler {
+
+    private final List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers;
+
+    private final ReferenceWidgetDefaultCreateElementHandler defaultReferenceWidgetCreateElementHandler;
+    private final Counter counter;
+
+    public ReferenceWidgetRootCreationDescriptionsEventHandler(List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers, ReferenceWidgetDefaultCreateElementHandler defaultReferenceWidgetCreateElementHandler, MeterRegistry meterRegistry) {
+        this.referenceWidgetCreateElementHandlers = Objects.requireNonNull(referenceWidgetCreateElementHandlers);
+        this.defaultReferenceWidgetCreateElementHandler = Objects.requireNonNull(defaultReferenceWidgetCreateElementHandler);
+        this.counter = Counter.builder(Monitoring.EVENT_HANDLER).tag(Monitoring.NAME, this.getClass().getSimpleName()).register(meterRegistry);
+    }
+
+    @Override
+    public boolean canHandle(IEditingContext editingContext, IInput input) {
+        return input instanceof ReferenceWidgetRootCreationDescriptionsInput;
+    }
+
+    @Override
+    public void handle(Sinks.One<IPayload> payloadSink, Sinks.Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, IInput input) {
+        this.counter.increment();
+
+        List<ChildCreationDescription> childCreationDescriptions = List.of();
+        if (input instanceof ReferenceWidgetRootCreationDescriptionsInput castInput) {
+
+            childCreationDescriptions = this.referenceWidgetCreateElementHandlers.stream()
+                    .filter(provider -> provider.canHandle(castInput.descriptionId()))
+                    .findFirst()
+                    .orElse(this.defaultReferenceWidgetCreateElementHandler)
+                    .getRootCreationDescriptions(editingContext, castInput.domainId(), castInput.referenceKind(), castInput.descriptionId());
+        }
+        payloadSink.tryEmitValue(new EditingContextRootObjectCreationDescriptionsPayload(input.id(), childCreationDescriptions));
+    }
+
+}

--- a/packages/forms/backend/sirius-components-widget-reference-graphql/src/main/java/org/eclipse/sirius/components/widget/reference/graphql/datafetchers/query/ReferenceWidgetChildCreationDescriptionsDataFetcher.java
+++ b/packages/forms/backend/sirius-components-widget-reference-graphql/src/main/java/org/eclipse/sirius/components/widget/reference/graphql/datafetchers/query/ReferenceWidgetChildCreationDescriptionsDataFetcher.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.widget.reference.graphql.datafetchers.query;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
+import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
+import org.eclipse.sirius.components.collaborative.dto.EditingContextChildObjectCreationDescriptionsPayload;
+import org.eclipse.sirius.components.collaborative.widget.reference.dto.ReferenceWidgetChildCreationDescriptionsInput;
+import org.eclipse.sirius.components.core.api.ChildCreationDescription;
+import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+
+import graphql.schema.DataFetchingEnvironment;
+
+/**
+ * The data fetcher used to retrieve referenceWidgetChildCreationDescriptions.
+ *
+ * @author frouene
+ */
+@QueryDataFetcher(type = "EditingContext", field = "referenceWidgetChildCreationDescriptions")
+public class ReferenceWidgetChildCreationDescriptionsDataFetcher implements IDataFetcherWithFieldCoordinates<CompletableFuture<List<ChildCreationDescription>>> {
+
+    private static final String KIND_ARGUMENT = "kind";
+    private static final String REFERENCE_KIND_ARGUMENT = "referenceKind";
+    private static final String WIDGET_DESCRIPTION_ID_ARGUMENT = "descriptionId";
+
+    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+
+    public ReferenceWidgetChildCreationDescriptionsDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
+        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    }
+
+    @Override
+    public CompletableFuture<List<ChildCreationDescription>> get(DataFetchingEnvironment environment) throws Exception {
+        String editingContextId = environment.getSource();
+        String kind = environment.getArgument(KIND_ARGUMENT);
+        String referenceKind = environment.getArgument(REFERENCE_KIND_ARGUMENT);
+        String descriptionId = environment.getArgument(WIDGET_DESCRIPTION_ID_ARGUMENT);
+
+        ReferenceWidgetChildCreationDescriptionsInput input = new ReferenceWidgetChildCreationDescriptionsInput(UUID.randomUUID(), editingContextId, kind,
+                referenceKind, descriptionId);
+
+        return this.editingContextEventProcessorRegistry.dispatchEvent(input.editingContextId(), input)
+                .filter(EditingContextChildObjectCreationDescriptionsPayload.class::isInstance)
+                .map(EditingContextChildObjectCreationDescriptionsPayload.class::cast)
+                .map(EditingContextChildObjectCreationDescriptionsPayload::childCreationDescriptions)
+                .toFuture();
+    }
+
+}

--- a/packages/forms/backend/sirius-components-widget-reference-graphql/src/main/java/org/eclipse/sirius/components/widget/reference/graphql/datafetchers/query/ReferenceWidgetRootCreationDescriptionsDataFetcher.java
+++ b/packages/forms/backend/sirius-components-widget-reference-graphql/src/main/java/org/eclipse/sirius/components/widget/reference/graphql/datafetchers/query/ReferenceWidgetRootCreationDescriptionsDataFetcher.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.widget.reference.graphql.datafetchers.query;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
+import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
+import org.eclipse.sirius.components.collaborative.dto.EditingContextRootObjectCreationDescriptionsPayload;
+import org.eclipse.sirius.components.collaborative.widget.reference.dto.ReferenceWidgetRootCreationDescriptionsInput;
+import org.eclipse.sirius.components.core.api.ChildCreationDescription;
+import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+
+import graphql.schema.DataFetchingEnvironment;
+
+/**
+ * The data fetcher used to retrieve referenceWidgetRootCreationDescriptions.
+ *
+ * @author frouene
+ */
+@QueryDataFetcher(type = "EditingContext", field = "referenceWidgetRootCreationDescriptions")
+public class ReferenceWidgetRootCreationDescriptionsDataFetcher implements IDataFetcherWithFieldCoordinates<CompletableFuture<List<ChildCreationDescription>>> {
+
+    private static final String DOMAIN_ID_ARGUMENT = "domainId";
+
+    private static final String REFERENCE_KIND_ARGUMENT = "referenceKind";
+    private static final String WIDGET_DESCRIPTION_ID = "descriptionId";
+
+    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+
+    public ReferenceWidgetRootCreationDescriptionsDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
+        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    }
+
+    @Override
+    public CompletableFuture<List<ChildCreationDescription>> get(DataFetchingEnvironment environment) throws Exception {
+        String editingContextId = environment.getSource();
+        String domainId = environment.getArgument(DOMAIN_ID_ARGUMENT);
+        String referenceKind = environment.getArgument(REFERENCE_KIND_ARGUMENT);
+        String descriptionId = environment.getArgument(WIDGET_DESCRIPTION_ID);
+
+        ReferenceWidgetRootCreationDescriptionsInput input = new ReferenceWidgetRootCreationDescriptionsInput(UUID.randomUUID(), editingContextId, domainId,
+                referenceKind, descriptionId);
+
+        return this.editingContextEventProcessorRegistry.dispatchEvent(input.editingContextId(), input)
+                .filter(EditingContextRootObjectCreationDescriptionsPayload.class::isInstance)
+                .map(EditingContextRootObjectCreationDescriptionsPayload.class::cast)
+                .map(EditingContextRootObjectCreationDescriptionsPayload::childCreationDescriptions)
+                .toFuture();
+    }
+
+}

--- a/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/IReferenceWidgetCreateElementHandler.java
+++ b/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/IReferenceWidgetCreateElementHandler.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.widget.reference;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.core.api.ChildCreationDescription;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+
+/**
+ * Handle a reference widget create element operations.
+ *
+ * @author frouene
+ */
+public interface IReferenceWidgetCreateElementHandler {
+
+    boolean canHandle(String descriptionId);
+
+    List<ChildCreationDescription> getRootCreationDescriptions(IEditingContext editingContext, String domainId, String referenceKind, String descriptionId);
+
+    List<ChildCreationDescription> getChildCreationDescriptions(IEditingContext editingContext, String kind, String referenceKind, String descriptionId);
+
+    Optional<Object> createRootObject(IEditingContext editingContext, UUID documentId, String domainId, String rootObjectCreationDescriptionId, String descriptionId);
+
+    Optional<Object> createChild(IEditingContext editingContext, Object object, String childCreationDescriptionId, String descriptionId);
+
+    /**
+     * Implementation which does nothing, used for mocks in unit tests.
+     *
+     * @author frouene
+     */
+    class NoOp implements IReferenceWidgetCreateElementHandler {
+
+        @Override
+        public boolean canHandle(String descriptionId) {
+            return true;
+        }
+
+        @Override
+        public List<ChildCreationDescription> getRootCreationDescriptions(IEditingContext editingContext, String domainId, String referenceKind, String descriptionId) {
+            return List.of();
+        }
+
+        @Override
+        public List<ChildCreationDescription> getChildCreationDescriptions(IEditingContext editingContext, String kind, String referenceKind, String descriptionId) {
+            return List.of();
+        }
+
+        @Override
+        public Optional<Object> createRootObject(IEditingContext editingContext, UUID documentId, String domainId, String rootObjectCreationDescriptionId, String descriptionId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Object> createChild(IEditingContext editingContext, Object object, String childCreationDescriptionId, String descriptionId) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceElementProps.java
+++ b/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceElementProps.java
@@ -22,7 +22,6 @@ import org.eclipse.sirius.components.annotations.Immutable;
 import org.eclipse.sirius.components.representations.Element;
 import org.eclipse.sirius.components.representations.IProps;
 import org.eclipse.sirius.components.representations.IStatus;
-import org.eclipse.sirius.components.widget.reference.dto.CreateElementInReferenceHandlerParameters;
 import org.eclipse.sirius.components.widget.reference.dto.MoveReferenceValueHandlerParameters;
 
 /**
@@ -70,8 +69,6 @@ public final class ReferenceElementProps implements IProps {
     private Function<Object, IStatus> setHandler;
 
     private Function<List<?>, IStatus> addHandler;
-
-    private Function<CreateElementInReferenceHandlerParameters, Object> createElementHandler;
 
     private Function<MoveReferenceValueHandlerParameters, IStatus> moveHandler;
 
@@ -151,10 +148,6 @@ public final class ReferenceElementProps implements IProps {
         return this.addHandler;
     }
 
-    public Function<CreateElementInReferenceHandlerParameters, Object> getCreateElementHandler() {
-        return this.createElementHandler;
-    }
-
     public Function<MoveReferenceValueHandlerParameters, IStatus> getMoveHandler() {
         return this.moveHandler;
     }
@@ -209,8 +202,6 @@ public final class ReferenceElementProps implements IProps {
         private Function<Object, IStatus> setHandler;
 
         private Function<List<?>, IStatus> addHandler;
-
-        private Function<CreateElementInReferenceHandlerParameters, Object> createElementHandler;
 
         private Function<MoveReferenceValueHandlerParameters, IStatus> moveHandler;
 
@@ -300,11 +291,6 @@ public final class ReferenceElementProps implements IProps {
             return this;
         }
 
-        public Builder createElementHandler(Function<CreateElementInReferenceHandlerParameters, Object> createElementHandler) {
-            this.createElementHandler = Objects.requireNonNull(createElementHandler);
-            return this;
-        }
-
         public Builder moveHandler(Function<MoveReferenceValueHandlerParameters, IStatus> moveHandler) {
             this.moveHandler = Objects.requireNonNull(moveHandler);
             return this;
@@ -335,7 +321,6 @@ public final class ReferenceElementProps implements IProps {
             referenceElementProps.clearHandler = this.clearHandler; // Optional on purpose
             referenceElementProps.setHandler = this.setHandler; // Optional on purpose
             referenceElementProps.addHandler = this.addHandler; // Optional on purpose
-            referenceElementProps.createElementHandler = this.createElementHandler;  // Optional on purpose
             referenceElementProps.moveHandler = this.moveHandler;  // Optional on purpose
             return referenceElementProps;
         }

--- a/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceWidget.java
+++ b/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceWidget.java
@@ -22,7 +22,6 @@ import org.eclipse.sirius.components.annotations.Immutable;
 import org.eclipse.sirius.components.forms.AbstractWidget;
 import org.eclipse.sirius.components.forms.validation.Diagnostic;
 import org.eclipse.sirius.components.representations.IStatus;
-import org.eclipse.sirius.components.widget.reference.dto.CreateElementInReferenceHandlerParameters;
 import org.eclipse.sirius.components.widget.reference.dto.MoveReferenceValueHandlerParameters;
 
 /**
@@ -54,8 +53,6 @@ public final class ReferenceWidget extends AbstractWidget {
     private Function<Object, IStatus> setHandler;
 
     private Function<List<?>, IStatus> addHandler;
-
-    private Function<CreateElementInReferenceHandlerParameters, Object> createElementHandler;
 
     private Function<MoveReferenceValueHandlerParameters, IStatus> moveHandler;
 
@@ -117,10 +114,6 @@ public final class ReferenceWidget extends AbstractWidget {
         return this.addHandler;
     }
 
-    public Function<CreateElementInReferenceHandlerParameters, Object> getCreateElementHandler() {
-        return this.createElementHandler;
-    }
-
     public Function<MoveReferenceValueHandlerParameters, IStatus> getMoveHandler() {
         return this.moveHandler;
     }
@@ -170,8 +163,6 @@ public final class ReferenceWidget extends AbstractWidget {
         private Function<Object, IStatus> setHandler;
 
         private Function<List<?>, IStatus> addHandler;
-
-        private Function<CreateElementInReferenceHandlerParameters, Object> createElementHandler;
 
         private Function<MoveReferenceValueHandlerParameters, IStatus> moveHandler;
 
@@ -261,11 +252,6 @@ public final class ReferenceWidget extends AbstractWidget {
             return this;
         }
 
-        public Builder createElementHandler(Function<CreateElementInReferenceHandlerParameters, Object> createElementHandler) {
-            this.createElementHandler = Objects.requireNonNull(createElementHandler);
-            return this;
-        }
-
         public Builder moveHandler(Function<MoveReferenceValueHandlerParameters, IStatus> moveHandler) {
             this.moveHandler = Objects.requireNonNull(moveHandler);
             return this;
@@ -296,7 +282,6 @@ public final class ReferenceWidget extends AbstractWidget {
             referenceWidget.clearHandler = this.clearHandler; // Optional on purpose
             referenceWidget.setHandler = this.setHandler; // Optional on purpose
             referenceWidget.addHandler = this.addHandler; // Optional on purpose
-            referenceWidget.createElementHandler = this.createElementHandler; // Optional on purpose
             referenceWidget.moveHandler = this.moveHandler; // Optional on purpose
             return referenceWidget;
         }

--- a/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceWidgetComponent.java
+++ b/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceWidgetComponent.java
@@ -25,7 +25,6 @@ import org.eclipse.sirius.components.representations.Element;
 import org.eclipse.sirius.components.representations.IComponent;
 import org.eclipse.sirius.components.representations.IStatus;
 import org.eclipse.sirius.components.representations.VariableManager;
-import org.eclipse.sirius.components.widget.reference.dto.CreateElementInReferenceHandlerParameters;
 import org.eclipse.sirius.components.widget.reference.dto.MoveReferenceValueHandlerParameters;
 
 /**
@@ -44,16 +43,6 @@ public class ReferenceWidgetComponent implements IComponent {
     public static final String MOVE_TO_VARIABLE = "toIndex";
 
     public static final String CLICK_EVENT_KIND_VARIABLE = "onClickEventKind";
-
-    public static final String DOCUMENT_ID_VARIABLE = "documentId";
-
-    public static final String DOMAIN_ID_VARIABLE = "domainId";
-
-    public static final String PARENT_VARIABLE = "parent";
-
-    public static final String CREATION_DESCRIPTION_ID_VARIABLE = "creationDescriptionId";
-
-    public static final String IS_CHILD_CREATION_VARIABLE = "isChildCreation";
 
     private final ReferenceWidgetComponentProps props;
 
@@ -130,25 +119,6 @@ public class ReferenceWidgetComponent implements IComponent {
                 return referenceDescription.getMoveHandlerProvider().apply(childVariableManager);
             };
             builder.moveHandler(moveHandler);
-        }
-        if (referenceDescription.getCreateElementHandlerProvider() != null) {
-            Function<CreateElementInReferenceHandlerParameters, Object> createElementHandler = input -> {
-                VariableManager childVariableManager = variableManager.createChild();
-                if (input.documentId() != null) {
-                    // root creation
-                    childVariableManager.put(IS_CHILD_CREATION_VARIABLE, false);
-                    childVariableManager.put(DOMAIN_ID_VARIABLE, input.domainId());
-                    childVariableManager.put(CREATION_DESCRIPTION_ID_VARIABLE, input.creationDescriptionId());
-                    childVariableManager.put(DOCUMENT_ID_VARIABLE, input.documentId());
-                } else {
-                    // child creation
-                    childVariableManager.put(IS_CHILD_CREATION_VARIABLE, true);
-                    childVariableManager.put(PARENT_VARIABLE, input.parent());
-                    childVariableManager.put(CREATION_DESCRIPTION_ID_VARIABLE, input.creationDescriptionId());
-                }
-                return referenceDescription.getCreateElementHandlerProvider().apply(childVariableManager);
-            };
-            builder.createElementHandler(createElementHandler);
         }
 
         if (readOnly != null) {

--- a/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceWidgetDescription.java
+++ b/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceWidgetDescription.java
@@ -71,8 +71,6 @@ public final class ReferenceWidgetDescription extends AbstractWidgetDescription 
 
     private Function<VariableManager, IStatus> addHandlerProvider;
 
-    private Function<VariableManager, Object> createElementHandlerProvider;
-
     private Function<VariableManager, IStatus> moveHandlerProvider;
 
     private ReferenceWidgetDescription() {
@@ -163,10 +161,6 @@ public final class ReferenceWidgetDescription extends AbstractWidgetDescription 
         return this.addHandlerProvider;
     }
 
-    public Function<VariableManager, Object> getCreateElementHandlerProvider() {
-        return this.createElementHandlerProvider;
-    }
-
     public Function<VariableManager, IStatus> getMoveHandlerProvider() {
         return this.moveHandlerProvider;
     }
@@ -236,8 +230,6 @@ public final class ReferenceWidgetDescription extends AbstractWidgetDescription 
         private Function<VariableManager, IStatus> setHandlerProvider;
 
         private Function<VariableManager, IStatus> addHandlerProvider;
-
-        private Function<VariableManager, Object> createElementHandlerProvider;
 
         private Function<VariableManager, IStatus> moveHandlerProvider;
 
@@ -375,11 +367,6 @@ public final class ReferenceWidgetDescription extends AbstractWidgetDescription 
             return this;
         }
 
-        public Builder createElementHandlerProvider(Function<VariableManager, Object> createElementHandlerProvider) {
-            this.createElementHandlerProvider = Objects.requireNonNull(createElementHandlerProvider);
-            return this;
-        }
-
         public Builder moveHandlerProvider(Function<VariableManager, IStatus> moveHandlerProvider) {
             this.moveHandlerProvider = Objects.requireNonNull(moveHandlerProvider);
             return this;
@@ -414,7 +401,6 @@ public final class ReferenceWidgetDescription extends AbstractWidgetDescription 
             referenceWidgetDescription.itemRemoveHandlerProvider = this.itemRemoveHandlerProvider; // Optional on purpose
             referenceWidgetDescription.setHandlerProvider = this.setHandlerProvider; // Optional on purpose
             referenceWidgetDescription.addHandlerProvider = this.addHandlerProvider; // Optional on purpose
-            referenceWidgetDescription.createElementHandlerProvider = this.createElementHandlerProvider;  // Optional on purpose
             referenceWidgetDescription.moveHandlerProvider = this.moveHandlerProvider;  // Optional on purpose
             return referenceWidgetDescription;
         }

--- a/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceWidgetDescriptor.java
+++ b/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceWidgetDescriptor.java
@@ -83,7 +83,6 @@ public class ReferenceWidgetDescriptor implements IWidgetDescriptor {
                     .clearHandler(props.getClearHandler())
                     .setHandler(props.getSetHandler())
                     .addHandler(props.getAddHandler())
-                    .createElementHandler(props.getCreateElementHandler())
                     .moveHandler(props.getMoveHandler());
             if (props.getHelpTextProvider() != null) {
                 builder.helpTextProvider(props.getHelpTextProvider());

--- a/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceWidgetPreviewConverterProvider.java
+++ b/packages/forms/backend/sirius-components-widget-reference/src/main/java/org/eclipse/sirius/components/widget/reference/ReferenceWidgetPreviewConverterProvider.java
@@ -78,7 +78,6 @@ public class ReferenceWidgetPreviewConverterProvider implements IWidgetPreviewCo
                 .itemRemoveHandlerProvider(variableManager -> new Success())
                 .setHandlerProvider(variableManager -> new Success())
                 .addHandlerProvider(variableManager -> new Success())
-                .createElementHandlerProvider(variableManager -> new Success())
                 .moveHandlerProvider(variableManager -> new Success())
                 .styleProvider(variableManager -> ReferenceWidgetPreviewConverterProvider.this.getWidgetStyle(referenceDescription, variableManager))
                 .diagnosticsProvider(variableManager -> List.of())

--- a/packages/forms/backend/sirius-components-widget-reference/src/main/resources/schema/reference.graphqls
+++ b/packages/forms/backend/sirius-components-widget-reference/src/main/resources/schema/reference.graphqls
@@ -2,6 +2,11 @@ extend type FormDescription {
   referenceValueOptions(referenceWidgetId: ID!): [ReferenceValue!]!
 }
 
+extend type EditingContext {
+  referenceWidgetRootCreationDescriptions(domainId: ID!, referenceKind: String, descriptionId: String!): [ChildCreationDescription!]!
+  referenceWidgetChildCreationDescriptions(kind: ID!, referenceKind: String, descriptionId: String!): [ChildCreationDescription!]!
+}
+
 type ReferenceWidget implements Widget {
   id: ID!
   descriptionId: String!
@@ -111,6 +116,7 @@ input CreateElementInReferenceInput {
   """
   domainId: ID
   creationDescriptionId: ID!
+  descriptionId: ID!
 }
 
 union CreateElementInReferencePayload = CreateElementInReferenceSuccessPayload | ErrorPayload

--- a/packages/forms/frontend/sirius-components-widget-reference/src/modals/CreateModal.tsx
+++ b/packages/forms/frontend/sirius-components-widget-reference/src/modals/CreateModal.tsx
@@ -107,10 +107,19 @@ const createElementInReferenceMutation = gql`
 `;
 
 const getChildCreationDescriptionsQuery = gql`
-  query getChildCreationDescriptions($editingContextId: ID!, $kind: ID!, $referenceKind: String) {
+  query getChildCreationDescriptions(
+    $editingContextId: ID!
+    $kind: ID!
+    $referenceKind: String
+    $descriptionId: String!
+  ) {
     viewer {
       editingContext(editingContextId: $editingContextId) {
-        childCreationDescriptions(kind: $kind, referenceKind: $referenceKind) {
+        referenceWidgetChildCreationDescriptions(
+          kind: $kind
+          referenceKind: $referenceKind
+          descriptionId: $descriptionId
+        ) {
           id
           label
           iconURL
@@ -124,12 +133,16 @@ const getRootObjectCreationDescriptionsQuery = gql`
   query getRootObjectCreationDescriptions(
     $editingContextId: ID!
     $domainId: ID!
-    $suggested: Boolean!
     $referenceKind: String
+    $descriptionId: String!
   ) {
     viewer {
       editingContext(editingContextId: $editingContextId) {
-        rootObjectCreationDescriptions(domainId: $domainId, suggested: $suggested, referenceKind: $referenceKind) {
+        referenceWidgetRootCreationDescriptions(
+          domainId: $domainId
+          referenceKind: $referenceKind
+          descriptionId: $descriptionId
+        ) {
           id
           label
           iconURL
@@ -297,6 +310,7 @@ export const CreateModal = ({ editingContextId, widget, onClose, formId }: Creat
         containerId,
         domainId: null,
         creationDescriptionId: selectedChildCreationDescriptionId,
+        descriptionId: widget.descriptionId,
       };
     } else if (createModal === 'validForRoot') {
       dispatch({ type: 'CREATE_ROOT' } as CreateRootEvent);
@@ -308,6 +322,7 @@ export const CreateModal = ({ editingContextId, widget, onClose, formId }: Creat
         containerId,
         domainId: selectedDomainId,
         creationDescriptionId: selectedChildCreationDescriptionId,
+        descriptionId: widget.descriptionId,
       };
     }
     createElementInReference({ variables: { input } });
@@ -335,6 +350,7 @@ export const CreateModal = ({ editingContextId, widget, onClose, formId }: Creat
           editingContextId,
           kind: containerKind,
           referenceKind: widget.reference.referenceKind,
+          descriptionId: widget.descriptionId,
         },
       });
     }
@@ -346,8 +362,8 @@ export const CreateModal = ({ editingContextId, widget, onClose, formId }: Creat
         variables: {
           editingContextId,
           domainId: selectedDomainId,
-          suggested: false,
           referenceKind: widget.reference.referenceKind,
+          descriptionId: widget.descriptionId,
         },
       });
     }

--- a/packages/forms/frontend/sirius-components-widget-reference/src/modals/CreateModal.types.ts
+++ b/packages/forms/frontend/sirius-components-widget-reference/src/modals/CreateModal.types.ts
@@ -28,6 +28,7 @@ export interface GQLGetChildCreationDescriptionsQueryVariables {
   editingContextId: string;
   kind: string;
   referenceKind?: string;
+  descriptionId: string;
 }
 
 export interface GQLGetChildCreationDescriptionsQueryData {
@@ -39,7 +40,7 @@ export interface GQLViewer {
 }
 
 export interface GQLEditingContext {
-  childCreationDescriptions: GQLChildCreationDescription[];
+  referenceWidgetChildCreationDescriptions: GQLChildCreationDescription[];
 }
 
 export interface GQLChildCreationDescription {
@@ -59,8 +60,8 @@ export interface GQLGetDomainsQueryData {
 export interface GQLGetRootObjectCreationDescriptionsQueryVariables {
   editingContextId: string;
   domainId: string;
-  suggested: boolean;
   referenceKind?: string;
+  descriptionId: string;
 }
 
 export interface GQLGetRootObjectCreationDescriptionsQueryData {
@@ -72,7 +73,7 @@ export interface GQLRootViewer {
 }
 
 export interface GQLRootEditingContext {
-  rootObjectCreationDescriptions: GQLRootChildCreationDescription[];
+  referenceWidgetRootCreationDescriptions: GQLRootChildCreationDescription[];
   domains: GQLDomain[];
 }
 
@@ -116,6 +117,7 @@ export interface GQLCreateElementInReferenceInput {
   containerId: string;
   domainId: string | null;
   creationDescriptionId: string;
+  descriptionId: string;
 }
 
 export interface GQLCreateElementInReferenceMutationData {

--- a/packages/forms/frontend/sirius-components-widget-reference/src/modals/CreateModalMachine.ts
+++ b/packages/forms/frontend/sirius-components-widget-reference/src/modals/CreateModalMachine.ts
@@ -350,17 +350,17 @@ export const createModalMachine = Machine<CreateModalContext, CreateModalStateSc
       }),
       updateChildCreationDescriptions: assign((_, event) => {
         const { data } = event as FetchedChildCreationDescriptionsEvent;
-        const { childCreationDescriptions } = data.viewer.editingContext;
+        const { referenceWidgetChildCreationDescriptions } = data.viewer.editingContext;
         const selectedChildCreationDescriptionId =
-          childCreationDescriptions.length > 0 ? childCreationDescriptions[0].id : '';
-        return { creationDescriptions: childCreationDescriptions, selectedChildCreationDescriptionId };
+          referenceWidgetChildCreationDescriptions.length > 0 ? referenceWidgetChildCreationDescriptions[0].id : '';
+        return { creationDescriptions: referenceWidgetChildCreationDescriptions, selectedChildCreationDescriptionId };
       }),
       updateRootChildCreationDescriptions: assign((_, event) => {
         const { data } = event as FetchedRootObjectCreationDescriptionsEvent;
-        const { rootObjectCreationDescriptions } = data.viewer.editingContext;
+        const { referenceWidgetRootCreationDescriptions } = data.viewer.editingContext;
         const selectedChildCreationDescriptionId =
-          rootObjectCreationDescriptions.length > 0 ? rootObjectCreationDescriptions[0].id : '';
-        return { creationDescriptions: rootObjectCreationDescriptions, selectedChildCreationDescriptionId };
+          referenceWidgetRootCreationDescriptions.length > 0 ? referenceWidgetRootCreationDescriptions[0].id : '';
+        return { creationDescriptions: referenceWidgetRootCreationDescriptions, selectedChildCreationDescriptionId };
       }),
       updateChildCreationDescription: assign((_, event) => {
         const { childCreationDescriptionId } = event as ChangeChildCreationDescriptionEvent;

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/ViewDetailsRenderingIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/ViewDetailsRenderingIntegrationTests.java
@@ -37,7 +37,6 @@ import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
 import org.eclipse.sirius.components.compatibility.emf.properties.api.IPropertiesValidationProvider;
 import org.eclipse.sirius.components.core.URLParser;
-import org.eclipse.sirius.components.core.api.IEditService;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IObjectService;
@@ -109,7 +108,7 @@ public class ViewDetailsRenderingIntegrationTests {
 
         EMFKindService emfKindService = new EMFKindService(new URLParser());
         IObjectService objectService = new ObjectService(emfKindService, composedAdapterFactory, new LabelFeatureProviderRegistry());
-        ViewPropertiesDescriptionServiceConfiguration parameters = new ViewPropertiesDescriptionServiceConfiguration(objectService, new IEditService.NoOp(), emfKindService, new IFeedbackMessageService.NoOp());
+        ViewPropertiesDescriptionServiceConfiguration parameters = new ViewPropertiesDescriptionServiceConfiguration(objectService, emfKindService, new IFeedbackMessageService.NoOp());
 
         // @formatter:off
         List<ITextfieldCustomizer> customizers = List.of(

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/ViewPropertiesDescriptionRegistryConfigurer.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/ViewPropertiesDescriptionRegistryConfigurer.java
@@ -36,7 +36,6 @@ import org.eclipse.sirius.components.compatibility.emf.properties.EStringIfDescr
 import org.eclipse.sirius.components.compatibility.emf.properties.NonContainmentReferenceIfDescriptionProvider;
 import org.eclipse.sirius.components.compatibility.emf.properties.NumberIfDescriptionProvider;
 import org.eclipse.sirius.components.compatibility.emf.properties.api.IPropertiesValidationProvider;
-import org.eclipse.sirius.components.core.api.IEditService;
 import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.emf.services.api.IEMFKindService;
@@ -99,12 +98,10 @@ public class ViewPropertiesDescriptionRegistryConfigurer implements IPropertiesD
 
     private final IFeedbackMessageService feedbackMessageService;
 
-    private final IEditService editService;
 
     public ViewPropertiesDescriptionRegistryConfigurer(ViewPropertiesDescriptionServiceConfiguration parameters, ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider,
             IEMFMessageService emfMessageService, List<ITextfieldCustomizer> customizers) {
         this.objectService = Objects.requireNonNull(parameters.getObjectService());
-        this.editService = Objects.requireNonNull(parameters.getEditService());
         this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
         this.emfMessageService = Objects.requireNonNull(emfMessageService);
@@ -209,7 +206,7 @@ public class ViewPropertiesDescriptionRegistryConfigurer implements IPropertiesD
         ifDescriptions.add(new EBooleanIfDescriptionProvider(this.composedAdapterFactory, this.propertiesValidationProvider, this.semanticTargetIdProvider).getIfDescription());
         ifDescriptions.add(new EEnumIfDescriptionProvider(this.composedAdapterFactory, this.propertiesValidationProvider, this.semanticTargetIdProvider).getIfDescription());
 
-        ifDescriptions.add(new NonContainmentReferenceIfDescriptionProvider(this.composedAdapterFactory, this.objectService, this.editService, this.emfKindService, this.feedbackMessageService, this.propertiesValidationProvider, this.semanticTargetIdProvider).getIfDescription());
+        ifDescriptions.add(new NonContainmentReferenceIfDescriptionProvider(this.composedAdapterFactory, this.objectService, this.emfKindService, this.feedbackMessageService, this.propertiesValidationProvider, this.semanticTargetIdProvider).getIfDescription());
 
         var numericDataTypes = List.of(
                 EcorePackage.Literals.EINT,

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/configuration/ViewPropertiesDescriptionServiceConfiguration.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/configuration/ViewPropertiesDescriptionServiceConfiguration.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.components.view.emf.configuration;
 
 import java.util.Objects;
 
-import org.eclipse.sirius.components.core.api.IEditService;
 import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.emf.services.api.IEMFKindService;
@@ -30,25 +29,18 @@ public class ViewPropertiesDescriptionServiceConfiguration {
 
     private final IObjectService objectService;
 
-    private final IEditService editService;
-
     private final IEMFKindService emfKindService;
 
     private final IFeedbackMessageService feedbackMessageService;
 
-    public ViewPropertiesDescriptionServiceConfiguration(IObjectService objectService, IEditService editService, IEMFKindService emfKindService, IFeedbackMessageService feedbackMessageService) {
+    public ViewPropertiesDescriptionServiceConfiguration(IObjectService objectService, IEMFKindService emfKindService, IFeedbackMessageService feedbackMessageService) {
         this.objectService = Objects.requireNonNull(objectService);
-        this.editService = Objects.requireNonNull(editService);
         this.emfKindService = Objects.requireNonNull(emfKindService);
         this.feedbackMessageService = Objects.requireNonNull(feedbackMessageService);
     }
 
     public IObjectService getObjectService() {
         return this.objectService;
-    }
-
-    public IEditService getEditService() {
-        return this.editService;
     }
 
     public IEMFKindService getEmfKindService() {


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/2460

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?