### PR TITLE
[2678] Put the PalettePortal higher in the dom tree

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -107,6 +107,7 @@ Now, for a multi-valued feature, the values are properly displayed and the delet
 - https://github.com/eclipse-sirius/sirius-web/issues/2755[#2755] [diagram] Ensure that the unfolded tool section is always visible above the rest of the palette
 - https://github.com/eclipse-sirius/sirius-web/issues/2786[#2786] [diagram] Fix an issue where resizing was clunky.
 - https://github.com/eclipse-sirius/sirius-web/issues/2912[#2912] [diagram] Send all requested node descriptions to the frontend when requested.
+- https://github.com/eclipse-sirius/sirius-web/issues/2678[#2678] [diagram] Fix an issue where tools from the diagram palette where not executed.
 
 === New Features
 

--- a/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/palette/PalettePortal.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams-reactflow/src/renderer/palette/PalettePortal.tsx
@@ -12,17 +12,20 @@
  *******************************************************************************/
 
 import { createPortal } from 'react-dom';
-import { ReactFlowState, useStore } from 'reactflow';
 import { PalettePortalProps } from './PalettePortal.types';
 
-const selector = (state: ReactFlowState) => state.domNode?.querySelector('.react-flow__renderer');
+//The sibling dom element .react-flow__renderer have a zIndex of 4, so we set it here to 5 to have the palette in front of the diagram.
+const palettePortalStyle: React.CSSProperties = {
+  zIndex: 5,
+  position: 'absolute',
+};
 
 export const PalettePortal = ({ children }: PalettePortalProps) => {
-  const wrapperRef = useStore(selector);
+  const wrapperRef = document.querySelector('.react-flow');
 
   if (!wrapperRef) {
     return null;
   }
 
-  return createPortal(children, wrapperRef);
+  return createPortal(<div style={palettePortalStyle}>{children}</div>, wrapperRef);
 };


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/2678

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?