### PR TITLE
[2910] Make the initial drop area larger and more visible on empty portals

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -168,6 +168,7 @@ This change makes the editing context the single source of truth for the state o
 - https://github.com/eclipse-sirius/sirius-web/issues/2904[#2904] [sirius-web] Order candidates in Representations sections in the Onboard Area.
 - https://github.com/eclipse-sirius/sirius-web/issues/2903[#2903] [sirius-web] Order New Representation modal candidates.
 - https://github.com/eclipse-sirius/sirius-web/issues/2796[#2796] [sirius-web] Flow diagram description has been converted to the view DSL.
+- https://github.com/eclipse-sirius/sirius-web/issues/2910[#2910] [portal] Make the initial drop area larger and more visible on empty portals
 
 == v2023.12.0
 


### PR DESCRIPTION
It's better that the empty zone before, but I can't (yet) quite get an active zone which actually matches the full area (hence the visible background to clearly identify the limits of the active zone).

[Capture vidéo du 2024-01-11 16-38-43.webm](https://github.com/eclipse-sirius/sirius-web/assets/10608/d0551717-a0de-4732-aa16-b0a79212ba02)
