### PR TITLE
[2679] Align the input element like the corresponding label

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -84,6 +84,7 @@ info: {
 - https://github.com/eclipse-sirius/sirius-web/issues/2766[#2766] [tree] Tree representations (including the explorer) now support dragging any kind of element (not just semantic elements).
 It is the responsibility of the drop targets (e.g. a diagram) to validate the dropped element(s) type and ignore the one it does not support.
 - https://github.com/eclipse-sirius/sirius-web/issues/2772[#2772] Improve performance of the Palette
+- https://github.com/eclipse-sirius/sirius-web/issues/2679[#2679] [diagram] When editing a label, place input element closer to the label's location (centered).
 
 
 == v2023.12.0

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/Label.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/Label.tsx
@@ -57,20 +57,22 @@ export const Label = memo(({ diagramElementId, label, faded, transform }: LabelP
     }
   };
 
-  if (label.id === currentlyEditedLabelId) {
-    return (
+  const content: JSX.Element =
+    label.id === currentlyEditedLabelId ? (
       <DiagramDirectEditInput editingKey={editingKey} onClose={handleClose} labelId={label.id} transform={transform} />
+    ) : (
+      <>
+        <IconOverlay iconURL={label.iconURL} alt={label.text} />
+        {label.text}
+      </>
     );
-  }
-
   return (
     <div
       data-id={label.id}
       data-testid={`Label - ${label.text}`}
       style={labelStyle(theme, label.style, faded, transform, !!label.iconURL)}
       className="nopan">
-      <IconOverlay iconURL={label.iconURL} alt={label.text} />
-      {label.text}
+      {content}
     </div>
   );
 });


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/2679

[Capture vidéo du 2023-11-29 17-29-01.webm](https://github.com/eclipse-sirius/sirius-web/assets/10608/3a4c0bb6-e23b-43f6-9520-bdce060dd726)
