### PR TITLE
[2600] Add a small margin at the top of a page

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -197,6 +197,7 @@ The new implementation of `IEditService`, named `ComposedEditService`, tries fir
 - https://github.com/eclipse-sirius/sirius-web/issues/2595[#2595] [diagram] Call the layout on node move and resize.
 Node will not be outside of their container, nor on a node header because of a move or resize.
 - https://github.com/eclipse-sirius/sirius-web/issues/2552[#2552] [diagram] Hide the diagram palette on 'Esc'
+- https://github.com/eclipse-sirius/sirius-web/issues/2600[#2600] [form] Add a small margin at the top of a page
 
 == v2023.10.0
 

--- a/packages/forms/frontend/sirius-components-forms/src/form/Form.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/form/Form.tsx
@@ -10,9 +10,9 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { makeStyles } from '@material-ui/core/styles';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
+import { makeStyles } from '@material-ui/core/styles';
 import React, { useEffect, useState } from 'react';
 import { Page } from '../pages/Page';
 import { ToolbarAction } from '../toolbaraction/ToolbarAction';
@@ -24,6 +24,7 @@ const useFormStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     paddingLeft: theme.spacing(1),
     paddingRight: theme.spacing(1),
+    gap: theme.spacing(1),
   },
   tabsRoot: {
     minHeight: theme.spacing(4),

--- a/packages/forms/frontend/sirius-components-forms/src/pages/Page.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/pages/Page.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2023 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at

--- a/packages/forms/frontend/sirius-components-forms/src/representations/FormRepresentation.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/representations/FormRepresentation.tsx
@@ -63,6 +63,10 @@ const formEventSubscription = (contributions: Array<WidgetContribution>) =>
 
 const useFormRepresentationStyles = makeStyles((theme) => ({
   page: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    paddingTop: theme.spacing(1),
     paddingLeft: theme.spacing(1),
     paddingRight: theme.spacing(1),
     overflowY: 'scroll',


### PR DESCRIPTION
This helps delineate the page's tab from the content, in particular
when the page contains action buttons.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/2600

**Before**

![before](https://github.com/eclipse-sirius/sirius-web/assets/10608/04b7899a-8009-46ed-89cf-cf88e470913f)

**After**

![after](https://github.com/eclipse-sirius/sirius-web/assets/10608/addf119b-7f7a-4903-b6d6-6f0f7b4456b5)

Note the added space above the "Group Action" button which is no longer too close to the page tabs separator.