### PR TITLE
[2559] Allow to target the whole node when creating or reconnecting an edge

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -128,6 +128,7 @@ The new implementation of `IObjectService`, named `ComposedObjectService`, tries
 It is now possible to contribute specific services to edit domain objects, through `IEditServiceDelegate`.
 The new implementation of `IEditService`, named `ComposedEditService`, tries first to delegate to the appropriate `IEditServiceDelegate` and then fallback to a default behavior from `IDefaultEditService` if needed.
 - https://github.com/eclipse-sirius/sirius-web/issues/2555[#2555] [diagram] Add distinct edge creation handles (only visible when a node is selected).
+- https://github.com/eclipse-sirius/sirius-web/issues/2559[#2559] [diagram] Allow to target the whole node when creating or reconnecting an edge.
 
 == v2023.10.0
 

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/index.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/index.ts
@@ -25,6 +25,7 @@ export { useConnector } from './renderer/connector/useConnector';
 export { useDrop } from './renderer/drop/useDrop';
 export { useDropNode } from './renderer/dropNode/useDropNode';
 export { ConnectionCreationHandles } from './renderer/handles/ConnectionCreationHandles';
+export { ConnectionTargetHandle } from './renderer/handles/ConnectionTargetHandle';
 export type { ILayoutEngine, INodeLayoutHandler } from './renderer/layout/LayoutEngine.types';
 export * from './renderer/layout/layoutBorderNodes';
 export * from './renderer/layout/layoutNode';

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/ConnectorContext.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/ConnectorContext.tsx
@@ -12,7 +12,7 @@
  *******************************************************************************/
 
 import React, { useState } from 'react';
-import { Connection } from 'reactflow';
+import { Connection, XYPosition } from 'reactflow';
 import {
   ConnectorContextProviderProps,
   ConnectorContextProviderState,
@@ -22,9 +22,11 @@ import { GQLNodeDescription } from './useConnector.types';
 
 const defaultValue: ConnectorContextValue = {
   connection: null,
+  position: null,
   candidates: [],
   isNewConnection: false,
   setConnection: () => {},
+  setPosition: () => {},
   setCandidates: () => {},
   resetConnection: () => {},
   setIsNewConnection: () => {},
@@ -35,12 +37,17 @@ export const ConnectorContext = React.createContext<ConnectorContextValue>(defau
 export const ConnectorContextProvider = ({ children }: ConnectorContextProviderProps) => {
   const [state, setState] = useState<ConnectorContextProviderState>({
     connection: null,
+    position: null,
     candidates: [],
     isNewConnection: false,
   });
 
   const setConnection = (connection: Connection) => {
     setState((prevState) => ({ ...prevState, connection }));
+  };
+
+  const setPosition = (position: XYPosition) => {
+    setState((prevState) => ({ ...prevState, position }));
   };
 
   const setCandidates = (candidates: GQLNodeDescription[]) => {
@@ -64,9 +71,11 @@ export const ConnectorContextProvider = ({ children }: ConnectorContextProviderP
     <ConnectorContext.Provider
       value={{
         connection: state.connection,
+        position: state.position,
         candidates: state.candidates,
         isNewConnection: state.isNewConnection,
         setConnection,
+        setPosition,
         setCandidates,
         resetConnection,
         setIsNewConnection,

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/ConnectorContext.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/ConnectorContext.types.ts
@@ -11,14 +11,16 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { Connection } from 'reactflow';
+import { Connection, XYPosition } from 'reactflow';
 import { GQLNodeDescription } from './useConnector.types';
 
 export interface ConnectorContextValue {
   connection: Connection | null;
+  position: XYPosition | null;
   candidates: GQLNodeDescription[];
   isNewConnection: boolean;
   setConnection: (connection: Connection) => void;
+  setPosition: (position: XYPosition) => void;
   setCandidates: (candidates: GQLNodeDescription[]) => void;
   setIsNewConnection: (isNewConnection: boolean) => void;
   resetConnection: () => void;
@@ -30,6 +32,7 @@ export interface ConnectorContextProviderProps {
 
 export interface ConnectorContextProviderState {
   connection: Connection | null;
+  position: XYPosition | null;
   candidates: GQLNodeDescription[];
   isNewConnection: boolean;
 }

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/ConnectorContextualMenu.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/ConnectorContextualMenu.tsx
@@ -22,8 +22,6 @@ import { DiagramContext } from '../../contexts/DiagramContext';
 import { DiagramContextValue } from '../../contexts/DiagramContext.types';
 import {
   ConnectorContextualMenuProps,
-  GetConnectorToolsData,
-  GetConnectorToolsVariables,
   GQLDiagramDescription,
   GQLErrorPayload,
   GQLInvokeSingleClickOnTwoDiagramElementsToolData,
@@ -31,6 +29,8 @@ import {
   GQLInvokeSingleClickOnTwoDiagramElementsToolVariables,
   GQLRepresentationDescription,
   GQLTool,
+  GetConnectorToolsData,
+  GetConnectorToolsVariables,
 } from './ConnectorContextualMenu.types';
 import { useConnector } from './useConnector';
 
@@ -106,10 +106,6 @@ export const ConnectorContextualMenu = ({}: ConnectorContextualMenuProps) => {
   const connectionTarget: HTMLElement | null = connection
     ? document.querySelector(`[data-id="${connection.target}"]`)
     : null;
-  let connectionTargetHandle: HTMLElement | null = null;
-  if (connection && connectionTarget) {
-    connectionTargetHandle = connectionTarget.querySelector(`[data-handleid="${connection.targetHandle}"]`);
-  }
 
   const sourceDiagramElementId = connectionSource?.dataset.id ?? '';
   const targetDiagramElementId = connectionTarget?.dataset.id ?? '';
@@ -198,10 +194,7 @@ export const ConnectorContextualMenu = ({}: ConnectorContextualMenuProps) => {
     return null;
   }
   return (
-    <Menu
-      open={connectionSource !== null && connectionTarget !== null && connectionTargetHandle !== null}
-      onClose={onShouldConnectorContextualMenuClose}
-      anchorEl={connectionTargetHandle}>
+    <Menu open={!!connection} onClose={onShouldConnectorContextualMenuClose} anchorEl={connectionTarget}>
       {connectorTools.map((tool) => (
         <MenuItem key={tool.id} onClick={() => invokeTool(tool)}>
           <ListItemIcon>

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/ConnectorContextualMenu.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/ConnectorContextualMenu.tsx
@@ -95,7 +95,7 @@ const isDiagramDescription = (
 
 export const ConnectorContextualMenu = ({}: ConnectorContextualMenuProps) => {
   const { editingContextId, diagramId } = useContext<DiagramContextValue>(DiagramContext);
-  const { connection, onConnectorContextualMenuClose } = useConnector();
+  const { connection, position, onConnectorContextualMenuClose } = useConnector();
 
   const { addMessages, addErrorMessage } = useMultiToast();
 
@@ -194,7 +194,12 @@ export const ConnectorContextualMenu = ({}: ConnectorContextualMenuProps) => {
     return null;
   }
   return (
-    <Menu open={!!connection} onClose={onShouldConnectorContextualMenuClose} anchorEl={connectionTarget}>
+    <Menu
+      open={!!connection}
+      onClose={onShouldConnectorContextualMenuClose}
+      anchorEl={connectionTarget}
+      anchorReference="anchorPosition"
+      anchorPosition={{ left: position?.x || 0, top: position?.y || 0 }}>
       {connectorTools.map((tool) => (
         <MenuItem key={tool.id} onClick={() => invokeTool(tool)}>
           <ListItemIcon>

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/useConnector.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/useConnector.tsx
@@ -20,8 +20,16 @@ import { ConnectorContextValue } from './ConnectorContext.types';
 import { NodeStyleProvider, UseConnectorValue } from './useConnector.types';
 
 export const useConnector = (): UseConnectorValue => {
-  const { connection, setConnection, resetConnection, candidates, isNewConnection, setIsNewConnection } =
-    useContext<ConnectorContextValue>(ConnectorContext);
+  const {
+    connection,
+    setConnection,
+    position,
+    setPosition,
+    resetConnection,
+    candidates,
+    isNewConnection,
+    setIsNewConnection,
+  } = useContext<ConnectorContextValue>(ConnectorContext);
 
   const theme = useTheme();
   const { hideDiagramElementPalette } = useDiagramElementPalette();
@@ -69,7 +77,13 @@ export const useConnector = (): UseConnectorValue => {
     }
   };
 
-  const onConnectEnd: OnConnectEnd = (_event: MouseEvent | TouchEvent) => {
+  const onConnectEnd: OnConnectEnd = (event: MouseEvent | TouchEvent) => {
+    if ('clientX' in event && 'clientY' in event) {
+      setPosition({ x: event.clientX || 0, y: event.clientY });
+    } else if ('touches' in event) {
+      const touchEvent = event as TouchEvent;
+      setPosition({ x: touchEvent.touches[0]?.clientX || 0, y: touchEvent.touches[0]?.clientY || 0 });
+    }
     setIsNewConnection(false);
   };
 
@@ -81,5 +95,6 @@ export const useConnector = (): UseConnectorValue => {
     onConnectionStartElementClick,
     newConnectionStyleProvider,
     connection,
+    position,
   };
 };

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/useConnector.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/connector/useConnector.types.ts
@@ -11,7 +11,7 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { Connection, OnConnect, OnConnectEnd, OnConnectStart } from 'reactflow';
+import { Connection, OnConnect, OnConnectEnd, OnConnectStart, XYPosition } from 'reactflow';
 
 export interface UseConnectorValue {
   onConnect: OnConnect;
@@ -21,6 +21,7 @@ export interface UseConnectorValue {
   onConnectionStartElementClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   newConnectionStyleProvider: NodeStyleProvider;
   connection: Connection | null;
+  position: XYPosition | null;
 }
 
 export interface NodeStyleProvider {

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/handles/ConnectionTargetHandle.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/handles/ConnectionTargetHandle.tsx
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import React from 'react';
+import { Handle, Position, useStore } from 'reactflow';
+import { ConnectionTargetHandleProps } from './ConnectionTargetHandle.types';
+
+const targetHandleNodeStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  transform: 'none',
+  borderRadius: 0,
+  border: 'none',
+  opacity: 0,
+  pointerEvents: 'all',
+  cursor: 'crosshair',
+};
+
+export const ConnectionTargetHandle = ({ nodeId }: ConnectionTargetHandleProps) => {
+  const connectionNodeId = useStore((state) => state.connectionNodeId);
+  const isConnecting = !!connectionNodeId;
+  if (isConnecting) {
+    return (
+      <Handle
+        id={`handle--${nodeId}--target`}
+        type="target"
+        position={Position.Top}
+        style={targetHandleNodeStyle}
+        isConnectableEnd={true}
+        isConnectableStart={false}
+      />
+    );
+  } else {
+    return null;
+  }
+};

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/handles/ConnectionTargetHandle.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/handles/ConnectionTargetHandle.types.ts
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+export interface ConnectionTargetHandleProps {
+  nodeId: string;
+}

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/node/ImageNode.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/node/ImageNode.tsx
@@ -20,6 +20,7 @@ import { Label } from '../Label';
 import { useConnector } from '../connector/useConnector';
 import { useDropNode } from '../dropNode/useDropNode';
 import { ConnectionCreationHandles } from '../handles/ConnectionCreationHandles';
+import { ConnectionTargetHandle } from '../handles/ConnectionTargetHandle';
 import { DiagramElementPalette } from '../palette/DiagramElementPalette';
 import { ImageNodeData } from './ImageNode.types';
 
@@ -85,6 +86,7 @@ export const ImageNode = memo(({ data, isConnectable, id, selected }: NodeProps<
       {data.label ? <Label diagramElementId={id} label={data.label} faded={data.faded} transform="" /> : null}
       {selected ? <DiagramElementPalette diagramElementId={id} labelId={data.label ? data.label.id : null} /> : null}
       {selected ? <ConnectionCreationHandles nodeId={id} /> : null}
+      <ConnectionTargetHandle nodeId={id} />
       <Handle
         id={`handle--${id}--top`}
         type="source"

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/node/ListNode.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/node/ListNode.tsx
@@ -20,6 +20,7 @@ import { useConnector } from '../connector/useConnector';
 import { useDrop } from '../drop/useDrop';
 import { useDropNode } from '../dropNode/useDropNode';
 import { ConnectionCreationHandles } from '../handles/ConnectionCreationHandles';
+import { ConnectionTargetHandle } from '../handles/ConnectionTargetHandle';
 import { DiagramElementPalette } from '../palette/DiagramElementPalette';
 import { ListNodeData } from './ListNode.types';
 
@@ -69,6 +70,7 @@ export const ListNode = memo(({ data, isConnectable, id, selected }: NodeProps<L
         {data.label ? <Label diagramElementId={id} label={data.label} faded={data.faded} transform="" /> : null}
         {selected ? <DiagramElementPalette diagramElementId={id} labelId={data.label ? data.label.id : null} /> : null}
         {selected ? <ConnectionCreationHandles nodeId={id} /> : null}
+        <ConnectionTargetHandle nodeId={id} />
         <Handle
           id={`handle--${id}--top`}
           type="source"

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/node/RectangularNode.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/node/RectangularNode.tsx
@@ -20,6 +20,7 @@ import { useConnector } from '../connector/useConnector';
 import { useDrop } from '../drop/useDrop';
 import { useDropNode } from '../dropNode/useDropNode';
 import { ConnectionCreationHandles } from '../handles/ConnectionCreationHandles';
+import { ConnectionTargetHandle } from '../handles/ConnectionTargetHandle';
 import { DiagramElementPalette } from '../palette/DiagramElementPalette';
 import { RectangularNodeData } from './RectangularNode.types';
 
@@ -67,6 +68,7 @@ export const RectangularNode = memo(({ data, isConnectable, id, selected }: Node
         {data.label ? <Label diagramElementId={id} label={data.label} faded={data.faded} transform="" /> : null}
         {selected ? <DiagramElementPalette diagramElementId={id} labelId={data.label ? data.label.id : null} /> : null}
         {selected ? <ConnectionCreationHandles nodeId={id} /> : null}
+        <ConnectionTargetHandle nodeId={id} />
         <Handle
           id={`handle--${id}--top`}
           type="source"

--- a/packages/sirius-web/frontend/sirius-web/src/nodes/EllipseNode.tsx
+++ b/packages/sirius-web/frontend/sirius-web/src/nodes/EllipseNode.tsx
@@ -14,6 +14,7 @@
 import { getCSSColor } from '@eclipse-sirius/sirius-components-core';
 import {
   ConnectionCreationHandles,
+  ConnectionTargetHandle,
   DiagramElementPalette,
   Label,
   useConnector,
@@ -75,6 +76,7 @@ export const EllipseNode = memo(({ data, isConnectable, id, selected }: NodeProp
         {data.label ? <Label diagramElementId={id} label={data.label} faded={data.faded} transform="" /> : null}
         {selected ? <DiagramElementPalette diagramElementId={id} labelId={data.label ? data.label.id : null} /> : null}
         {selected ? <ConnectionCreationHandles nodeId={id} /> : null}
+        <ConnectionTargetHandle nodeId={id} />
         <Handle
           id={`handle--${id}--top`}
           type="source"


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/2559
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
