### PR TITLE
[fix] Fix TaskObjectServiceDelegate.canHandle(IEditingContext)

### DIFF
--- a/packages/starters/backend/sirius-components-task-starter/src/main/java/org/eclipse/sirius/components/task/starter/configuration/TaskObjectServiceDelegate.java
+++ b/packages/starters/backend/sirius-components-task-starter/src/main/java/org/eclipse/sirius/components/task/starter/configuration/TaskObjectServiceDelegate.java
@@ -47,7 +47,7 @@ public class TaskObjectServiceDelegate extends DefaultObjectService implements I
 
     @Override
     public boolean canHandle(IEditingContext editingContext) {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
The `IObjectServiceDelegate.canHandle(IEditingContext)` method is only used to guard the `getObject()` and `getContents()` methods.

`TaskObjectServiceDelegate` does not override these so it should not return `true` here as it prevents other delegates to be considered for these two methods.
