### PR TITLE
Avoid unnecessary work

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -78,6 +78,7 @@ image:doc/screenshots/deploymenDiagram.png[Deployment Diagram,70%]
 - https://github.com/eclipse-sirius/sirius-web/issues/3056[#3056] [trees] Expand the clickable/draggable zone for tree items
 - [forms] Avoid creating a new subscription when re-selecting the same element
 - [tree] Avoid sending treePath query if the selection does not actually change
+- [core] Ignore empty changes of kind ChangeKind.NOTHING
 
 
 == v2024.1.0

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -76,6 +76,8 @@ image:doc/screenshots/deploymenDiagram.png[Deployment Diagram,70%]
 - https://github.com/eclipse-sirius/sirius-web/issues/1844[#1844] [emf] Unload resources by default when the EMF based editing context is disposed
 - https://github.com/eclipse-sirius/sirius-web/issues/3020[#3020] [sirius-web] Improve the creation of the Apollo GraphQL client.
 - https://github.com/eclipse-sirius/sirius-web/issues/3056[#3056] [trees] Expand the clickable/draggable zone for tree items
+- [forms] Avoid creating a new subscription when re-selecting the same element
+
 
 == v2024.1.0
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -77,6 +77,7 @@ image:doc/screenshots/deploymenDiagram.png[Deployment Diagram,70%]
 - https://github.com/eclipse-sirius/sirius-web/issues/3020[#3020] [sirius-web] Improve the creation of the Apollo GraphQL client.
 - https://github.com/eclipse-sirius/sirius-web/issues/3056[#3056] [trees] Expand the clickable/draggable zone for tree items
 - [forms] Avoid creating a new subscription when re-selecting the same element
+- [tree] Avoid sending treePath query if the selection does not actually change
 
 
 == v2024.1.0

--- a/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessor.java
+++ b/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Obeo.
+ * Copyright (c) 2019, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -112,7 +112,7 @@ public class EditingContextEventProcessor implements IEditingContextEventProcess
     private final Disposable changeDescriptionDisposable;
 
     private final List<IInputPreProcessor> inputPreProcessors;
-    
+
     private final List<IInputPostProcessor> inputPostProcessors;
 
     private final MeterRegistry meterRegistry;
@@ -149,6 +149,8 @@ public class EditingContextEventProcessor implements IEditingContextEventProcess
                             (String) representationLabel);
                     this.doHandle(Sinks.one(), renameRepresentationInput);
                 }
+            } else if (ChangeKind.NOTHING.equals(changeDescription.getKind())) {
+                return;
             }
 
             this.publishEvent(changeDescription);
@@ -384,7 +386,7 @@ public class EditingContextEventProcessor implements IEditingContextEventProcess
 
         if (optionalRepresentationEventProcessor.isPresent()) {
             var representationId = optionalRepresentationEventProcessor.get().getRepresentation().getId();
-            var timer = meterRegistry.timer(Monitoring.TIMER_CREATE_REPRESENATION_EVENT_PROCESSOR,
+            var timer = this.meterRegistry.timer(Monitoring.TIMER_CREATE_REPRESENATION_EVENT_PROCESSOR,
                     "editingContext", this.editingContext.getId(),
                     "input", input.getClass().getSimpleName(),
                     REPRESENTATION_ID, representationId);

--- a/packages/forms/frontend/sirius-components-forms/src/views/FormBasedView.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/views/FormBasedView.tsx
@@ -91,8 +91,16 @@ export const FormBasedView = ({
   /**
    * Displays another form if the selection indicates that we should display another properties view.
    */
+  const currentSelectionKey: string = currentSelection?.entries
+    .map((entry) => entry.id)
+    .sort()
+    .join(':');
+  const newSelectionKey: string = selection?.entries
+    .map((entry) => entry.id)
+    .sort()
+    .join(':');
   useEffect(() => {
-    if (selection.entries.length > 0 && selection !== currentSelection) {
+    if (selection.entries.length > 0 && currentSelectionKey !== newSelectionKey) {
       const switchSelectionEvent: SwitchSelectionEvent = {
         type: 'SWITCH_SELECTION',
         selection: selection,
@@ -105,7 +113,7 @@ export const FormBasedView = ({
       };
       dispatch(switchSelectionEvent);
     }
-  }, [currentSelection, selection, dispatch]);
+  }, [currentSelectionKey, newSelectionKey, dispatch]);
 
   const input: GQLPropertiesEventInput = {
     id,

--- a/packages/trees/frontend/sirius-components-trees/src/views/TreeView.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/views/TreeView.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Obeo.
+ * Copyright (c) 2019, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -102,6 +102,10 @@ export const TreeView = ({
   ] = useLazyQuery<GQLGetExpandAllTreePathData, GQLGetExpandAllTreePathVariables>(getExpandAllTreePathQuery);
 
   // If we should auto-expand to reveal the selection, we need to compute the tree path to expand
+  const selectionKey: string = selection?.entries
+    .map((entry) => entry.id)
+    .sort()
+    .join(':');
   useEffect(() => {
     if (tree && autoExpandToRevealSelection) {
       const variables: GQLGetTreePathVariables = {
@@ -111,7 +115,7 @@ export const TreeView = ({
       };
       getTreePath({ variables });
     }
-  }, [editingContextId, tree, selection, autoExpandToRevealSelection, getTreePath]);
+  }, [editingContextId, tree, selectionKey, autoExpandToRevealSelection, getTreePath]);
 
   useEffect(() => {
     if (!treePathLoading) {


### PR DESCRIPTION
These are various small possible improvements I found when analyzing #2890. I'm not entirely sure they are the right solution for the problems they fix, but push them here for discussion.

- [enh] Avoid creating a new subscription when re-selecting the same element
- [enh] Avoid sending treePath query if the selection does not actually change
- [enh] Ignore empty changes of kind ChangeKind.NOTHING
