### PR TITLE
[2948] Use a better icon for the button to remove a view from a portal

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -177,6 +177,7 @@ This change makes the editing context the single source of truth for the state o
 - https://github.com/eclipse-sirius/sirius-web/issues/2932[#2932] The line and the handle used to resize a node is now bigger. The handle is now circular.
 .Old resize handles vs new ones
 image:doc/screenshots/biggerResizeHandles2.png[Compartment with header without separator,70%]
+- https://github.com/eclipse-sirius/sirius-web/issues/2948[#2948] [portal] Use a "close" icon instead of "delete" icon for the button that removes a representation from a portal (but does not delete the representation).
 
 == v2023.12.0
 

--- a/packages/portals/frontend/sirius-components-portals/src/representations/RepresentationFrame.tsx
+++ b/packages/portals/frontend/sirius-components-portals/src/representations/RepresentationFrame.tsx
@@ -19,7 +19,7 @@ import {
 import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
-import DeleteIcon from '@material-ui/icons/Delete';
+import CloseOutlinedIcon from '@material-ui/icons/CloseOutlined';
 import { useContext } from 'react';
 import { RepresentationFrameProps } from './RepresentationFrame.types';
 
@@ -76,7 +76,7 @@ export const RepresentationFrame = ({
                 onDelete();
               }}
               size="small">
-              <DeleteIcon fontSize="small" />
+              <CloseOutlinedIcon fontSize="small" />
             </IconButton>
           ) : null}
         </div>


### PR DESCRIPTION
Note the "X" icons instead of "trash cans" before:

![image](https://github.com/eclipse-sirius/sirius-web/assets/10608/e41f0c2f-975c-49e7-970a-2a6394914113)
