### PR TITLE
[fix] Register portals in RepresentationMetadataDataFetcher

### DIFF
--- a/packages/sirius-web/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/representation/RepresentationMetadataDataFetcher.java
+++ b/packages/sirius-web/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/representation/RepresentationMetadataDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -56,7 +56,8 @@ public class RepresentationMetadataDataFetcher implements IDataFetcherWithFieldC
                 FieldCoordinates.coordinates("Selection", METADATA_FIELD),
                 FieldCoordinates.coordinates("Validation", METADATA_FIELD),
                 FieldCoordinates.coordinates("Gantt", METADATA_FIELD),
-                FieldCoordinates.coordinates("Deck", METADATA_FIELD)
+                FieldCoordinates.coordinates("Deck", METADATA_FIELD),
+                FieldCoordinates.coordinates("Portal", METADATA_FIELD)
         );
         // @formatter:on
     }


### PR DESCRIPTION
Not exactly sure what are the impacts of not having this. I only needed this in the context of #2879 which is in pause/abandonned, but still it seems more consistent to register it like the others.
