### PR TITLE
[2359] Ignore hidden nodes when computing DnD targets & overlaps

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -67,7 +67,7 @@ image:doc/screenshots/compartmentWithHeaderWithoutSeparator.png[Compartment with
 - https://github.com/eclipse-sirius/sirius-web/issues/1712[#1712] [diagram] Fix an issue that triggers direct label edition even if there is no corresponding tool.
 Note that double-clicking no longer triggers a direct edit.
 - https://github.com/eclipse-sirius/sirius-web/issues/2498[#2498] [diagram] Fix an issue that prevents tool name to be displayed on multi lines in react flow diagram palette.
-- https://github.com/eclipse-sirius/sirius-web/issues/2491[2491] [diagram] Fix an issue where multiple tool section could be opened.
+- https://github.com/eclipse-sirius/sirius-web/issues/2491[#2491] [diagram] Fix an issue where multiple tool section could be opened.
 - https://github.com/eclipse-sirius/sirius-web/issues/2509[#2509] [diagram] Fix an issue that prevents using graphical DnD in deep node in some cases.
 - https://github.com/eclipse-sirius/sirius-web/issues/2453[#2453] [diagram] Add support for feedback messages on following actions: DropOnDiagram, DeleteFromDiagram, ReconnectEdge and EditLabel
 - https://github.com/eclipse-sirius/sirius-web/issues/2513[#2513] [diagram] Fix the double node border displayed when node list was containing compartments.
@@ -75,6 +75,7 @@ Note that double-clicking no longer triggers a direct edit.
 - https://github.com/eclipse-sirius/sirius-web/issues/2543[#2543] [diagram] Prevent list items being moved to inconsistent positions
 - https://github.com/eclipse-sirius/sirius-web/issues/2500[#2500] [diagram] Selecting an element in the explorer now correctly selects and focuses on the corresponding edge on the current diagram if there is one.
 - https://github.com/eclipse-sirius/sirius-web/issues/2547[#2547] [diagram] Fix a bug where edge labels could be hidden/covered by other nodes
+- https://github.com/eclipse-sirius/sirius-web/issues/2539[#2539] [diagram] Ignore hidden nodes when determining potential drop targets.
 
 === New Features
 

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.tsx
@@ -189,7 +189,7 @@ export const useDropNode = (): UseDropNodeValue => {
       (entry) => entry.droppedNodeDescriptionId === (node as Node<NodeData>).data.descriptionId
     );
     const compatibleNodes = getNodes()
-      .filter((candidate) => !isDescendantOf(node, candidate, getNodeById))
+      .filter((candidate) => !candidate.hidden && !isDescendantOf(node, candidate, getNodeById))
       .filter((n) => dropDataEntry?.droppableOnNodeTypes.includes((n as Node<NodeData>).data.descriptionId))
       .map((n) => n.id);
 
@@ -204,7 +204,7 @@ export const useDropNode = (): UseDropNodeValue => {
 
   const onNodeDrag: NodeDragHandler = (_event, node) => {
     if (draggedNode && !draggedNode.data.isBorderNode) {
-      const intersections = getIntersectingNodes(node);
+      const intersections = getIntersectingNodes(node).filter((node) => !node.hidden);
       const newParentId =
         [...intersections]
           .filter((intersectingNode) => !isDescendantOf(draggedNode, intersectingNode, getNodeById))


### PR DESCRIPTION
See https://github.com/eclipse-sirius/sirius-web/issues/2539 for the steps to reproduce.
