### PR TITLE
[2580] Cancel direct edit on 'Escape'

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -63,6 +63,7 @@ info: {
 === Bug fixes
 
 - https://github.com/eclipse-sirius/sirius-web/issues/2812[#2812] [trees] Fix an issue that prevents icon to be displayed in treeNodes.
+- https://github.com/eclipse-sirius/sirius-web/issues/2580[#2580] [diagram] Cancel direct edit on 'Esc'.
 
 === New Features
 

--- a/integration-tests/cypress/e2e/project/diagrams/direct-edit-label.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/direct-edit-label.cy.ts
@@ -99,6 +99,25 @@ describe('Diagram - Direct edit label', () => {
         diagram.getNodes('diagram', 'Entity2').trigger('keydown', { altKey: true, keyCode: 113, which: 113 }); // key code for F2
         cy.getByTestId('name-edit').should('exist');
       });
+
+      it('Then during edit triggering escape cancelled the current edition', () => {
+        const explorer = new Explorer();
+        explorer.createObject('Root', 'Entity2s Entity2');
+        explorer.getTreeItemByLabel('Entity2').click();
+
+        const details = new Details();
+        details.getTextField('Name').type('Entity2{Enter}');
+
+        const diagram = new Diagram();
+        diagram.fitToScreen();
+        diagram.getNodes('diagram', 'Entity2').click();
+        diagram.getPalette().should('exist');
+
+        cy.getByTestId('Edit - Tool').click();
+        cy.getByTestId('name-edit').should('exist').type('test{esc}');
+        diagram.getNodes('diagram', 'Entity2').should('exist');
+        diagram.getNodes('diagram', 'test').should('not.exist');
+      });
     });
   });
 });

--- a/integration-tests/cypress/workbench/Explorer.ts
+++ b/integration-tests/cypress/workbench/Explorer.ts
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2023 Obeo.
  * This program and the accompanying materials
- * are made available under the erms of the Eclipse Public License v2.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
@@ -57,6 +57,7 @@ export class Explorer {
     this.getTreeItemByLabel(objectTreeItemLabel).find('button').click();
     cy.getByTestId('new-object').click();
 
+    cy.getByTestId('childCreationDescription').children('[role="button"]').invoke('text').should('have.length.gt', 1);
     cy.getByTestId('childCreationDescription').click();
     cy.getByTestId('childCreationDescription')
       .get(`[data-value="${childCreationDescriptionLabel}"]`)

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/direct-edit/DiagramDirectEditInput.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/direct-edit/DiagramDirectEditInput.tsx
@@ -77,10 +77,10 @@ export const DiagramDirectEditInput = ({ labelId, editingKey, onClose, transform
     newLabel: initialLabel,
   });
 
+  const editionFinished = useRef<boolean>(false);
+
   const { addErrorMessage, addMessages } = useMultiToast();
-
   const { hideDiagramElementPalette } = useDiagramElementPalette();
-
   const { editingContextId, diagramId } = useContext<DiagramContextValue>(DiagramContext);
 
   const textInput = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
@@ -159,21 +159,29 @@ export const DiagramDirectEditInput = ({ labelId, editingKey, onClose, transform
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const newLabel = event.target.value;
-
     setState((prevState) => {
       return { ...prevState, newLabel: newLabel };
     });
   };
 
+  const onBlur = () => {
+    if (!editionFinished.current) {
+      doRename();
+    }
+  };
+
   const onFinishEditing = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const { key } = event;
     if (key === 'Enter' && !event.shiftKey) {
+      editionFinished.current = true;
       event.preventDefault();
       doRename();
     } else if (key === 'Escape') {
+      editionFinished.current = true;
       onClose();
     }
   };
+
   return (
     <>
       <TextField
@@ -185,7 +193,7 @@ export const DiagramDirectEditInput = ({ labelId, editingKey, onClose, transform
         multiline={true}
         onChange={handleChange}
         onKeyDown={onFinishEditing}
-        onBlur={doRename}
+        onBlur={onBlur}
         autoFocus
         data-testid="name-edit"
         style={{ transform }}


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/2580

To test, check (on a React Flow diagram and an element which supports direct edit):
1. Finishing a direct edit with an explicit _Return_ triggers the rename.
2. Finishing a direct edit by simply clicking elsewhere ("on blur") triggers the rename.
3. Finishing a direct edit by hitting _Escape_ *cancels* the operation, does not trigger the mutation and reverts to the initial state on the front.

