### PR TITLE
[2685] Fix direct edit of edge labels with F2

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -129,6 +129,7 @@ It uses our algorithm instead of elk.js to perform the arrange-all.
 - https://github.com/eclipse-sirius/sirius-web/issues/2647[#2647] [diagram] Split border shorthand CSS properties into non-shorthand properties for list nodes.
 Make some border node transparent when the node is in a list node in the convert engine.
 - https://github.com/eclipse-sirius/sirius-web/issues/2646[#2646] [diagram] Fix an issue where the palette was re rendering too much.
+- https://github.com/eclipse-sirius/sirius-web/issues/2685[#2685] [diagram] Fix direct edit of edge labels with F2.
 
 === New Features
 

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/direct-edit/useDiagramDirectEdit.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/direct-edit/useDiagramDirectEdit.tsx
@@ -38,9 +38,11 @@ export const useDiagramDirectEdit = (): UseDiagramDirectEditValue => {
       const validFirstInputChar =
         !event.metaKey && !event.ctrlKey && key.length === 1 && directEditActivationValidCharacters.test(key);
       let currentlyEditedLabelId: string | undefined | null = nodes.find((node) => node.selected)?.data.label?.id;
-      const isLabelEditable: boolean = nodes.find((node) => node.selected)?.data.labelEditable || false;
+      let isLabelEditable: boolean = nodes.find((node) => node.selected)?.data.labelEditable || false;
       if (!currentlyEditedLabelId) {
         currentlyEditedLabelId = edges.find((edge) => edge.selected)?.data?.label?.id;
+        // GQLEdge does not expose a labelEditable flag, so we currently assume all edge (center) labels are editable.
+        isLabelEditable = true;
       }
 
       if (currentlyEditedLabelId && isLabelEditable) {


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/2685
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
