### PR TITLE
[2633] Make sure the grid is visible when enabled, even when moving a non-droppable node

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -118,6 +118,7 @@ It uses our algorithm instead of elk.js to perform the arrange-all.
 - https://github.com/eclipse-sirius/sirius-web/issues/2593[#2593] [diagram] Fix an issue where and edge could be reconnected if not selected after a semantic change.
 - https://github.com/eclipse-sirius/sirius-web/issues/2624[#2624] [diagram] Fix an issue where edge arrows in react flow diagrams were wrongly drawn.
 - https://github.com/eclipse-sirius/sirius-web/issues/2625[#2625] [diagram] Fix the line style computation on edge and border node.
+- https://github.com/eclipse-sirius/sirius-web/issues/2633[#2633] [diagram] Make sure the grid is visible when enabled, even when moving a non-droppable node
 
 === New Features
 

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/dropNode/useDropNode.ts
@@ -213,10 +213,9 @@ export const useDropNode = (): UseDropNodeValue => {
   );
 
   const theme = useTheme();
-  const diagramForbidden = draggedNode?.id !== null && !droppableOnDiagram;
   const diagramTargeted = targetNodeId === null && initialParentId !== null;
-  const backgroundColor =
-    diagramTargeted && diagramForbidden ? theme.palette.action.disabledBackground : theme.palette.background.default;
+  const diagramForbidden = diagramTargeted && draggedNode?.id !== null && !droppableOnDiagram;
+  const backgroundColor = diagramForbidden ? theme.palette.action.disabledBackground : theme.palette.background.default;
   const diagramBackgroundStyle: DiagramBackgroundStyle = {
     backgroundColor,
     smallGridColor: diagramForbidden ? backgroundColor : '#f1f1f1',


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/2633
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
