### PR TITLE
[2460] Reference widget default handler/provider do not need to be @Service

### DIFF
--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/ReferenceWidgetDefaultCreateElementHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/ReferenceWidgetDefaultCreateElementHandler.java
@@ -21,7 +21,6 @@ import org.eclipse.sirius.components.core.api.ChildCreationDescription;
 import org.eclipse.sirius.components.core.api.IEditService;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.widget.reference.IReferenceWidgetCreateElementHandler;
-import org.springframework.stereotype.Service;
 
 /**
  * * Default implementation of {@link IReferenceWidgetCreateElementHandler}.
@@ -29,7 +28,6 @@ import org.springframework.stereotype.Service;
  *
  * @author frouene
  */
-@Service
 public class ReferenceWidgetDefaultCreateElementHandler implements IReferenceWidgetCreateElementHandler {
 
     private final IEditService editService;
@@ -40,7 +38,7 @@ public class ReferenceWidgetDefaultCreateElementHandler implements IReferenceWid
 
     @Override
     public boolean canHandle(String descriptionId) {
-        return false; // Default implementation, it'll be used if no other service can handle the descriptionId
+        return true;
     }
 
     @Override

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/browser/ModelBrowsersDescriptionProvider.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/browser/ModelBrowsersDescriptionProvider.java
@@ -78,12 +78,12 @@ public class ModelBrowsersDescriptionProvider implements IRepresentationDescript
 
     private final ReferenceWidgetDefaultCandidateSearchProvider defaultCandidateProvider;
 
-    public ModelBrowsersDescriptionProvider(IObjectService objectService, IURLParser urlParser, IEMFKindService emfKindService, List<IReferenceWidgetRootCandidateSearchProvider> candidateProviders, ReferenceWidgetDefaultCandidateSearchProvider defaultCandidateProvider) {
+    public ModelBrowsersDescriptionProvider(IObjectService objectService, IURLParser urlParser, IEMFKindService emfKindService, List<IReferenceWidgetRootCandidateSearchProvider> candidateProviders) {
         this.objectService = Objects.requireNonNull(objectService);
         this.urlParser = Objects.requireNonNull(urlParser);
         this.emfKindService = Objects.requireNonNull(emfKindService);
         this.candidateProviders = Objects.requireNonNull(candidateProviders);
-        this.defaultCandidateProvider = Objects.requireNonNull(defaultCandidateProvider);
+        this.defaultCandidateProvider = new ReferenceWidgetDefaultCandidateSearchProvider();
     }
 
     @Override

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/browser/ReferenceWidgetDefaultCandidateSearchProvider.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/browser/ReferenceWidgetDefaultCandidateSearchProvider.java
@@ -22,7 +22,6 @@ import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.EditingContext;
 import org.eclipse.sirius.components.widget.reference.IReferenceWidgetRootCandidateSearchProvider;
-import org.springframework.stereotype.Service;
 
 /**
  * Default implementation of {@link IReferenceWidgetRootCandidateSearchProvider}.
@@ -30,12 +29,11 @@ import org.springframework.stereotype.Service;
  *
  * @author Arthur Daussy
  */
-@Service
 public class ReferenceWidgetDefaultCandidateSearchProvider implements IReferenceWidgetRootCandidateSearchProvider {
 
     @Override
     public boolean canHandle(String descriptionId) {
-        return false; // Default implementation, it'll be used if no other service can handle the descriptionId
+        return true;
     }
 
     @Override

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/CreateElementEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/CreateElementEventHandler.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.components.collaborative.widget.reference.dto.CreateEl
 import org.eclipse.sirius.components.collaborative.widget.reference.dto.CreateElementInput;
 import org.eclipse.sirius.components.collaborative.widget.reference.messages.IReferenceMessageService;
 import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditService;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IObjectService;
@@ -65,12 +66,12 @@ public class CreateElementEventHandler implements IFormEventHandler {
 
     private final IFeedbackMessageService feedbackMessageService;
 
-    public CreateElementEventHandler(IFormQueryService formQueryService, IReferenceMessageService messageService, IObjectService objectService, List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers, ReferenceWidgetDefaultCreateElementHandler defaultReferenceWidgetCreateElementHandler, MeterRegistry meterRegistry, IFeedbackMessageService feedbackMessageService) {
+    public CreateElementEventHandler(IFormQueryService formQueryService, IReferenceMessageService messageService, IObjectService objectService, List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers, IEditService editService, MeterRegistry meterRegistry, IFeedbackMessageService feedbackMessageService) {
         this.formQueryService = Objects.requireNonNull(formQueryService);
         this.messageService = Objects.requireNonNull(messageService);
         this.objectService = Objects.requireNonNull(objectService);
         this.referenceWidgetCreateElementHandlers = Objects.requireNonNull(referenceWidgetCreateElementHandlers);
-        this.defaultReferenceWidgetCreateElementHandler = Objects.requireNonNull(defaultReferenceWidgetCreateElementHandler);
+        this.defaultReferenceWidgetCreateElementHandler = new ReferenceWidgetDefaultCreateElementHandler(Objects.requireNonNull(editService));
         this.feedbackMessageService = Objects.requireNonNull(feedbackMessageService);
 
         this.counter = Counter.builder(Monitoring.EVENT_HANDLER).tag(Monitoring.NAME, this.getClass().getSimpleName()).register(meterRegistry);

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/ReferenceWidgetChildCreationDescriptionsEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/ReferenceWidgetChildCreationDescriptionsEventHandler.java
@@ -22,6 +22,7 @@ import org.eclipse.sirius.components.collaborative.dto.EditingContextChildObject
 import org.eclipse.sirius.components.collaborative.widget.reference.ReferenceWidgetDefaultCreateElementHandler;
 import org.eclipse.sirius.components.collaborative.widget.reference.dto.ReferenceWidgetChildCreationDescriptionsInput;
 import org.eclipse.sirius.components.core.api.ChildCreationDescription;
+import org.eclipse.sirius.components.core.api.IEditService;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
@@ -46,9 +47,9 @@ public class ReferenceWidgetChildCreationDescriptionsEventHandler implements IEd
 
     private final Counter counter;
 
-    public ReferenceWidgetChildCreationDescriptionsEventHandler(List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers, ReferenceWidgetDefaultCreateElementHandler defaultReferenceWidgetCreateElementHandler, MeterRegistry meterRegistry) {
+    public ReferenceWidgetChildCreationDescriptionsEventHandler(List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers, IEditService editService, MeterRegistry meterRegistry) {
         this.referenceWidgetCreateElementHandlers = Objects.requireNonNull(referenceWidgetCreateElementHandlers);
-        this.defaultReferenceWidgetCreateElementHandler = Objects.requireNonNull(defaultReferenceWidgetCreateElementHandler);
+        this.defaultReferenceWidgetCreateElementHandler = new ReferenceWidgetDefaultCreateElementHandler(Objects.requireNonNull(editService));
         this.counter = Counter.builder(Monitoring.EVENT_HANDLER).tag(Monitoring.NAME, this.getClass().getSimpleName()).register(meterRegistry);
     }
 

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/ReferenceWidgetRootCreationDescriptionsEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/main/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/ReferenceWidgetRootCreationDescriptionsEventHandler.java
@@ -22,6 +22,7 @@ import org.eclipse.sirius.components.collaborative.dto.EditingContextRootObjectC
 import org.eclipse.sirius.components.collaborative.widget.reference.ReferenceWidgetDefaultCreateElementHandler;
 import org.eclipse.sirius.components.collaborative.widget.reference.dto.ReferenceWidgetRootCreationDescriptionsInput;
 import org.eclipse.sirius.components.core.api.ChildCreationDescription;
+import org.eclipse.sirius.components.core.api.IEditService;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
@@ -43,11 +44,12 @@ public class ReferenceWidgetRootCreationDescriptionsEventHandler implements IEdi
     private final List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers;
 
     private final ReferenceWidgetDefaultCreateElementHandler defaultReferenceWidgetCreateElementHandler;
+
     private final Counter counter;
 
-    public ReferenceWidgetRootCreationDescriptionsEventHandler(List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers, ReferenceWidgetDefaultCreateElementHandler defaultReferenceWidgetCreateElementHandler, MeterRegistry meterRegistry) {
+    public ReferenceWidgetRootCreationDescriptionsEventHandler(List<IReferenceWidgetCreateElementHandler> referenceWidgetCreateElementHandlers, IEditService editService, MeterRegistry meterRegistry) {
         this.referenceWidgetCreateElementHandlers = Objects.requireNonNull(referenceWidgetCreateElementHandlers);
-        this.defaultReferenceWidgetCreateElementHandler = Objects.requireNonNull(defaultReferenceWidgetCreateElementHandler);
+        this.defaultReferenceWidgetCreateElementHandler = new ReferenceWidgetDefaultCreateElementHandler(Objects.requireNonNull(editService));
         this.counter = Counter.builder(Monitoring.EVENT_HANDLER).tag(Monitoring.NAME, this.getClass().getSimpleName()).register(meterRegistry);
     }
 

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/src/test/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/CreateElementEventHandlerTests.java
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/src/test/java/org/eclipse/sirius/components/collaborative/widget/reference/handlers/CreateElementEventHandlerTests.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.collaborative.forms.api.IFormQueryService;
-import org.eclipse.sirius.components.collaborative.widget.reference.ReferenceWidgetDefaultCreateElementHandler;
 import org.eclipse.sirius.components.collaborative.widget.reference.dto.CreateElementInReferenceSuccessPayload;
 import org.eclipse.sirius.components.collaborative.widget.reference.dto.CreateElementInput;
 import org.eclipse.sirius.components.collaborative.widget.reference.messages.IReferenceMessageService;
@@ -124,8 +123,7 @@ public class CreateElementEventHandlerTests {
         };
 
         CreateElementEventHandler handler = new CreateElementEventHandler(formQueryService, new IReferenceMessageService.NoOp(), objectService, List.of(referenceWidgetCreateElementHandler),
-                new ReferenceWidgetDefaultCreateElementHandler(new IEditService.NoOp()), new SimpleMeterRegistry(),
-                new IFeedbackMessageService.NoOp());
+                new IEditService.NoOp(), new SimpleMeterRegistry(), new IFeedbackMessageService.NoOp());
         assertThat(handler.canHandle(input)).isTrue();
 
         Sinks.Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
@@ -195,7 +193,7 @@ public class CreateElementEventHandlerTests {
             }
         };
 
-        CreateElementEventHandler handler = new CreateElementEventHandler(formQueryService, messageService, new IObjectService.NoOp(), List.of(), new ReferenceWidgetDefaultCreateElementHandler(new IEditService.NoOp()), new SimpleMeterRegistry(), new IFeedbackMessageService.NoOp());
+        CreateElementEventHandler handler = new CreateElementEventHandler(formQueryService, messageService, new IObjectService.NoOp(), List.of(), new IEditService.NoOp(), new SimpleMeterRegistry(), new IFeedbackMessageService.NoOp());
         assertThat(handler.canHandle(input)).isTrue();
 
         Sinks.Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();


### PR DESCRIPTION
In https://github.com/eclipse-sirius/sirius-web/pull/2502 both `ReferenceWidgetDefaultCreateElementHandler` and `ReferenceWidgetDefaultCandidateSearchProvider` are defined as Spring Boot `@Services`.

This means they will always appear in e.g. `List<IReferenceWidgetRootCandidateSearchProvider>` along with the "normal" (application-provided) ones. They need to return `false` on `canHandle()` to be ignored when iterating on these lists, which seems wrong as they actually *can* handle all descriptionId. Then we also inject them (a second time) through their concrete type to use them as fallbacks/actual defaults.

Do not mark them as `@Services`.

They can (correctly) return true on `canHandle`.

In the few places where we explictly want these default implementations, create them explicitly.
- `ReferenceWidgetDefaultCandidateSearchProvider` has no constructor dependency
- `ReferenceWidgetDefaultCreateElementHandler` only needs the `IEditService`, which we can get easily.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/2460
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
