### PR TITLE
[2934] Fix the initial position of representations added into portals

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -113,6 +113,7 @@ Now, for a multi-valued feature, the values are properly displayed and the delet
 - https://github.com/eclipse-sirius/sirius-web/issues/2678[#2678] [diagram] Fix an issue where tools from the diagram palette where not executed.
 - https://github.com/eclipse-sirius/sirius-web/issues/2943[#2943] [view] Fix an issue where the default colors were not applied to sub-nodes and border nodes.
 - https://github.com/eclipse-sirius/sirius-web/issues/2957[#2957] [diagram] Fix an issue where childs of custom node lose their position.
+- https://github.com/eclipse-sirius/sirius-web/issues/2934[#2934] [portal] Fix the initial position of representations added into portals
 
 === New Features
 

--- a/packages/portals/backend/sirius-components-collaborative-portals/src/main/java/org/eclipse/sirius/components/collaborative/portals/dto/AddPortalViewInput.java
+++ b/packages/portals/backend/sirius-components-collaborative-portals/src/main/java/org/eclipse/sirius/components/collaborative/portals/dto/AddPortalViewInput.java
@@ -21,5 +21,5 @@ import org.eclipse.sirius.components.collaborative.portals.api.IPortalInput;
  *
  * @author pcdavid
  */
-public record AddPortalViewInput(UUID id, String editingContextId, String representationId, String viewRepresentationId) implements IPortalInput {
+public record AddPortalViewInput(UUID id, String editingContextId, String representationId, String viewRepresentationId, int x, int y, int width, int height) implements IPortalInput {
 }

--- a/packages/portals/backend/sirius-components-collaborative-portals/src/main/java/org/eclipse/sirius/components/collaborative/portals/handlers/AddPortalViewEventHandler.java
+++ b/packages/portals/backend/sirius-components-collaborative-portals/src/main/java/org/eclipse/sirius/components/collaborative/portals/handlers/AddPortalViewEventHandler.java
@@ -78,7 +78,7 @@ public class AddPortalViewEventHandler implements IPortalEventHandler {
                 } else if (portalServices.referencesRepresentation(context.getCurrentPortal(), addPortalViewInput.viewRepresentationId())) {
                     payload = new ErrorPayload(portalInput.id(), "The representation is already included in the portal");
                 } else {
-                    var newPortal = portalServices.addView(context.getCurrentPortal(), addPortalViewInput.viewRepresentationId());
+                    var newPortal = portalServices.addView(context.getCurrentPortal(), addPortalViewInput.viewRepresentationId(), addPortalViewInput.x(), addPortalViewInput.y(), addPortalViewInput.width(), addPortalViewInput.height());
                     context.setNextPortal(newPortal);
                     payload = new SuccessPayload(addPortalViewInput.id(), List.of());
                     changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, context.getEditingContext().getId(), context.getInput());

--- a/packages/portals/backend/sirius-components-collaborative-portals/src/main/resources/schema/portal.graphqls
+++ b/packages/portals/backend/sirius-components-collaborative-portals/src/main/resources/schema/portal.graphqls
@@ -45,6 +45,10 @@ input AddPortalViewInput {
   editingContextId: ID!
   representationId: ID!
   viewRepresentationId: ID!
+  x: Int!
+  y: Int!
+  width: Int!
+  height: Int!
 }
 
 union AddPortalViewPayload = SuccessPayload | ErrorPayload

--- a/packages/portals/frontend/sirius-components-portals/src/hooks/usePortalMutations.types.ts
+++ b/packages/portals/frontend/sirius-components-portals/src/hooks/usePortalMutations.types.ts
@@ -12,9 +12,10 @@
  *******************************************************************************/
 
 export interface UsePortalMutationsValue {
-  addPortalView: (viewRepresentationId: string) => void;
+  addPortalView: (viewRepresentationId: string, x: number, y: number, width: number, height: number) => void;
   removePortalView: (portalViewId: string) => void;
   layoutPortal: (layoutData: GQLLayoutPortalLayoutData[]) => void;
+  layoutInProgress: boolean;
 }
 
 // mutation addPortalView
@@ -27,6 +28,10 @@ export interface GQLAddPortalViewInput {
   editingContextId: string;
   representationId: string;
   viewRepresentationId: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 export interface GQLAddPortalViewMutationData {


### PR DESCRIPTION
- [2910] Make the initial drop area larger and more visible on empty portals
- [2934] Fix the initial position of representations added into portals

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?