### PR TITLE
[test] Make integration tests more robust

### DIFF
--- a/integration-tests/cypress/e2e/project/diagrams/diagram-contextual-palette.cy.js
+++ b/integration-tests/cypress/e2e/project/diagrams/diagram-contextual-palette.cy.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -102,6 +102,10 @@ describe('/projects/:projectId/edit - Robot Diagram', () => {
     cy.getByTestId('ViewNewModel').dblclick();
     cy.getByTestId('View').dblclick();
     cy.get('[data-testid$=" Diagram Description"]').dblclick();
+    cy.get('[data-testid$=" Diagram Description-more"]').click();
+    cy.getByTestId('treeitem-contextmenu').findByTestId('rename-tree-item').click();
+    cy.getByTestId('name-edit').type('Diagram Description{enter}');
+
     cy.createChildObject('DiagramPalette', 'Diagram Tool Section');
     cy.getByTestId('Tool Section').click();
     cy.getByTestId('Name').type('{selectAll}section1');
@@ -144,6 +148,8 @@ describe('/projects/:projectId/edit - Robot Diagram', () => {
     cy.getByTestId('treeitem-contextmenu').findByTestId('new-representation').click();
     cy.getByTestId('name').clear();
     cy.getByTestId('name').type('__REACT_FLOW');
+    cy.getByTestId('representationDescription').click();
+    cy.getByTestId('Diagram Description').click();
     cy.getByTestId('create-representation').click();
 
     cy.getByTestId('rf__wrapper')

--- a/integration-tests/cypress/e2e/project/diagrams/diagram.cy.js
+++ b/integration-tests/cypress/e2e/project/diagrams/diagram.cy.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Obeo.
+ * Copyright (c) 2021, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,8 @@ describe('/projects/:projectId/edit - Diagram', () => {
 
     cy.getByTestId('name').clear();
     cy.getByTestId('name').type('Topography1__SPROTTY');
+    cy.getByTestId('representationDescription').click();
+    cy.getByTestId('Topography').click();
     cy.getByTestId('create-representation').click();
 
     cy.getByTestId('Robot-more').click();

--- a/integration-tests/cypress/e2e/project/formdescriptioneditor/formdescriptioneditor.cy.js
+++ b/integration-tests/cypress/e2e/project/formdescriptioneditor/formdescriptioneditor.cy.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,8 @@ describe('/projects/:projectId/edit - FormDescriptionEditor', () => {
     cy.getByTestId('New Form Description').click();
     cy.getByTestId('New Form Description-more').should('be.enabled').click();
     cy.getByTestId('treeitem-contextmenu').findByTestId('new-representation').click();
+    cy.getByTestId('representationDescription').click();
+    cy.getByTestId('FormDescriptionEditor').click();
     cy.getByTestId('create-representation').click();
   });
 

--- a/integration-tests/cypress/e2e/project/representations.cy.js
+++ b/integration-tests/cypress/e2e/project/representations.cy.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Obeo.
+ * Copyright (c) 2021, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the erms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -80,6 +80,8 @@ describe('/projects/:projectId/edit - Representations', () => {
     cy.getByTestId('treeitem-contextmenu').findByTestId('new-representation').click();
     cy.getByTestId('name').clear();
     cy.getByTestId('name').type('Topography1__SPROTTY');
+    cy.getByTestId('representationDescription').click();
+    cy.getByTestId('Topography').click();
     cy.getByTestId('create-representation').click();
     cy.getByTestId('representation-tab-Topography1__SPROTTY').should('exist');
 
@@ -91,6 +93,8 @@ describe('/projects/:projectId/edit - Representations', () => {
     cy.getByTestId('treeitem-contextmenu').findByTestId('new-representation').click();
     cy.getByTestId('name').clear();
     cy.getByTestId('name').type('Topography2__SPROTTY');
+    cy.getByTestId('representationDescription').click();
+    cy.getByTestId('Topography').click();
     cy.getByTestId('create-representation').click();
     cy.getByTestId('representation-tab-Topography2__SPROTTY').should('exist');
 

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/formdescritpioneditors/FormDescriptionEditorPageIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/formdescritpioneditors/FormDescriptionEditorPageIntegrationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -59,6 +59,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import graphql.ExecutionInput;
 import graphql.GraphQL;
+import net.minidev.json.JSONArray;
 import reactor.test.StepVerifier;
 
 /**
@@ -283,6 +284,7 @@ public class FormDescriptionEditorPageIntegrationTests extends AbstractIntegrati
                          edges {
                            node {
                              id
+                             label
                            }
                          }
                        }
@@ -301,7 +303,8 @@ public class FormDescriptionEditorPageIntegrationTests extends AbstractIntegrati
         String representationDescriptionId = null;
         try {
             var jsonResult = this.objectMapper.writeValueAsString(getRepresentationDescriptionsExecutionResult.toSpecification());
-            representationDescriptionId = JsonPath.read(jsonResult, "$.data.viewer.editingContext.representationDescriptions.edges[0].node.id");
+            var matches = (JSONArray) JsonPath.read(jsonResult, "$.data.viewer.editingContext.representationDescriptions.edges[?(@.node.label=='FormDescriptionEditor')].node.id");
+            representationDescriptionId = (String) matches.get(0);
         } catch (JsonProcessingException exception) {
             fail(exception.getMessage());
         }

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/view/ViewDiagramIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/view/ViewDiagramIntegrationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import graphql.ExecutionInput;
 import graphql.GraphQL;
+import net.minidev.json.JSONArray;
 import reactor.test.StepVerifier;
 
 /**
@@ -264,6 +265,7 @@ public class ViewDiagramIntegrationTests extends AbstractIntegrationTests {
                         edges {
                           node {
                             id
+                            label
                           }
                         }
                       }
@@ -282,7 +284,8 @@ public class ViewDiagramIntegrationTests extends AbstractIntegrationTests {
         String representationDescriptionId = null;
         try {
             var jsonResult = this.objectMapper.writeValueAsString(getRepresentationDescriptionsExecutionResult.toSpecification());
-            representationDescriptionId = JsonPath.read(jsonResult, "$.data.viewer.editingContext.representationDescriptions.edges[0].node.id");
+            var matches = (JSONArray) JsonPath.read(jsonResult, "$.data.viewer.editingContext.representationDescriptions.edges[?(@.node.label=='Diagram')].node.id");
+            representationDescriptionId = (String) matches.get(0);
         } catch (JsonProcessingException exception) {
             fail(exception.getMessage());
         }

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/view/ViewFormIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/view/ViewFormIntegrationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -55,6 +55,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import graphql.ExecutionInput;
 import graphql.GraphQL;
+import net.minidev.json.JSONArray;
 import reactor.test.StepVerifier;
 
 /**
@@ -245,6 +246,7 @@ public class ViewFormIntegrationTests extends AbstractIntegrationTests {
                     edges {
                       node {
                         id
+                        label
                       }
                     }
                   }
@@ -263,7 +265,8 @@ public class ViewFormIntegrationTests extends AbstractIntegrationTests {
         String representationDescriptionId = null;
         try {
             var jsonResult = this.objectMapper.writeValueAsString(getRepresentationDescriptionsExecutionResult.toSpecification());
-            representationDescriptionId = JsonPath.read(jsonResult, "$.data.viewer.editingContext.representationDescriptions.edges[1].node.id");
+            var matches = (JSONArray) JsonPath.read(jsonResult, "$.data.viewer.editingContext.representationDescriptions.edges[?(@.node.label=='Overview Form')].node.id");
+            representationDescriptionId = (String) matches.get(0);
         } catch (JsonProcessingException exception) {
             fail(exception.getMessage());
         }

--- a/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/view/ViewInitialDirectEditElementLabelProviderIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web-sample-application/src/test/java/org/eclipse/sirius/web/sample/tests/integration/view/ViewInitialDirectEditElementLabelProviderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import graphql.ExecutionInput;
 import graphql.GraphQL;
+import net.minidev.json.JSONArray;
 import reactor.test.StepVerifier;
 
 /**
@@ -299,6 +300,7 @@ public class ViewInitialDirectEditElementLabelProviderIntegrationTests extends A
                         edges {
                           node {
                             id
+                            label
                           }
                         }
                       }
@@ -317,7 +319,8 @@ public class ViewInitialDirectEditElementLabelProviderIntegrationTests extends A
         String representationDescriptionId = null;
         try {
             var jsonResult = this.objectMapper.writeValueAsString(getRepresentationDescriptionsExecutionResult.toSpecification());
-            representationDescriptionId = JsonPath.read(jsonResult, "$.data.viewer.editingContext.representationDescriptions.edges[0].node.id");
+            var matches = (JSONArray) JsonPath.read(jsonResult, "$.data.viewer.editingContext.representationDescriptions.edges[?(@.node.label=='Diagram')].node.id");
+            representationDescriptionId = (String) matches.get(0);
         } catch (JsonProcessingException exception) {
             fail(exception.getMessage());
         }


### PR DESCRIPTION
Find the expected representation descriptions by their label instead of hard-coded indexes.

Otherwise the integration tests in my branches where the 'Portal' representation is available (on all objects).
