### PR TITLE
[3084] Add SplitButton widget

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -116,6 +116,7 @@ image:doc/screenshots/showDeletionConfirmation.png[Deletion Confirmation Dialog,
 - https://github.com/eclipse-sirius/sirius-web/issues/3082[#3082] [forms] Add checkbox support for tree widget.
 - https://github.com/eclipse-sirius/sirius-web/issues/3133[#3133] [deck] Add OKR and Kanban samples in the Task template and Deck view stereotype.
 - https://github.com/eclipse-sirius/sirius-web/issues/3145[#3145] [diagram] Add support for helper lines to facilitate the alignment of nodes with each other.
+- https://github.com/eclipse-sirius/sirius-web/issues/3084[#3084] [form] Add SplitButton Widget.
 
 === Improvements
 

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/handlers/AddWidgetEventHandler.java
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/handlers/AddWidgetEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.core.api.SuccessPayload;
 import org.eclipse.sirius.components.formdescriptioneditors.IWidgetDescriptionProvider;
+import org.eclipse.sirius.components.view.form.ButtonDescription;
 import org.eclipse.sirius.components.view.form.FlexDirection;
 import org.eclipse.sirius.components.view.form.FlexboxContainerDescription;
 import org.eclipse.sirius.components.view.form.FormElementDescription;
@@ -42,6 +43,7 @@ import org.eclipse.sirius.components.view.form.FormElementIf;
 import org.eclipse.sirius.components.view.form.FormFactory;
 import org.eclipse.sirius.components.view.form.FormPackage;
 import org.eclipse.sirius.components.view.form.GroupDescription;
+import org.eclipse.sirius.components.view.form.SplitButtonDescription;
 import org.eclipse.sirius.components.view.form.WidgetDescription;
 import org.springframework.stereotype.Service;
 
@@ -134,6 +136,12 @@ public class AddWidgetEventHandler implements IFormDescriptionEditorEventHandler
                     } else if (container instanceof FormElementIf formElementIf) {
                         formElementIf.getChildren().add(index, formElementDescription);
                         success = true;
+                    } else if (container instanceof SplitButtonDescription splitButtonDescription && newElement instanceof ButtonDescription buttonDescription) {
+                        splitButtonDescription.getActions().add(index, buttonDescription);
+                        success = true;
+                    }
+                    if (newElement instanceof SplitButtonDescription splitButtonDescription) {
+                        this.createButton(splitButtonDescription);
                     }
                 }
             }
@@ -141,6 +149,18 @@ public class AddWidgetEventHandler implements IFormDescriptionEditorEventHandler
         return success;
     }
 
+    private void createButton(SplitButtonDescription splitButtonDescription) {
+        EClassifier eClassifier = this.getWidgetDescriptionType("Button");
+        if (eClassifier instanceof EClass eClass) {
+            var newElement = EcoreUtil.create(eClass);
+            if (newElement instanceof WidgetDescription widgetDescription) {
+                this.createStyle(widgetDescription);
+                if (newElement instanceof ButtonDescription buttonDescription) {
+                    splitButtonDescription.getActions().add(0, buttonDescription);
+                }
+            }
+        }
+    }
 
     private EClassifier getWidgetDescriptionType(String kind) {
         for (IWidgetDescriptionProvider widgetDescriptionProvider : this.widgetDescriptionProviders) {
@@ -165,8 +185,8 @@ public class AddWidgetEventHandler implements IFormDescriptionEditorEventHandler
         EStructuralFeature styleFeature = widgetDescription.eClass().getEStructuralFeature("style");
         if (styleFeature instanceof EReference) {
             EClassifier eClassifier = styleFeature.getEType();
-            if (eClassifier instanceof EClass) {
-                var widgetDescriptionStyle = FormFactory.eINSTANCE.create((EClass) eClassifier);
+            if (eClassifier instanceof EClass eClass) {
+                var widgetDescriptionStyle = FormFactory.eINSTANCE.create(eClass);
                 if (eClassifier.isInstance(widgetDescriptionStyle)) {
                     widgetDescription.eSet(styleFeature, widgetDescriptionStyle);
                 }

--- a/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/formdescriptioneditors/components/ViewFormDescriptionEditorConverterSwitch.java
+++ b/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/formdescriptioneditors/components/ViewFormDescriptionEditorConverterSwitch.java
@@ -53,6 +53,7 @@ import org.eclipse.sirius.components.forms.description.MultiSelectDescription;
 import org.eclipse.sirius.components.forms.description.RadioDescription;
 import org.eclipse.sirius.components.forms.description.RichTextDescription;
 import org.eclipse.sirius.components.forms.description.SelectDescription;
+import org.eclipse.sirius.components.forms.description.SplitButtonDescription;
 import org.eclipse.sirius.components.forms.description.TextareaDescription;
 import org.eclipse.sirius.components.forms.description.TextfieldDescription;
 import org.eclipse.sirius.components.forms.description.TreeDescription;
@@ -381,6 +382,33 @@ public class ViewFormDescriptionEditorConverterSwitch extends FormSwitch<Abstrac
         if (viewButtonDescription.getHelpExpression() != null && !viewButtonDescription.getHelpExpression().isBlank()) {
             builder.helpTextProvider(vm -> this.getWidgetHelpText(viewButtonDescription));
         }
+        return builder.build();
+    }
+
+    @Override
+    public AbstractWidgetDescription caseSplitButtonDescription(org.eclipse.sirius.components.view.form.SplitButtonDescription splitButtonDescription) {
+        VariableManager childVariableManager = this.variableManager.createChild();
+        childVariableManager.put(VariableManager.SELF, splitButtonDescription);
+        String id = this.formDescriptionEditorDescription.getTargetObjectIdProvider().apply(childVariableManager);
+
+        List<ButtonDescription> actions = splitButtonDescription.getActions().stream()
+                .map(ViewFormDescriptionEditorConverterSwitch.this::doSwitch)
+                .filter(ButtonDescription.class::isInstance)
+                .map(ButtonDescription.class::cast).toList();
+
+        SplitButtonDescription.Builder builder = SplitButtonDescription.newSplitButtonDescription(UUID.randomUUID().toString())
+                .idProvider(vm -> id)
+                .targetObjectIdProvider(vm -> "")
+                .labelProvider(vm -> this.getWidgetLabel(splitButtonDescription, "SplitButton"))
+                .diagnosticsProvider(vm -> List.of())
+                .kindProvider(object -> "")
+                .actions(actions)
+                .messageProvider(object -> "");
+
+        if (splitButtonDescription.getHelpExpression() != null && !splitButtonDescription.getHelpExpression().isBlank()) {
+            builder.helpTextProvider(vm -> this.getWidgetHelpText(splitButtonDescription));
+        }
+
         return builder.build();
     }
 

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/FormDescriptionEditorRepresentation.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/FormDescriptionEditorRepresentation.tsx
@@ -411,6 +411,17 @@ export const FormDescriptionEditorRepresentation = ({
             </Typography>
           </div>
           <div
+            id="SplitButton"
+            data-testid="FormDescriptionEditor-SplitButton"
+            draggable="true"
+            className={classes.widgetKind}
+            onDragStart={handleDragStartWidget}>
+            <Button width={'24px'} height={'24px'} color={'secondary'} />
+            <Typography variant="caption" gutterBottom>
+              SplitButton
+            </Typography>
+          </div>
+          <div
             id="TextArea"
             data-testid="FormDescriptionEditor-TextArea"
             draggable="true"

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/SplitButtonWidget.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/SplitButtonWidget.tsx
@@ -1,0 +1,379 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { useMutation } from '@apollo/client/react';
+import {
+  ServerContext,
+  ServerContextValue,
+  Toast,
+  getCSSColor,
+  useSelection,
+} from '@eclipse-sirius/sirius-components-core';
+import { GQLButtonStyle, getTextDecorationLineValue } from '@eclipse-sirius/sirius-components-forms';
+import Button from '@material-ui/core/Button';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import Grow from '@material-ui/core/Grow';
+import MenuItem from '@material-ui/core/MenuItem';
+import MenuList from '@material-ui/core/MenuList';
+import Paper from '@material-ui/core/Paper';
+import Popper from '@material-ui/core/Popper';
+import Typography from '@material-ui/core/Typography';
+import { Theme, makeStyles, useTheme } from '@material-ui/core/styles';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import HelpOutlineOutlined from '@material-ui/icons/HelpOutlineOutlined';
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { addWidgetMutation } from './FormDescriptionEditorEventFragment';
+import {
+  GQLAddWidgetInput,
+  GQLAddWidgetMutationData,
+  GQLAddWidgetMutationVariables,
+  GQLAddWidgetPayload,
+  GQLErrorPayload,
+} from './FormDescriptionEditorEventFragment.types';
+import { SplitButtonWidgetState } from './SplitButtonWidget.type';
+import { SplitButtonWidgetProps } from './WidgetEntry.types';
+
+const isErrorPayload = (payload: GQLAddWidgetPayload): payload is GQLErrorPayload =>
+  payload.__typename === 'ErrorPayload';
+
+const actionStyle = (theme: Theme, style: GQLButtonStyle): React.CSSProperties => {
+  const actionStyle: React.CSSProperties = {
+    backgroundColor: style.backgroundColor ? getCSSColor(style.backgroundColor, theme) : theme.palette.primary.light,
+    color: style.foregroundColor ? getCSSColor(style.foregroundColor, theme) : 'white',
+    fontSize: style.fontSize ? style.fontSize : undefined,
+    fontStyle: style.italic ? 'italic' : undefined,
+    fontWeight: style.bold ? 'bold' : undefined,
+    textDecorationLine:
+      style.underline || style.strikeThrough
+        ? getTextDecorationLineValue(style.underline, style.strikeThrough)
+        : undefined,
+  };
+  return actionStyle;
+};
+
+const imageStyle = (theme: Theme, iconOnly: boolean): React.CSSProperties => {
+  return {
+    marginRight: iconOnly ? theme.spacing(2) : theme.spacing(0),
+    width: theme.spacing(2),
+    height: theme.spacing(2),
+  };
+};
+
+const useStyles = makeStyles<Theme>((theme) => ({
+  bottomDropArea: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'whitesmoke',
+    borderRadius: '10px',
+    color: 'gray',
+    height: '30px',
+    width: '100%',
+  },
+  helpOutlineOutlined: {
+    marginLeft: theme.spacing(1),
+    fontSize: theme.spacing(2),
+  },
+  dragOver: {
+    borderWidth: '1px',
+    borderStyle: 'dashed',
+    borderColor: theme.palette.primary.main,
+  },
+  selected: {
+    color: theme.palette.primary.main,
+  },
+  containerAndLabel: {
+    margin: '0px',
+    padding: '0px',
+    borderWidth: '1px',
+    borderColor: 'gray',
+    borderStyle: 'solid',
+    borderRadius: '0px',
+  },
+  propertySectionLabel: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+}));
+
+export const SplitButtonWidget = ({ widget, editingContextId, representationId }: SplitButtonWidgetProps) => {
+  const initialState: SplitButtonWidgetState = {
+    selected: false,
+    open: false,
+    selectedIndex: 0,
+    message: '',
+    actionsButtonLabel: [],
+    actionsImageURL: [],
+    actionsIsValidImage: [],
+  };
+
+  const [state, setState] = useState<SplitButtonWidgetState>(initialState);
+  const theme: Theme = useTheme();
+  const { httpOrigin } = useContext<ServerContextValue>(ServerContext);
+  const { selection } = useSelection();
+  const buttonGroupRef = useRef<HTMLDivElement>(null);
+  const widgetRef = useRef<HTMLDivElement>(null);
+
+  const [addWidget, { loading: addWidgetLoading, data: addWidgetData, error: addWidgetError }] = useMutation<
+    GQLAddWidgetMutationData,
+    GQLAddWidgetMutationVariables
+  >(addWidgetMutation);
+
+  useEffect(() => {
+    if (!addWidgetLoading) {
+      if (addWidgetError) {
+        setState((prevState) => {
+          return { ...prevState, message: addWidgetError.message };
+        });
+      }
+      if (addWidgetData) {
+        const { addWidget } = addWidgetData;
+        if (isErrorPayload(addWidget)) {
+          setState((prevState) => {
+            return { ...prevState, message: addWidget.message };
+          });
+        }
+      }
+    }
+  }, [addWidgetLoading, addWidgetData, addWidgetError]);
+
+  useEffect(() => {
+    const actionsButtonLabel: string[] = [];
+    const actionsImageURL: string[] = [];
+    const actionsIsValidImage: boolean[] = [];
+
+    widget.actions.forEach((action, index) => {
+      actionsIsValidImage[index] = true;
+      if (!action.imageURL) {
+        actionsIsValidImage[index] = false;
+      } else if (action.imageURL.startsWith('http://') || action.imageURL.startsWith('https://')) {
+        actionsImageURL[index] = action.imageURL;
+      } else {
+        actionsImageURL[index] = httpOrigin + action.imageURL;
+      }
+      const buttonLabel: string = action.buttonLabel;
+      const isButtonLabelBlank: boolean = buttonLabel == null || buttonLabel.trim() === '';
+      if (actionsIsValidImage[index] && isButtonLabelBlank) {
+        actionsButtonLabel[index] = null;
+      } else if (!isButtonLabelBlank && !buttonLabel.startsWith('aql:')) {
+        actionsButtonLabel[index] = buttonLabel;
+      } else {
+        actionsButtonLabel[index] = 'Lorem';
+      }
+    });
+
+    setState((prevState) => {
+      return {
+        ...prevState,
+        actionsButtonLabel: actionsButtonLabel,
+        actionsImageURL: actionsImageURL,
+        actionsIsValidImage: actionsIsValidImage,
+      };
+    });
+  }, [
+    widget.actions.map((action) => action.imageURL).join(),
+    widget.actions.map((action) => action.buttonLabel).join(),
+  ]);
+
+  useEffect(() => {
+    if (widgetRef.current && selection.entries.find((entry) => entry.id === widget.id)) {
+      widgetRef.current.focus();
+      setState((prevState) => ({ ...prevState, selected: true }));
+    } else {
+      setState((prevState) => ({ ...prevState, selected: false }));
+    }
+  }, [selection, widget]);
+
+  const classes = useStyles();
+
+  const handleMenuItemClick = (_event, index) => {
+    setState((prevState) => ({ ...prevState, open: false, selectedIndex: index }));
+  };
+
+  const handleToggle = () => {
+    setState((prevState) => ({ ...prevState, open: !prevState.open }));
+  };
+
+  const handleClose = (event) => {
+    if (widgetRef.current && widgetRef.current.contains(event.target)) {
+      return;
+    }
+    setState((prevState) => ({ ...prevState, open: false }));
+  };
+
+  const handleDragEnter: React.DragEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault();
+    event.currentTarget.classList.add(classes.dragOver);
+  };
+
+  const handleDragOver: React.DragEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault();
+    event.currentTarget.classList.add(classes.dragOver);
+  };
+
+  const handleDragLeave: React.DragEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault();
+    event.currentTarget.classList.remove(classes.dragOver);
+  };
+
+  const handleDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault();
+    event.currentTarget.classList.remove(classes.dragOver);
+
+    const id: string = event.dataTransfer.getData('draggedElementId');
+    const type: string = event.dataTransfer.getData('draggedElementType');
+    if (type !== 'Widget') {
+      return;
+    }
+
+    if (id === 'Button') {
+      const addWidgetInput: GQLAddWidgetInput = {
+        id: crypto.randomUUID(),
+        editingContextId,
+        representationId,
+        containerId: widget.id,
+        kind: id,
+        index: widget.actions.length || 0,
+      };
+      const addWidgetVariables: GQLAddWidgetMutationVariables = { input: addWidgetInput };
+      addWidget({ variables: addWidgetVariables });
+    }
+  };
+
+  const getStyle = (index: number): React.CSSProperties => {
+    if (widget.actions.length == 0) {
+      const defaultProps = {
+        backgroundColor: null,
+        foregroundColor: null,
+        fontSize: null,
+        italic: null,
+        bold: null,
+        underline: null,
+        strikeThrough: null,
+      };
+      return actionStyle(theme, defaultProps);
+    }
+    return actionStyle(theme, widget.actions[index].style);
+  };
+
+  return (
+    <div className={classes.containerAndLabel} tabIndex={0} ref={widgetRef}>
+      <div className={classes.propertySectionLabel}>
+        <Typography variant="subtitle2" className={state.selected ? classes.selected : ''}>
+          {widget.label}
+        </Typography>
+        {widget.hasHelpText ? <HelpOutlineOutlined color="secondary" className={classes.helpOutlineOutlined} /> : null}
+      </div>
+      <ButtonGroup
+        variant="contained"
+        color="primary"
+        ref={buttonGroupRef}
+        aria-label="split button"
+        onFocus={() =>
+          setState((prevState) => {
+            return {
+              ...prevState,
+              selected: true,
+            };
+          })
+        }
+        onBlur={() =>
+          setState((prevState) => {
+            return {
+              ...prevState,
+              selected: false,
+            };
+          })
+        }>
+        <Button
+          data-testid={widget.label}
+          variant="contained"
+          color="primary"
+          style={{ ...getStyle(state.selectedIndex) }}>
+          {state.actionsIsValidImage[state.selectedIndex] && state.actionsImageURL[state.selectedIndex] ? (
+            <img
+              style={{ ...imageStyle(theme, state.actionsIsValidImage[state.selectedIndex]) }}
+              alt={widget.actions[state.selectedIndex].label}
+              src={state.actionsImageURL[state.selectedIndex]}
+            />
+          ) : null}
+          {state.actionsButtonLabel[state.selectedIndex]}
+        </Button>
+        <Button
+          color="primary"
+          size="small"
+          aria-controls={state.open ? 'split-button-menu' : undefined}
+          aria-expanded={state.open ? 'true' : undefined}
+          aria-label="select button action"
+          aria-haspopup="menu"
+          role={'show-actions'}
+          onClick={handleToggle}
+          style={{ ...getStyle(state.selectedIndex) }}>
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
+      <Popper open={state.open} anchorEl={buttonGroupRef.current} transition placement="bottom">
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
+            }}>
+            <Paper>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList id="split-button-menu">
+                  {widget.actions.map((option, index) => (
+                    <MenuItem
+                      key={index}
+                      selected={index === state.selectedIndex}
+                      onClick={(event) => handleMenuItemClick(event, index)}
+                      style={{ ...getStyle(index) }}>
+                      {state.actionsIsValidImage[index] && state.actionsImageURL[index] ? (
+                        <img
+                          style={{ ...imageStyle(theme, state.actionsIsValidImage[index]) }}
+                          alt={option.label}
+                          src={state.actionsImageURL[index]}
+                        />
+                      ) : null}
+                      {state.actionsButtonLabel[index]}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+      <div
+        data-testid={`${widget.__typename}-Widgets-DropArea-${widget.id}`}
+        className={classes.bottomDropArea}
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}>
+        <Typography variant="body1">{'Drag and drop a button widget here'}</Typography>
+      </div>
+      <Toast
+        message={state.message}
+        open={!!state.message}
+        onClose={() =>
+          setState((prevState) => {
+            return { ...prevState, message: null };
+          })
+        }
+      />
+    </div>
+  );
+};

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/SplitButtonWidget.type.ts
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/SplitButtonWidget.type.ts
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+export interface SplitButtonWidgetState {
+  actionsButtonLabel: string[];
+  actionsImageURL: string[];
+  actionsIsValidImage: boolean[];
+  selected: boolean;
+  open: boolean;
+  selectedIndex: number;
+  message: string;
+}

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/WidgetEntry.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/WidgetEntry.tsx
@@ -26,6 +26,7 @@ import {
   GQLRadio,
   GQLRichText,
   GQLSelect,
+  GQLSplitButton,
   GQLTextarea,
   GQLTextfield,
   GQLTree,
@@ -67,6 +68,7 @@ import { PieChartWidget } from './PieChartWidget';
 import { RadioWidget } from './RadioWidget';
 import { RichTextWidget } from './RichTextWidget';
 import { SelectWidget } from './SelectWidget';
+import { SplitButtonWidget } from './SplitButtonWidget';
 import { TextAreaWidget } from './TextAreaWidget';
 import { TextfieldWidget } from './TextfieldWidget';
 import { TreeWidget } from './TreeWidget';
@@ -314,6 +316,16 @@ export const WidgetEntry = ({
   let widgetElement: JSX.Element | null = null;
   if (widget.__typename === 'Button') {
     widgetElement = <ButtonWidget data-testid={widget.id} widget={widget as GQLButton} onDropBefore={onDropBefore} />;
+  } else if (widget.__typename === 'SplitButton') {
+    widgetElement = (
+      <SplitButtonWidget
+        data-testid={widget.id}
+        editingContextId={editingContextId}
+        representationId={representationId}
+        widget={widget as GQLSplitButton}
+        onDropBefore={onDropBefore}
+      />
+    );
   } else if (widget.__typename === 'Checkbox') {
     widgetElement = (
       <CheckboxWidget data-testid={widget.id} widget={widget as GQLCheckbox} onDropBefore={onDropBefore} />

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/WidgetEntry.types.ts
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/WidgetEntry.types.ts
@@ -26,6 +26,7 @@ import {
   GQLRadio,
   GQLRichText,
   GQLSelect,
+  GQLSplitButton,
   GQLTextarea,
   GQLTextfield,
   GQLTree,
@@ -53,6 +54,11 @@ export interface WidgetProps<WidgetType extends GQLWidget> {
 export type BarChartWidgetProps = WidgetProps<GQLChartWidget>;
 export type ButtonWidgetProps = WidgetProps<GQLButton>;
 export type CheckboxWidgetProps = WidgetProps<GQLCheckbox>;
+
+export interface SplitButtonWidgetProps extends WidgetProps<GQLSplitButton> {
+  editingContextId: string;
+  representationId: string;
+}
 
 export interface FlexboxContainerWidgetProps {
   editingContextId: string;

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/WidgetOperations.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/WidgetOperations.tsx
@@ -22,6 +22,7 @@ export const isKind = (value: string): value is Kind => {
     value === 'Select' ||
     value === 'MultiSelect' ||
     value === 'Button' ||
+    value === 'SplitButton' ||
     value === 'Label' ||
     value === 'Link' ||
     value === 'List' ||

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/FormQueryService.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/FormQueryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Obeo.
+ * Copyright (c) 2021, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,15 +16,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.springframework.stereotype.Service;
 
 import org.eclipse.sirius.components.collaborative.forms.api.IFormQueryService;
 import org.eclipse.sirius.components.forms.AbstractWidget;
 import org.eclipse.sirius.components.forms.FlexboxContainer;
 import org.eclipse.sirius.components.forms.Form;
 import org.eclipse.sirius.components.forms.Group;
+import org.eclipse.sirius.components.forms.SplitButton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 /**
  * Class used to manipulate forms.
@@ -59,12 +60,13 @@ public class FormQueryService implements IFormQueryService {
     }
 
     private List<AbstractWidget> getAllWidgets(Group group) {
-        List<AbstractWidget> widgets = new ArrayList<>();
-        group.getToolbarActions().forEach(widgets::add);
+        List<AbstractWidget> widgets = new ArrayList<>(group.getToolbarActions());
         group.getWidgets().forEach(widget -> {
             widgets.add(widget);
             if (widget instanceof FlexboxContainer flexboxContainer) {
                 widgets.addAll(this.getAllWidgets(flexboxContainer));
+            } else if (widget instanceof SplitButton splitButton) {
+                widgets.addAll(this.getAllWidgets(splitButton));
             }
         });
         return widgets;
@@ -79,5 +81,9 @@ public class FormQueryService implements IFormQueryService {
             }
         });
         return widgets;
+    }
+
+    private List<AbstractWidget> getAllWidgets(SplitButton splitButton) {
+        return splitButton.getActions().stream().map(AbstractWidget.class::cast).toList();
     }
 }

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/resources/schema/form.graphqls
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/resources/schema/form.graphqls
@@ -302,6 +302,16 @@ type Button implements Widget {
   style: ButtonStyle
 }
 
+type SplitButton implements Widget {
+  id: ID!
+  label: String!
+  iconURL: [String!]!
+  diagnostics: [Diagnostic!]!
+  hasHelpText: Boolean!
+  readOnly: Boolean!
+  actions: [Button!]!
+}
+
 type ButtonStyle {
   backgroundColor: String
   foregroundColor: String

--- a/packages/forms/backend/sirius-components-forms-graphql/src/main/java/org/eclipse/sirius/components/forms/graphql/datafetchers/form/WidgetHasHelpTextDataFetcher.java
+++ b/packages/forms/backend/sirius-components-forms-graphql/src/main/java/org/eclipse/sirius/components/forms/graphql/datafetchers/form/WidgetHasHelpTextDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ import graphql.schema.FieldCoordinates;
  */
 @QueryDataFetcher(type = "Widget", field = "hasHelpText")
 public class WidgetHasHelpTextDataFetcher  implements IDataFetcherWithFieldCoordinates<Boolean> {
-
+    
     private static final String HAS_HELP_TEXT_FIELD = "hasHelpText";
 
     private static final List<String> CORE_WIDGET_TYPES = List.of(
@@ -46,6 +46,7 @@ public class WidgetHasHelpTextDataFetcher  implements IDataFetcherWithFieldCoord
             "Radio",
             "RichText",
             "Select",
+            "SplitButton",
             "Textarea",
             "Textfield",
             "ToolbarAction",

--- a/packages/forms/backend/sirius-components-forms-graphql/src/main/java/org/eclipse/sirius/components/forms/graphql/datafetchers/form/WidgetIconURLDataFetcher.java
+++ b/packages/forms/backend/sirius-components-forms-graphql/src/main/java/org/eclipse/sirius/components/forms/graphql/datafetchers/form/WidgetIconURLDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,7 @@ public class WidgetIconURLDataFetcher implements IDataFetcherWithFieldCoordinate
             "Radio",
             "RichText",
             "Select",
+            "SplitButton",
             "Textarea",
             "Textfield",
             "ToolbarAction",

--- a/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/SplitButton.java
+++ b/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/SplitButton.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.forms;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import java.text.MessageFormat;
+
+import org.eclipse.sirius.components.annotations.Immutable;
+import org.eclipse.sirius.components.forms.validation.Diagnostic;
+
+/**
+ * The Splitbutton widget.
+ * It contains a list of Button widget.
+ *
+ * @author mcharfadi
+ */
+@Immutable
+public final class SplitButton extends AbstractWidget {
+
+    private String label;
+
+    private List<Button> actions = new ArrayList<>();
+
+    private SplitButton() {
+        // Prevent instantiation
+    }
+
+    public static SplitButton.Builder newSplitButton(String id) {
+        return new SplitButton.Builder(id);
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    public List<Button> getActions() {
+        return actions;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, label: {2}, actionsCount: {3}'}'";
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.getId(), this.label, this.actions.size());
+    }
+
+    /**
+     * The builder used to create the splitButton.
+     *
+     * @author mcharfadi
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+
+        private final String id;
+
+        private String label;
+
+        private List<String> iconURL = List.of();
+
+        private List<Button> actions;
+
+        private List<Diagnostic> diagnostics;
+
+        private Supplier<String> helpTextProvider;
+
+        private boolean readOnly;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public SplitButton.Builder label(String label) {
+            this.label = Objects.requireNonNull(label);
+            return this;
+        }
+
+        public SplitButton.Builder iconURL(List<String> iconURL) {
+            this.iconURL = Objects.requireNonNull(iconURL);
+            return this;
+        }
+
+        public SplitButton.Builder diagnostics(List<Diagnostic> diagnostics) {
+            this.diagnostics = Objects.requireNonNull(diagnostics);
+            return this;
+        }
+
+        public SplitButton.Builder helpTextProvider(Supplier<String> helpTextProvider) {
+            this.helpTextProvider = Objects.requireNonNull(helpTextProvider);
+            return this;
+        }
+
+        public SplitButton.Builder readOnly(boolean readOnly) {
+            this.readOnly = readOnly;
+            return this;
+        }
+
+        public SplitButton.Builder actions(List<Button> actions) {
+            this.actions = Objects.requireNonNull(actions);
+            return this;
+        }
+
+        public SplitButton build() {
+            SplitButton splitButton = new SplitButton();
+            splitButton.id = Objects.requireNonNull(this.id);
+            splitButton.label = Objects.requireNonNull(this.label);
+            splitButton.iconURL = Objects.requireNonNull(this.iconURL);
+            splitButton.diagnostics = Objects.requireNonNull(this.diagnostics);
+            splitButton.helpTextProvider = this.helpTextProvider; // Optional on purpose
+            splitButton.actions = Objects.requireNonNull(this.actions);
+            splitButton.readOnly = this.readOnly;
+            return splitButton;
+        }
+    }
+}

--- a/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/components/SplitButtonComponent.java
+++ b/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/components/SplitButtonComponent.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.forms.components;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.forms.description.ButtonDescription;
+import org.eclipse.sirius.components.forms.description.SplitButtonDescription;
+import org.eclipse.sirius.components.forms.elements.SplitButtonElementProps;
+import org.eclipse.sirius.components.forms.validation.DiagnosticComponent;
+import org.eclipse.sirius.components.forms.validation.DiagnosticComponentProps;
+import org.eclipse.sirius.components.representations.Element;
+import org.eclipse.sirius.components.representations.IComponent;
+import org.eclipse.sirius.components.representations.VariableManager;
+
+/**
+ * The component used to create the splitButton widget.
+ *
+ * @author mcharfadi
+ */
+public class SplitButtonComponent implements IComponent {
+
+    private final SplitButtonComponentProps props;
+
+    public SplitButtonComponent(SplitButtonComponentProps props) {
+        this.props = Objects.requireNonNull(props);
+    }
+
+    @Override
+    public Element render() {
+        VariableManager variableManager = this.props.getVariableManager();
+        SplitButtonDescription splitButtonDescription = this.props.getSplitButtonDescription();
+
+        String label = splitButtonDescription.getLabelProvider().apply(variableManager);
+        List<String> iconURL = splitButtonDescription.getIconURLProvider().apply(variableManager);
+        
+        VariableManager idVariableManager = variableManager.createChild();
+        idVariableManager.put(FormComponent.TARGET_OBJECT_ID, splitButtonDescription.getTargetObjectIdProvider().apply(variableManager));
+        idVariableManager.put(FormComponent.CONTROL_DESCRIPTION_ID, splitButtonDescription.getId());
+        idVariableManager.put(FormComponent.WIDGET_LABEL, label);
+        String id = splitButtonDescription.getIdProvider().apply(idVariableManager);
+        Boolean readOnly = splitButtonDescription.getIsReadOnlyProvider().apply(variableManager);
+
+        List<Element> children = new ArrayList<>(List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(splitButtonDescription, variableManager))));
+
+        VariableManager childrenVariableManager = idVariableManager.createChild();
+        childrenVariableManager.put(FormComponent.PARENT_ELEMENT_ID, id);
+        for (ButtonDescription buttonDescription : splitButtonDescription.getActions()) {
+            children.add(new Element(ButtonComponent.class, new ButtonComponentProps(childrenVariableManager, buttonDescription)));
+        }
+
+        SplitButtonElementProps.Builder splitButtonElementPropsBuilder = SplitButtonElementProps.newSplitButtonElementProps(id)
+                .label(label)
+                .children(children);
+
+        if (splitButtonDescription.getHelpTextProvider() != null) {
+            splitButtonElementPropsBuilder.helpTextProvider(() -> splitButtonDescription.getHelpTextProvider().apply(variableManager));
+        }
+
+        if (iconURL != null) {
+            splitButtonElementPropsBuilder.iconURL(iconURL);
+        }
+
+        if (readOnly != null) {
+            splitButtonElementPropsBuilder.readOnly(readOnly);
+        }
+
+        SplitButtonElementProps splitButtonElementProps = splitButtonElementPropsBuilder.build();
+
+        return new Element(SplitButtonElementProps.TYPE, splitButtonElementProps);
+    }
+
+}

--- a/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/components/SplitButtonComponentProps.java
+++ b/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/components/SplitButtonComponentProps.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.forms.components;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.components.forms.description.SplitButtonDescription;
+import org.eclipse.sirius.components.representations.IProps;
+import org.eclipse.sirius.components.representations.VariableManager;
+
+/**
+ * The properties of the splitButton component.
+ *
+ * @author mcharfadi
+ */
+public class SplitButtonComponentProps implements IProps {
+
+    private final VariableManager variableManager;
+
+    private final SplitButtonDescription splitButtonDescription;
+
+    public SplitButtonComponentProps(VariableManager variableManager, SplitButtonDescription splitButtonDescription) {
+        this.variableManager = Objects.requireNonNull(variableManager);
+        this.splitButtonDescription = Objects.requireNonNull(splitButtonDescription);
+    }
+
+    public VariableManager getVariableManager() {
+        return this.variableManager;
+    }
+
+    public SplitButtonDescription getSplitButtonDescription() {
+        return this.splitButtonDescription;
+    }
+
+}

--- a/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/components/WidgetComponent.java
+++ b/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/components/WidgetComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Obeo.
+ * Copyright (c) 2019, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import org.eclipse.sirius.components.forms.description.MultiSelectDescription;
 import org.eclipse.sirius.components.forms.description.RadioDescription;
 import org.eclipse.sirius.components.forms.description.RichTextDescription;
 import org.eclipse.sirius.components.forms.description.SelectDescription;
+import org.eclipse.sirius.components.forms.description.SplitButtonDescription;
 import org.eclipse.sirius.components.forms.description.TextareaDescription;
 import org.eclipse.sirius.components.forms.description.TextfieldDescription;
 import org.eclipse.sirius.components.forms.description.TreeDescription;
@@ -86,6 +87,9 @@ public class WidgetComponent implements IComponent {
         } else if (widgetDescription instanceof ButtonDescription) {
             ButtonComponentProps buttonProps = new ButtonComponentProps(variableManager, (ButtonDescription) widgetDescription);
             element = new Element(ButtonComponent.class, buttonProps);
+        } else if (widgetDescription instanceof SplitButtonDescription) {
+            SplitButtonComponentProps splitButtonProps = new SplitButtonComponentProps(variableManager, (SplitButtonDescription) widgetDescription);
+            element = new Element(SplitButtonComponent.class, splitButtonProps);
         } else if (widgetDescription instanceof LabelDescription) {
             LabelWidgetComponentProps labelProps = new LabelWidgetComponentProps(variableManager, (LabelDescription) widgetDescription);
             element = new Element(LabelWidgetComponent.class, labelProps);

--- a/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/description/SplitButtonDescription.java
+++ b/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/description/SplitButtonDescription.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.forms.description;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.text.MessageFormat;
+
+import org.eclipse.sirius.components.annotations.Immutable;
+import org.eclipse.sirius.components.representations.VariableManager;
+
+/**
+ * The description of the split button widget.
+ *
+ * @author mcharfadi
+ */
+@Immutable
+public final class SplitButtonDescription extends AbstractWidgetDescription {
+
+    private Function<VariableManager, String> idProvider;
+
+    private Function<VariableManager, String> labelProvider;
+
+    private Function<VariableManager, List<String>> iconURLProvider;
+
+    private List<ButtonDescription> actions;
+
+    private SplitButtonDescription() {
+        // Prevent instantiation
+    }
+
+    public static Builder newSplitButtonDescription(String id) {
+        return new Builder(id);
+    }
+
+    public Function<VariableManager, String> getIdProvider() {
+        return this.idProvider;
+    }
+
+    public Function<VariableManager, String> getLabelProvider() {
+        return this.labelProvider;
+    }
+
+    public Function<VariableManager, List<String>> getIconURLProvider() {
+        return this.iconURLProvider;
+    }
+
+    public List<ButtonDescription> getActions() {
+        return this.actions;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}'}'";
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.getId());
+    }
+
+    /**
+     * Builder used to create the splitButton description.
+     *
+     * @author mcharfadi
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+
+        private final String id;
+
+        private Function<VariableManager, String> idProvider;
+
+        private Function<VariableManager, String> targetObjectIdProvider;
+
+        private Function<VariableManager, String> labelProvider;
+
+        private Function<VariableManager, List<String>> iconURLProvider = variableManager -> List.of();
+
+        private Function<VariableManager, Boolean> isReadOnlyProvider = variableManager -> false;
+
+        private Function<Object, String> kindProvider;
+
+        private Function<Object, String> messageProvider;
+
+        private Function<VariableManager, String> helpTextProvider;
+
+        private Function<VariableManager, List<?>> diagnosticsProvider;
+
+        private List<ButtonDescription> actions;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder idProvider(Function<VariableManager, String> idProvider) {
+            this.idProvider = Objects.requireNonNull(idProvider);
+            return this;
+        }
+
+        public Builder targetObjectIdProvider(Function<VariableManager, String> targetObjectIdProvider) {
+            this.targetObjectIdProvider = Objects.requireNonNull(targetObjectIdProvider);
+            return this;
+        }
+
+        public Builder labelProvider(Function<VariableManager, String> labelProvider) {
+            this.labelProvider = Objects.requireNonNull(labelProvider);
+            return this;
+        }
+
+        public Builder iconURLProvider(Function<VariableManager, List<String>> iconURLProvider) {
+            this.iconURLProvider = Objects.requireNonNull(iconURLProvider);
+            return this;
+        }
+
+        public Builder isReadOnlyProvider(Function<VariableManager, Boolean> isReadOnlyProvider) {
+            this.isReadOnlyProvider = Objects.requireNonNull(isReadOnlyProvider);
+            return this;
+        }
+
+        public Builder actions(List<ButtonDescription> actions) {
+            this.actions = Objects.requireNonNull(actions);
+            return this;
+        }
+        public Builder kindProvider(Function<Object, String> kindProvider) {
+            this.kindProvider = Objects.requireNonNull(kindProvider);
+            return this;
+        }
+
+        public Builder messageProvider(Function<Object, String> messageProvider) {
+            this.messageProvider = Objects.requireNonNull(messageProvider);
+            return this;
+        }
+
+        public Builder diagnosticsProvider(Function<VariableManager, List<?>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
+            return this;
+        }
+        public Builder helpTextProvider(Function<VariableManager, String> helpTextProvider) {
+            this.helpTextProvider = Objects.requireNonNull(helpTextProvider);
+            return this;
+        }
+
+        public SplitButtonDescription build() {
+            SplitButtonDescription splitButtonDescription = new SplitButtonDescription();
+            splitButtonDescription.id = Objects.requireNonNull(this.id);
+            splitButtonDescription.targetObjectIdProvider = Objects.requireNonNull(this.targetObjectIdProvider);
+            splitButtonDescription.idProvider = Objects.requireNonNull(this.idProvider);
+            splitButtonDescription.labelProvider = Objects.requireNonNull(this.labelProvider);
+            splitButtonDescription.iconURLProvider = Objects.requireNonNull(this.iconURLProvider);
+            splitButtonDescription.isReadOnlyProvider = Objects.requireNonNull(this.isReadOnlyProvider);
+            splitButtonDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
+            splitButtonDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
+            splitButtonDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
+            splitButtonDescription.actions = Objects.requireNonNull(this.actions);
+            splitButtonDescription.helpTextProvider = this.helpTextProvider; // Optional on purpose
+            return splitButtonDescription;
+        }
+
+    }
+}

--- a/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/elements/SplitButtonElementProps.java
+++ b/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/elements/SplitButtonElementProps.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.forms.elements;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.text.MessageFormat;
+
+import org.eclipse.sirius.components.annotations.Immutable;
+import org.eclipse.sirius.components.representations.Element;
+import org.eclipse.sirius.components.representations.IProps;
+
+/**
+ * The properties of the splitButton element.
+ *
+ * @author mcharfadi
+ */
+@Immutable
+public final class SplitButtonElementProps implements IProps {
+
+    public static final String TYPE = "SplitButton";
+
+    private String id;
+
+    private String label;
+
+    private List<String> iconURL;
+
+    private boolean readOnly;
+
+    private Supplier<String> helpTextProvider;
+
+    private List<Element> children;
+
+    private SplitButtonElementProps() {
+        // Prevent instantiation
+    }
+
+    public static Builder newSplitButtonElementProps(String id) {
+        return new Builder(id);
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getLabel() {
+        return this.label;
+    }
+
+    public List<String> getIconURL() {
+        return this.iconURL;
+    }
+
+    public boolean isReadOnly() {
+        return this.readOnly;
+    }
+
+    public Supplier<String> getHelpTextProvider() {
+        return this.helpTextProvider;
+    }
+
+    @Override
+    public List<Element> getChildren() {
+        return this.children;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, label: {2}'}'";
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.label);
+    }
+
+    /**
+     * The builder of the splitButton element props.
+     *
+     * @author mcharfadi
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+
+        private String id;
+
+        private String label;
+
+        private List<String> iconURL;
+
+        private boolean readOnly;
+
+        private Supplier<String> helpTextProvider;
+
+        private List<Element> children;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder label(String label) {
+            this.label = Objects.requireNonNull(label);
+            return this;
+        }
+
+        public Builder iconURL(List<String> iconURL) {
+            this.iconURL = Objects.requireNonNull(iconURL);
+            return this;
+        }
+
+        public Builder readOnly(boolean readOnly) {
+            this.readOnly = readOnly;
+            return this;
+        }
+
+        public Builder children(List<Element> children) {
+            this.children = Objects.requireNonNull(children);
+            return this;
+        }
+
+        public Builder helpTextProvider(Supplier<String> helpTextProvider) {
+            this.helpTextProvider = Objects.requireNonNull(helpTextProvider);
+            return this;
+        }
+
+        public SplitButtonElementProps build() {
+            SplitButtonElementProps buttonElementProps = new SplitButtonElementProps();
+            buttonElementProps.id = Objects.requireNonNull(this.id);
+            buttonElementProps.label = Objects.requireNonNull(this.label);
+            buttonElementProps.iconURL = this.iconURL;
+            buttonElementProps.readOnly = this.readOnly;
+            buttonElementProps.children = Objects.requireNonNull(this.children);
+            buttonElementProps.helpTextProvider = this.helpTextProvider; // Optional on purpose
+            return buttonElementProps;
+        }
+    }
+}

--- a/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/renderer/FormComponentPropsValidator.java
+++ b/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/renderer/FormComponentPropsValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Obeo.
+ * Copyright (c) 2019, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -54,6 +54,8 @@ import org.eclipse.sirius.components.forms.components.RichTextComponent;
 import org.eclipse.sirius.components.forms.components.RichTextComponentProps;
 import org.eclipse.sirius.components.forms.components.SelectComponent;
 import org.eclipse.sirius.components.forms.components.SelectComponentProps;
+import org.eclipse.sirius.components.forms.components.SplitButtonComponent;
+import org.eclipse.sirius.components.forms.components.SplitButtonComponentProps;
 import org.eclipse.sirius.components.forms.components.TextareaComponent;
 import org.eclipse.sirius.components.forms.components.TextareaComponentProps;
 import org.eclipse.sirius.components.forms.components.TextfieldComponent;
@@ -118,6 +120,8 @@ public class FormComponentPropsValidator implements IComponentPropsValidator {
             checkValidProps = props instanceof LinkComponentProps;
         } else if (ButtonComponent.class.equals(componentType)) {
             checkValidProps = props instanceof ButtonComponentProps;
+        } else if (SplitButtonComponent.class.equals(componentType)) {
+            checkValidProps = props instanceof SplitButtonComponentProps;
         } else if (LabelWidgetComponent.class.equals(componentType)) {
             checkValidProps = props instanceof LabelWidgetComponentProps;
         } else if (ChartWidgetComponent.class.equals(componentType)) {

--- a/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/renderer/FormElementFactory.java
+++ b/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/renderer/FormElementFactory.java
@@ -40,6 +40,7 @@ import org.eclipse.sirius.components.forms.Page;
 import org.eclipse.sirius.components.forms.Radio;
 import org.eclipse.sirius.components.forms.RichText;
 import org.eclipse.sirius.components.forms.Select;
+import org.eclipse.sirius.components.forms.SplitButton;
 import org.eclipse.sirius.components.forms.Textarea;
 import org.eclipse.sirius.components.forms.Textfield;
 import org.eclipse.sirius.components.forms.ToolbarAction;
@@ -59,6 +60,7 @@ import org.eclipse.sirius.components.forms.elements.PageElementProps;
 import org.eclipse.sirius.components.forms.elements.RadioElementProps;
 import org.eclipse.sirius.components.forms.elements.RichTextElementProps;
 import org.eclipse.sirius.components.forms.elements.SelectElementProps;
+import org.eclipse.sirius.components.forms.elements.SplitButtonElementProps;
 import org.eclipse.sirius.components.forms.elements.TextareaElementProps;
 import org.eclipse.sirius.components.forms.elements.TextfieldElementProps;
 import org.eclipse.sirius.components.forms.elements.ToolbarActionElementProps;
@@ -110,6 +112,8 @@ public class FormElementFactory implements IElementFactory {
             object = this.instantiateLink((LinkElementProps) props, children);
         } else if (ButtonElementProps.TYPE.equals(type) && props instanceof ButtonElementProps) {
             object = this.instantiateButton((ButtonElementProps) props, children);
+        } else if (SplitButtonElementProps.TYPE.equals(type) && props instanceof SplitButtonElementProps) {
+            object = this.instantiateSplitButton((SplitButtonElementProps) props, children);
         } else if (LabelWidgetElementProps.TYPE.equals(type) && props instanceof LabelWidgetElementProps) {
             object = this.instantiateLabel((LabelWidgetElementProps) props, children);
         } else if (ChartWidgetElementProps.TYPE.equals(type) && props instanceof ChartWidgetElementProps) {
@@ -480,6 +484,26 @@ public class FormElementFactory implements IElementFactory {
         if (props.getStyle() != null) {
             buttonBuilder.style(props.getStyle());
         }
+        if (props.getHelpTextProvider() != null) {
+            buttonBuilder.helpTextProvider(props.getHelpTextProvider());
+        }
+        return buttonBuilder.build();
+    }
+
+    private SplitButton instantiateSplitButton(SplitButtonElementProps props, List<Object> children) {
+        List<Diagnostic> diagnostics = this.getDiagnosticsFromChildren(children);
+        List<Button> actions = children.stream()
+                    .filter(Button.class::isInstance)
+                    .map(Button.class::cast)
+                    .toList();
+
+        SplitButton.Builder buttonBuilder = SplitButton.newSplitButton(props.getId())
+                .label(props.getLabel())
+                .iconURL(props.getIconURL())
+                .diagnostics(diagnostics)
+                .actions(actions)
+                .readOnly(props.isReadOnly());
+
         if (props.getHelpTextProvider() != null) {
             buttonBuilder.helpTextProvider(props.getHelpTextProvider());
         }

--- a/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/renderer/FormInstancePropsValidator.java
+++ b/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/renderer/FormInstancePropsValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Obeo.
+ * Copyright (c) 2019, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,7 @@ import org.eclipse.sirius.components.forms.elements.PageElementProps;
 import org.eclipse.sirius.components.forms.elements.RadioElementProps;
 import org.eclipse.sirius.components.forms.elements.RichTextElementProps;
 import org.eclipse.sirius.components.forms.elements.SelectElementProps;
+import org.eclipse.sirius.components.forms.elements.SplitButtonElementProps;
 import org.eclipse.sirius.components.forms.elements.TextareaElementProps;
 import org.eclipse.sirius.components.forms.elements.TextfieldElementProps;
 import org.eclipse.sirius.components.forms.elements.ToolbarActionElementProps;
@@ -85,6 +86,8 @@ public class FormInstancePropsValidator implements IInstancePropsValidator {
             checkValidProps = props instanceof LinkElementProps;
         } else if (ButtonElementProps.TYPE.equals(type)) {
             checkValidProps = props instanceof ButtonElementProps;
+        } else if (SplitButtonElementProps.TYPE.equals(type)) {
+            checkValidProps = props instanceof SplitButtonElementProps;
         } else if (LabelWidgetElementProps.TYPE.equals(type)) {
             checkValidProps = props instanceof LabelWidgetElementProps;
         } else if (ChartWidgetElementProps.TYPE.equals(type)) {

--- a/packages/forms/backend/sirius-components-forms/src/test/java/org/eclipse/sirius/components/forms/render/RenderSplitButtonTest.java
+++ b/packages/forms/backend/sirius-components-forms/src/test/java/org/eclipse/sirius/components/forms/render/RenderSplitButtonTest.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.forms.render;
+
+import java.util.List;
+import java.util.function.Function;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.sirius.components.forms.Button;
+import org.eclipse.sirius.components.forms.ButtonStyle;
+import org.eclipse.sirius.components.forms.Form;
+import org.eclipse.sirius.components.forms.GroupDisplayMode;
+import org.eclipse.sirius.components.forms.SplitButton;
+import org.eclipse.sirius.components.forms.components.FormComponent;
+import org.eclipse.sirius.components.forms.components.FormComponentProps;
+import org.eclipse.sirius.components.forms.description.ButtonDescription;
+import org.eclipse.sirius.components.forms.description.FormDescription;
+import org.eclipse.sirius.components.forms.description.GroupDescription;
+import org.eclipse.sirius.components.forms.description.PageDescription;
+import org.eclipse.sirius.components.forms.description.SplitButtonDescription;
+import org.eclipse.sirius.components.forms.renderer.FormRenderer;
+import org.eclipse.sirius.components.representations.Element;
+import org.eclipse.sirius.components.representations.Success;
+import org.eclipse.sirius.components.representations.VariableManager;
+
+/**
+ * Tests the rendering of a SplitButton component.
+ *
+ * @author mcharfadi
+ */
+public class RenderSplitButtonTest {
+
+    private static final String SPLITBUTTON_DESCRIPTION_ID = "splitButtonDescriptionId";
+
+    private static final String SPLITBUTTON_ID = "splitButtonId";
+
+    private static final String BUTTON_DESCRIPTION_ID = "buttonDescriptionId";
+
+    private static final String BUTTON_ID = "buttonId";
+
+    private static final String BUTTON_DESCRIPTION_ID2 = "buttonDescriptionId2";
+
+    private static final String BUTTON_ID2 = "buttonId2";
+
+    private static final String LABEL = "label";
+
+    private static final String BACKGROUNDCOLOR = "value";
+
+    private ButtonStyle style;
+
+    private Object self;
+
+    @BeforeEach
+    public void setup() {
+        this.style = ButtonStyle.newButtonStyle()
+                .backgroundColor(BACKGROUNDCOLOR)
+                .foregroundColor("white")
+                .fontSize(12)
+                .italic(false)
+                .underline(false)
+                .strikeThrough(false)
+                .build();
+        this.self = new Object();
+    }
+
+    @Test
+    public void testRenderSplitButtonWithoutActions() {
+        SplitButtonDescription splitButtonDescription = SplitButtonDescription.newSplitButtonDescription(SPLITBUTTON_DESCRIPTION_ID)
+                .targetObjectIdProvider(this.constantProvider(SPLITBUTTON_ID))
+                .idProvider(this.constantProvider(SPLITBUTTON_ID))
+                .labelProvider(this.constantProvider(LABEL))
+                .diagnosticsProvider(variableManager -> List.of())
+                .kindProvider(diagnostic -> "")
+                .messageProvider(diagnostic -> "")
+                .actions(List.of())
+                .build();
+
+        FormDescription formDescription = this.createSingleWidgetForm(splitButtonDescription);
+        Form form = this.renderForm(formDescription);
+
+        assertThat(form).isNotNull();
+        assertThat(form.getPages()).hasSize(1);
+        assertThat(form.getPages().get(0).getGroups()).hasSize(1);
+        assertThat(form.getPages().get(0).getGroups().get(0).getWidgets()).hasSize(1);
+        assertThat(form.getPages().get(0).getGroups().get(0).getWidgets().get(0)).isInstanceOf(SplitButton.class);
+        SplitButton renderedSplitButton = (SplitButton) form.getPages().get(0).getGroups().get(0).getWidgets().get(0);
+        assertThat(renderedSplitButton).isNotNull();
+        assertThat(renderedSplitButton.getActions()).isEmpty();
+    }
+
+    @Test
+    public void testRenderSplitButtonWithActions() {
+        ButtonDescription buttonDescription = createButtonDescription(BUTTON_DESCRIPTION_ID, BUTTON_DESCRIPTION_ID, LABEL);
+        ButtonDescription buttonDescription2 = createButtonDescription(BUTTON_DESCRIPTION_ID2, BUTTON_DESCRIPTION_ID2, LABEL);
+
+        SplitButtonDescription splitButtonDescription = SplitButtonDescription.newSplitButtonDescription(SPLITBUTTON_DESCRIPTION_ID)
+                .targetObjectIdProvider(this.constantProvider(SPLITBUTTON_DESCRIPTION_ID))
+                .idProvider(this.constantProvider(SPLITBUTTON_DESCRIPTION_ID))
+                .labelProvider(this.constantProvider(LABEL))
+                .diagnosticsProvider(variableManager -> List.of())
+                .kindProvider(diagnostic -> "")
+                .messageProvider(diagnostic -> "")
+                .actions(List.of(buttonDescription, buttonDescription2))
+                .build();
+
+        FormDescription formDescription = this.createSingleWidgetForm(splitButtonDescription);
+        Form form = this.renderForm(formDescription);
+
+        assertThat(form).isNotNull();
+        assertThat(form.getPages()).hasSize(1);
+        assertThat(form.getPages().get(0).getGroups()).hasSize(1);
+        assertThat(form.getPages().get(0).getGroups().get(0).getWidgets()).hasSize(1);
+        assertThat(form.getPages().get(0).getGroups().get(0).getWidgets().get(0)).isInstanceOf(SplitButton.class);
+        SplitButton renderedSplitButton = (SplitButton) form.getPages().get(0).getGroups().get(0).getWidgets().get(0);
+        assertThat(renderedSplitButton).isNotNull();
+        assertThat(renderedSplitButton.getActions()).hasSize(2);
+        Button renderedButton = renderedSplitButton.getActions().get(0);
+        assertThat(renderedButton).isNotNull();
+        assertThat(renderedButton.getStyle().getBackgroundColor()).isEqualTo(BACKGROUNDCOLOR);
+        assertThat(renderedButton.getId()).isEqualTo(BUTTON_DESCRIPTION_ID);
+        Button renderedButton2 = renderedSplitButton.getActions().get(1);
+        assertThat(renderedButton2).isNotNull();
+        assertThat(renderedButton2.getId()).isEqualTo(BUTTON_DESCRIPTION_ID2);
+    }
+
+    private ButtonDescription createButtonDescription(String descriptionId, String id, String label) {
+        return ButtonDescription.newButtonDescription(descriptionId)
+                .targetObjectIdProvider(this.constantProvider(id))
+                .idProvider(this.constantProvider(id))
+                .labelProvider(this.constantProvider(label))
+                .diagnosticsProvider(variableManager -> List.of())
+                .kindProvider(diagnostic -> "")
+                .messageProvider(diagnostic -> "")
+                .imageURLProvider(variableManager -> "")
+                .buttonLabelProvider((variableManager) -> LABEL)
+                .pushButtonHandler((variableManager) -> new Success())
+                .styleProvider((variableManager) -> style)
+                .build();
+    }
+
+    private Form renderForm(FormDescription formDescription) {
+        VariableManager variableManager = new VariableManager();
+        variableManager.put(VariableManager.SELF, this.self);
+        FormComponentProps props = new FormComponentProps(variableManager, formDescription, List.of());
+        return new FormRenderer(List.of()).render(new Element(FormComponent.class, props));
+    }
+
+    private FormDescription createSingleWidgetForm(SplitButtonDescription splitButtonDescription) {
+        GroupDescription groupDescription = GroupDescription.newGroupDescription("groupDescriptionId")
+                .idProvider(this.constantProvider("groupId"))
+                .labelProvider(this.constantProvider("groupLabel"))
+                .displayModeProvider(this.constantProvider(GroupDisplayMode.LIST))
+                .toolbarActionDescriptions(List.of())
+                .controlDescriptions(List.of(splitButtonDescription))
+                .semanticElementsProvider(this.constantProvider(List.of(this.self)))
+                .build();
+        PageDescription pageDescription = PageDescription.newPageDescription("pageDescriptionId")
+                .idProvider(this.constantProvider("pageId"))
+                .labelProvider(this.constantProvider("pageLabel"))
+                .canCreatePredicate(variableManager -> true)
+                .groupDescriptions(List.of(groupDescription))
+                .semanticElementsProvider(this.constantProvider(List.of(this.self)))
+                .build();
+        return FormDescription.newFormDescription("formDescriptionId")
+                .targetObjectIdProvider(this.constantProvider(SPLITBUTTON_DESCRIPTION_ID))
+                .label("formDescriptionLabel")
+                .idProvider(this.constantProvider("formId"))
+                .labelProvider(this.constantProvider("formLabel"))
+                .canCreatePredicate(variableManager -> true)
+                .pageDescriptions(List.of(pageDescription))
+                .targetObjectIdProvider(this.constantProvider("selfId"))
+                .build();
+    }
+
+    private <T> Function<VariableManager, T> constantProvider(T value) {
+        return (VariableManager variableManager) -> value;
+    }
+}

--- a/packages/forms/frontend/sirius-components-forms/src/form/FormEventFragments.ts
+++ b/packages/forms/frontend/sirius-components-forms/src/form/FormEventFragments.ts
@@ -200,6 +200,14 @@ export const widgetFields = (contributions: Array<WidgetContribution>) => `
     }
   }
 
+  fragment splitButtonFields on SplitButton {
+    label
+    actions {
+      ...commonFields
+      ...buttonFields
+    }
+  }
+
   fragment toolbarActionFields on ToolbarAction {
     label
     buttonLabel
@@ -343,6 +351,9 @@ export const widgetFields = (contributions: Array<WidgetContribution>) => `
     }
     ... on Button {
       ...buttonFields
+    }
+    ... on SplitButton {
+      ...splitButtonFields
     }
     ... on ToolbarAction {
       ...toolbarActionFields

--- a/packages/forms/frontend/sirius-components-forms/src/form/FormEventFragments.types.ts
+++ b/packages/forms/frontend/sirius-components-forms/src/form/FormEventFragments.types.ts
@@ -283,6 +283,10 @@ export interface GQLButton extends GQLWidget {
   style: GQLButtonStyle;
 }
 
+export interface GQLSplitButton extends GQLWidget {
+  actions: GQLButton[];
+}
+
 export interface GQLButtonStyle {
   backgroundColor: string | null;
   foregroundColor: string | null;

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/PropertySection.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/PropertySection.tsx
@@ -26,6 +26,7 @@ import {
   GQLRadio,
   GQLRichText,
   GQLSelect,
+  GQLSplitButton,
   GQLTextarea,
   GQLTextfield,
   GQLTree,
@@ -44,6 +45,7 @@ import { PropertySectionProps } from './PropertySection.types';
 import { RadioPropertySection } from './RadioPropertySection';
 import { RichTextPropertySection } from './RichTextPropertySection';
 import { SelectPropertySection } from './SelectPropertySection';
+import { SplitButtonPropertySection } from './SplitButtonPropertySection';
 import { TextfieldPropertySection } from './TextfieldPropertySection';
 import { TreePropertySection } from './TreePropertySection';
 
@@ -56,6 +58,7 @@ const isRadio = (widget: GQLWidget): widget is GQLRadio => widget.__typename ===
 const isList = (widget: GQLWidget): widget is GQLList => widget.__typename === 'List';
 const isLink = (widget: GQLWidget): widget is GQLLink => widget.__typename === 'Link';
 const isButton = (widget: GQLWidget): widget is GQLButton => widget.__typename === 'Button';
+const isSplitButton = (widget: GQLWidget): widget is GQLSplitButton => widget.__typename === 'SplitButton';
 const isLabelWidget = (widget: GQLWidget): widget is GQLLabelWidget => widget.__typename === 'LabelWidget';
 const isChartWidget = (widget: GQLWidget): widget is GQLChartWidget => widget.__typename === 'ChartWidget';
 const isFlexboxContainer = (widget: GQLWidget): widget is GQLFlexboxContainer =>
@@ -153,6 +156,17 @@ export const PropertySection = ({
   } else if (isButton(widget)) {
     propertySection = (
       <ButtonPropertySection
+        editingContextId={editingContextId}
+        formId={formId}
+        widget={widget}
+        key={widget.id}
+        subscribers={subscribers}
+        readOnly={readOnly}
+      />
+    );
+  } else if (isSplitButton(widget)) {
+    propertySection = (
+      <SplitButtonPropertySection
         editingContextId={editingContextId}
         formId={formId}
         widget={widget}

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/SplitButtonPropertySection.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/SplitButtonPropertySection.tsx
@@ -1,0 +1,322 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { useMutation } from '@apollo/client';
+import { ServerContext, ServerContextValue, getCSSColor, useMultiToast } from '@eclipse-sirius/sirius-components-core';
+import Button from '@material-ui/core/Button';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import Grow from '@material-ui/core/Grow';
+import MenuItem from '@material-ui/core/MenuItem';
+import MenuList from '@material-ui/core/MenuList';
+import Paper from '@material-ui/core/Paper';
+import Popper from '@material-ui/core/Popper';
+import { Theme, makeStyles } from '@material-ui/core/styles';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import gql from 'graphql-tag';
+import { useContext, useEffect, useRef, useState } from 'react';
+import { GQLButton } from '../form/FormEventFragments.types';
+import {
+  ButtonStyleProps,
+  GQLErrorPayload,
+  GQLPushButtonInput,
+  GQLPushButtonMutationData,
+  GQLPushButtonMutationVariables,
+  GQLPushButtonPayload,
+  GQLSuccessPayload,
+} from './ButtonPropertySection.types';
+import { PropertySectionLabel } from './PropertySectionLabel';
+import {
+  GQLUpdateWidgetFocusInput,
+  GQLUpdateWidgetFocusMutationData,
+  GQLUpdateWidgetFocusMutationVariables,
+  GQLUpdateWidgetFocusPayload,
+  SplitButtonPropertySectionProps,
+  SplitButtonState,
+} from './SplitButtonPropertySection.types';
+import { getTextDecorationLineValue } from './getTextDecorationLineValue';
+
+const useStyle = makeStyles<Theme, ButtonStyleProps>((theme) => ({
+  style: {
+    backgroundColor: ({ backgroundColor }) =>
+      backgroundColor ? getCSSColor(backgroundColor, theme) : theme.palette.primary.light,
+    color: ({ foregroundColor }) => (foregroundColor ? getCSSColor(foregroundColor, theme) : 'white'),
+    fontSize: ({ fontSize }) => (fontSize ? fontSize : null),
+    fontStyle: ({ italic }) => (italic ? 'italic' : null),
+    fontWeight: ({ bold }) => (bold ? 'bold' : null),
+    textDecorationLine: ({ underline, strikeThrough }) => getTextDecorationLineValue(underline, strikeThrough),
+    '&:hover': {
+      backgroundColor: ({ backgroundColor }) =>
+        backgroundColor ? getCSSColor(backgroundColor, theme) : theme.palette.primary.main,
+      color: ({ foregroundColor }) => (foregroundColor ? getCSSColor(foregroundColor, theme) : 'white'),
+      fontSize: ({ fontSize }) => (fontSize ? fontSize : null),
+      fontStyle: ({ italic }) => (italic ? 'italic' : null),
+      fontWeight: ({ bold }) => (bold ? 'bold' : null),
+      textDecorationLine: ({ underline, strikeThrough }) => getTextDecorationLineValue(underline, strikeThrough),
+    },
+    '&.Mui-disabled': {
+      color: theme.palette.action.disabled,
+      backgroundColor: theme.palette.action.disabledBackground,
+      opacity: 1,
+    },
+  },
+  icon: {
+    marginRight: ({ iconOnly }) => (iconOnly ? theme.spacing(0) : theme.spacing(2)),
+    height: theme.spacing(2),
+    width: theme.spacing(2),
+  },
+}));
+
+export const updateWidgetFocusMutation = gql`
+  mutation updateWidgetFocus($input: UpdateWidgetFocusInput!) {
+    updateWidgetFocus(input: $input) {
+      __typename
+      ... on ErrorPayload {
+        messages {
+          body
+          level
+        }
+      }
+    }
+  }
+`;
+
+export const pushButtonMutation = gql`
+  mutation pushButton($input: PushButtonInput!) {
+    pushButton(input: $input) {
+      __typename
+      ... on ErrorPayload {
+        messages {
+          body
+          level
+        }
+      }
+      ... on SuccessPayload {
+        messages {
+          body
+          level
+        }
+      }
+    }
+  }
+`;
+
+const isErrorPayload = (payload: GQLPushButtonPayload | GQLUpdateWidgetFocusPayload): payload is GQLErrorPayload =>
+  payload.__typename === 'ErrorPayload';
+
+const isSuccessPayload = (payload: GQLPushButtonPayload | GQLUpdateWidgetFocusPayload): payload is GQLSuccessPayload =>
+  payload.__typename === 'SuccessPayload';
+
+export const SplitButtonPropertySection = ({
+  editingContextId,
+  formId,
+  widget,
+  subscribers,
+  readOnly,
+}: SplitButtonPropertySectionProps) => {
+  const { addErrorMessage, addMessages } = useMultiToast();
+  const [state, setState] = useState<SplitButtonState>({
+    open: false,
+    selectedIndex: 0,
+  });
+
+  const buttonGroupRef = useRef<HTMLDivElement>(null);
+
+  const { httpOrigin } = useContext<ServerContextValue>(ServerContext);
+
+  if (widget.actions.length == 0) {
+    return null;
+  }
+
+  const firstEnabledAction = widget.actions.find((action) => !action.readOnly);
+
+  useEffect(() => {
+    if (!!firstEnabledAction) {
+      setState((prevState) => ({ ...prevState, selectedIndex: widget.actions.indexOf(firstEnabledAction) }));
+    }
+  }, []);
+
+  const classes = widget.actions.map((action) => {
+    const props: ButtonStyleProps = {
+      backgroundColor: action.style?.backgroundColor ?? null,
+      foregroundColor: action.style?.foregroundColor ?? null,
+      fontSize: action.style?.fontSize ?? null,
+      italic: action.style?.italic ?? null,
+      bold: action.style?.bold ?? null,
+      underline: action.style?.underline ?? null,
+      strikeThrough: action.style?.strikeThrough ?? null,
+      iconOnly: action.buttonLabel ? false : true,
+    };
+    return useStyle(props);
+  });
+
+  const [pushButton, { loading, data, error }] = useMutation<GQLPushButtonMutationData, GQLPushButtonMutationVariables>(
+    pushButtonMutation
+  );
+
+  useEffect(() => {
+    if (!loading) {
+      if (error) {
+        addErrorMessage('An unexpected error has occurred, please refresh the page');
+      }
+      if (data) {
+        const { pushButton } = data;
+        if (isErrorPayload(pushButton) || isSuccessPayload(pushButton)) {
+          addMessages(pushButton.messages);
+        }
+      }
+    }
+  }, [loading, error, data]);
+
+  const [
+    updateWidgetFocus,
+    { loading: updateWidgetFocusLoading, data: updateWidgetFocusData, error: updateWidgetFocusError },
+  ] = useMutation<GQLUpdateWidgetFocusMutationData, GQLUpdateWidgetFocusMutationVariables>(updateWidgetFocusMutation);
+
+  const sendUpdateWidgetFocus = (selected: boolean) => {
+    const input: GQLUpdateWidgetFocusInput = {
+      id: crypto.randomUUID(),
+      editingContextId,
+      representationId: formId,
+      widgetId: widget.id,
+      selected,
+    };
+    const variables: GQLUpdateWidgetFocusMutationVariables = {
+      input,
+    };
+    updateWidgetFocus({ variables });
+  };
+
+  useEffect(() => {
+    if (!updateWidgetFocusLoading) {
+      if (updateWidgetFocusError) {
+        addErrorMessage('An unexpected error has occurred, please refresh the page');
+      }
+      if (updateWidgetFocusData) {
+        const { updateWidgetFocus } = updateWidgetFocusData;
+        if (isErrorPayload(updateWidgetFocus)) {
+          addMessages(updateWidgetFocus.messages);
+        }
+      }
+    }
+  }, [updateWidgetFocusLoading, updateWidgetFocusData, updateWidgetFocusError]);
+
+  const onFocus = () => sendUpdateWidgetFocus(true);
+  const onBlur = () => {
+    sendUpdateWidgetFocus(false);
+  };
+
+  const handleClick = () => {
+    const button: GQLButton = widget.actions[state.selectedIndex];
+    const input: GQLPushButtonInput = {
+      id: crypto.randomUUID(),
+      editingContextId,
+      representationId: formId,
+      buttonId: button.id,
+    };
+    const variables: GQLPushButtonMutationVariables = { input };
+    pushButton({ variables });
+  };
+
+  const handleMenuItemClick = (_event, index) => {
+    setState((prevState) => ({ ...prevState, open: false, selectedIndex: index }));
+  };
+
+  const handleToggle = () => {
+    setState((prevState) => ({ ...prevState, open: !prevState.open }));
+  };
+
+  const handleClose = (event) => {
+    if (buttonGroupRef.current && buttonGroupRef.current.contains(event.target)) {
+      return;
+    }
+    setState((prevState) => ({ ...prevState, open: false }));
+  };
+
+  return (
+    <div>
+      <PropertySectionLabel
+        editingContextId={editingContextId}
+        formId={formId}
+        widget={widget}
+        subscribers={subscribers}
+        data-testid={widget.label}
+      />
+      <ButtonGroup
+        variant="contained"
+        color="primary"
+        ref={buttonGroupRef}
+        aria-label="split button"
+        onFocus={onFocus}
+        onBlur={onBlur}>
+        <Button
+          data-testid={widget.label}
+          variant="contained"
+          color="primary"
+          onClick={handleClick}
+          disabled={readOnly || widget.readOnly || widget.actions[state.selectedIndex].readOnly}
+          classes={{ root: classes[state.selectedIndex].style }}>
+          {widget.actions[state.selectedIndex].imageURL?.length > 0 ? (
+            <img
+              className={classes[state.selectedIndex].icon}
+              alt={widget.actions[state.selectedIndex].label}
+              src={httpOrigin + widget.actions[state.selectedIndex].imageURL}
+            />
+          ) : null}
+          {widget.actions[state.selectedIndex].buttonLabel}
+        </Button>
+        <Button
+          color="primary"
+          size="small"
+          aria-controls={state.open ? 'split-button-menu' : undefined}
+          aria-expanded={state.open ? 'true' : undefined}
+          aria-label="select button action"
+          aria-haspopup="menu"
+          role={'show-actions'}
+          disabled={readOnly || widget.readOnly}
+          onClick={handleToggle}
+          classes={{ root: classes[state.selectedIndex].style }}>
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
+      <Popper open={state.open} anchorEl={buttonGroupRef.current} transition placement="bottom">
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
+            }}>
+            <Paper>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList id="split-button-menu">
+                  {widget.actions.map((option, index) => (
+                    <MenuItem
+                      key={index}
+                      selected={index === state.selectedIndex}
+                      onClick={(event) => handleMenuItemClick(event, index)}
+                      classes={{ root: classes[index].style }}
+                      disabled={readOnly || widget.readOnly || widget.actions[index].readOnly}>
+                      {option.imageURL?.length > 0 ? (
+                        <img className={classes[index].icon} alt={option.label} src={httpOrigin + option.imageURL} />
+                      ) : null}
+                      {option.buttonLabel}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </div>
+  );
+};

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/SplitButtonPropertySection.types.ts
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/SplitButtonPropertySection.types.ts
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { GQLSplitButton, GQLSubscriber } from '../form/FormEventFragments.types';
+
+export interface SplitButtonPropertySectionProps {
+  editingContextId: string;
+  formId: string;
+  widget: GQLSplitButton;
+  subscribers: GQLSubscriber[];
+  readOnly: boolean;
+}
+export interface GQLUpdateWidgetFocusMutationVariables {
+  input: GQLUpdateWidgetFocusInput;
+}
+
+export interface SplitButtonState {
+  open: boolean;
+  selectedIndex: number;
+}
+
+export interface GQLUpdateWidgetFocusInput {
+  id: string;
+  editingContextId: string;
+  representationId: string;
+  widgetId: string;
+  selected: boolean;
+}
+
+export interface GQLUpdateWidgetFocusMutationData {
+  updateWidgetFocus: GQLUpdateWidgetFocusPayload;
+}
+
+export interface GQLUpdateWidgetFocusPayload {
+  __typename: string;
+}
+
+export interface GQLUpdateWidgetFocusSuccessPayload extends GQLUpdateWidgetFocusPayload {}

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/SplitButtonPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/SplitButtonPropertySection.test.tsx
@@ -1,0 +1,380 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { MessageOptions, ServerContext, ToastContext, ToastContextValue } from '@eclipse-sirius/sirius-components-core';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { afterEach, expect, test, vi } from 'vitest';
+import { GQLButton, GQLSplitButton } from '../../form/FormEventFragments.types';
+import { pushButtonMutation, updateWidgetFocusMutation } from '../ButtonPropertySection';
+import {
+  GQLErrorPayload,
+  GQLPushButtonMutationData,
+  GQLPushButtonMutationVariables,
+  GQLSuccessPayload,
+  GQLUpdateWidgetFocusMutationData,
+  GQLUpdateWidgetFocusMutationVariables,
+  GQLUpdateWidgetFocusSuccessPayload,
+} from '../ButtonPropertySection.types';
+import { SplitButtonPropertySection } from '../SplitButtonPropertySection';
+
+crypto.randomUUID = vi.fn(() => '48be95fc-3422-45d3-b1f9-d590e847e9e1');
+
+afterEach(() => cleanup());
+
+const defaultButton: GQLButton = {
+  __typename: 'Button',
+  id: 'buttonId',
+  label: 'Label',
+  iconURL: [],
+  hasHelpText: false,
+  diagnostics: [],
+  buttonLabel: 'ButtonLabel',
+  imageURL: null,
+  style: {
+    backgroundColor: null,
+    foregroundColor: null,
+    fontSize: null,
+    italic: null,
+    bold: null,
+    underline: null,
+    strikeThrough: null,
+  },
+  readOnly: false,
+};
+
+const defaultSplitButton: GQLSplitButton = {
+  __typename: 'Button',
+  id: 'buttonId',
+  label: 'Label',
+  iconURL: [],
+  hasHelpText: false,
+  diagnostics: [],
+  readOnly: false,
+  actions: [defaultButton, defaultButton],
+};
+
+const buttonWithStyle: GQLButton = {
+  ...defaultButton,
+  style: {
+    backgroundColor: '#de1000',
+    foregroundColor: '#fbb800',
+    fontSize: 14,
+    italic: false,
+    bold: false,
+    underline: false,
+    strikeThrough: false,
+  },
+};
+
+const readOnlyButton: GQLButton = {
+  __typename: 'Button',
+  id: 'buttonId',
+  label: 'Label',
+  iconURL: [],
+  diagnostics: [],
+  buttonLabel: 'ButtonLabel',
+  imageURL: null,
+  style: {
+    backgroundColor: null,
+    foregroundColor: null,
+    fontSize: null,
+    italic: null,
+    bold: null,
+    underline: null,
+    strikeThrough: null,
+  },
+  readOnly: true,
+  hasHelpText: false,
+};
+
+const splitButtonWithStyle: GQLSplitButton = {
+  __typename: 'Button',
+  id: 'buttonId',
+  label: 'Label',
+  iconURL: [],
+  hasHelpText: false,
+  diagnostics: [],
+  readOnly: false,
+  actions: [buttonWithStyle, buttonWithStyle],
+};
+
+const splitButtonWithReadOnlyAction: GQLSplitButton = {
+  __typename: 'Button',
+  id: 'buttonId',
+  label: 'Label',
+  iconURL: [],
+  hasHelpText: false,
+  diagnostics: [],
+  readOnly: false,
+  actions: [readOnlyButton, readOnlyButton],
+};
+
+const pushButtonVariables: GQLPushButtonMutationVariables = {
+  input: {
+    id: '48be95fc-3422-45d3-b1f9-d590e847e9e1',
+    editingContextId: 'editingContextId',
+    representationId: 'formId',
+    buttonId: 'buttonId',
+  },
+};
+const successPayload: GQLSuccessPayload = { __typename: 'SuccessPayload', messages: [] };
+const pushButtonSuccessData: GQLPushButtonMutationData = { pushButton: successPayload };
+
+const pushButtonErrorPayload: GQLErrorPayload = {
+  __typename: 'ErrorPayload',
+  messages: [
+    {
+      body: 'An error has occurred, please refresh the page',
+      level: 'ERROR',
+    },
+    {
+      body: 'FeedbackMessage',
+      level: 'INFO',
+    },
+  ],
+};
+const pushButtonErrorData: GQLPushButtonMutationData = {
+  pushButton: pushButtonErrorPayload,
+};
+
+const updateWidgetFocusVariables: GQLUpdateWidgetFocusMutationVariables = {
+  input: {
+    id: '48be95fc-3422-45d3-b1f9-d590e847e9e1',
+    editingContextId: 'editingContextId',
+    representationId: 'formId',
+    widgetId: 'buttonId',
+    selected: true,
+  },
+};
+const updateWidgetFocusSuccessPayload: GQLUpdateWidgetFocusSuccessPayload = {
+  __typename: 'UpdateWidgetFocusSuccessPayload',
+};
+const updateWidgetFocusSuccessData: GQLUpdateWidgetFocusMutationData = {
+  updateWidgetFocus: updateWidgetFocusSuccessPayload,
+};
+
+const updateWidgetFocusErrorPayload: GQLErrorPayload = {
+  __typename: 'ErrorPayload',
+  messages: [
+    {
+      body: 'An error has occurred, please refresh the page',
+      level: 'ERROR',
+    },
+  ],
+};
+const updateWidgetFocusErrorData: GQLUpdateWidgetFocusMutationData = {
+  updateWidgetFocus: updateWidgetFocusErrorPayload,
+};
+
+const mockEnqueue = vi.fn<[string, MessageOptions?], void>();
+
+const toastContextMock: ToastContextValue = {
+  enqueueSnackbar: mockEnqueue,
+};
+
+test('should render the split button and his actions', () => {
+  const { container } = render(
+    <MockedProvider>
+      <ServerContext.Provider value={{ httpOrigin: 'http://localhost' }}>
+        <ToastContext.Provider value={toastContextMock}>
+          <SplitButtonPropertySection
+            editingContextId="editingContextId"
+            formId="formId"
+            widget={defaultSplitButton}
+            subscribers={[]}
+            readOnly={false}
+          />
+        </ToastContext.Provider>
+      </ServerContext.Provider>
+    </MockedProvider>
+  );
+  screen.getByRole('show-actions').click();
+  expect(container).toMatchSnapshot();
+});
+
+test('should render a readOnly button and his actions', () => {
+  const { container } = render(
+    <MockedProvider>
+      <ServerContext.Provider value={{ httpOrigin: 'http://localhost' }}>
+        <ToastContext.Provider value={toastContextMock}>
+          <SplitButtonPropertySection
+            editingContextId="editingContextId"
+            formId="formId"
+            widget={defaultSplitButton}
+            subscribers={[]}
+            readOnly
+          />
+        </ToastContext.Provider>
+      </ServerContext.Provider>
+    </MockedProvider>
+  );
+  screen.getByRole('show-actions').click();
+  expect(container).toMatchSnapshot();
+});
+
+test('should send mutation when clicked', async () => {
+  let updateWidgetFocusCalled = false;
+  const updateWidgetFocusSuccessMock: MockedResponse<Record<string, any>> = {
+    request: {
+      query: updateWidgetFocusMutation,
+      variables: updateWidgetFocusVariables,
+    },
+    result: () => {
+      updateWidgetFocusCalled = true;
+      return { data: updateWidgetFocusSuccessData };
+    },
+  };
+
+  let pushButtonCalled = false;
+  const pushButtonSuccessMock: MockedResponse<Record<string, any>> = {
+    request: {
+      query: pushButtonMutation,
+      variables: pushButtonVariables,
+    },
+    result: () => {
+      pushButtonCalled = true;
+      return { data: pushButtonSuccessData };
+    },
+  };
+
+  const mocks = [updateWidgetFocusSuccessMock, pushButtonSuccessMock];
+  const { container } = render(
+    <MockedProvider mocks={mocks}>
+      <ServerContext.Provider value={{ httpOrigin: 'http://localhost' }}>
+        <ToastContext.Provider value={toastContextMock}>
+          <SplitButtonPropertySection
+            editingContextId="editingContextId"
+            formId="formId"
+            widget={defaultSplitButton}
+            subscribers={[]}
+            readOnly={false}
+          />
+        </ToastContext.Provider>
+      </ServerContext.Provider>
+    </MockedProvider>
+  );
+  expect(container).toMatchSnapshot();
+
+  const element: HTMLElement = screen.getByTestId('Label');
+
+  await act(async () => {
+    userEvent.click(element);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await waitFor(() => {
+      expect(updateWidgetFocusCalled).toBeTruthy();
+      expect(pushButtonCalled).toBeTruthy();
+      expect(container).toMatchSnapshot();
+    });
+  });
+});
+
+test('should display the error received', async () => {
+  let updateWidgetFocusCalled = false;
+  const updateWidgetFocusErrorMock: MockedResponse<Record<string, any>> = {
+    request: {
+      query: updateWidgetFocusMutation,
+      variables: updateWidgetFocusVariables,
+    },
+    result: () => {
+      updateWidgetFocusCalled = true;
+      return { data: updateWidgetFocusErrorData };
+    },
+  };
+
+  let pushButtonCalled = false;
+  const pushButtonErrorMock: MockedResponse<Record<string, any>> = {
+    request: {
+      query: pushButtonMutation,
+      variables: pushButtonVariables,
+    },
+    result: () => {
+      pushButtonCalled = true;
+      return { data: pushButtonErrorData };
+    },
+  };
+
+  const mocks = [updateWidgetFocusErrorMock, pushButtonErrorMock];
+  const { baseElement } = render(
+    <MockedProvider mocks={mocks}>
+      <ServerContext.Provider value={{ httpOrigin: 'http://localhost' }}>
+        <ToastContext.Provider value={toastContextMock}>
+          <SplitButtonPropertySection
+            editingContextId="editingContextId"
+            formId="formId"
+            widget={defaultSplitButton}
+            subscribers={[]}
+            readOnly={false}
+          />
+        </ToastContext.Provider>
+      </ServerContext.Provider>
+    </MockedProvider>
+  );
+  expect(baseElement).toMatchSnapshot();
+
+  const element: HTMLElement = screen.getByTestId('Label');
+
+  await act(async () => {
+    userEvent.click(element);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await waitFor(() => {
+      expect(updateWidgetFocusCalled).toBeTruthy();
+      expect(pushButtonCalled).toBeTruthy();
+      expect(mockEnqueue).toHaveBeenCalledTimes(3);
+      expect(baseElement).toMatchSnapshot();
+    });
+  });
+});
+
+test('should render the button and his actions with style', () => {
+  const { baseElement } = render(
+    <MockedProvider>
+      <ServerContext.Provider value={{ httpOrigin: 'http://localhost' }}>
+        <ToastContext.Provider value={toastContextMock}>
+          <SplitButtonPropertySection
+            editingContextId="editingContextId"
+            formId="formId"
+            widget={splitButtonWithStyle}
+            subscribers={[]}
+            readOnly={false}
+          />
+        </ToastContext.Provider>
+      </ServerContext.Provider>
+    </MockedProvider>
+  );
+  screen.getByRole('show-actions').click();
+  expect(baseElement).toMatchSnapshot();
+});
+
+test('should render the button with help hint', () => {
+  const { baseElement } = render(
+    <MockedProvider>
+      <ServerContext.Provider value={{ httpOrigin: 'http://localhost' }}>
+        {' '}
+        <ToastContext.Provider value={toastContextMock}>
+          <SplitButtonPropertySection
+            editingContextId="editingContextId"
+            formId="formId"
+            widget={{ ...defaultSplitButton, hasHelpText: true }}
+            subscribers={[]}
+            readOnly={false}
+          />
+        </ToastContext.Provider>
+      </ServerContext.Provider>
+    </MockedProvider>
+  );
+  expect(baseElement).toMatchSnapshot();
+});

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/__snapshots__/SplitButtonPropertySection.test.tsx.snap
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/__snapshots__/SplitButtonPropertySection.test.tsx.snap
@@ -1,0 +1,590 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should display the error received 1`] = `
+<body>
+  <div>
+    <div>
+      <div
+        class="makeStyles-propertySectionLabel-34"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle2"
+        >
+          Label
+        </h6>
+        <div
+          class="makeStyles-subscribers-35"
+        />
+      </div>
+      <div
+        aria-label="split button"
+        class="MuiButtonGroup-root MuiButtonGroup-contained"
+        role="group"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root makeStyles-style-28 makeStyles-style-30 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
+          data-testid="Label"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            ButtonLabel
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          aria-haspopup="menu"
+          aria-label="select button action"
+          class="MuiButtonBase-root MuiButton-root makeStyles-style-28 makeStyles-style-30 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+          role="show-actions"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`should display the error received 2`] = `
+<body>
+  <div>
+    <div>
+      <div
+        class="makeStyles-propertySectionLabel-34"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle2"
+        >
+          Label
+        </h6>
+        <div
+          class="makeStyles-subscribers-35"
+        />
+      </div>
+      <div
+        aria-label="split button"
+        class="MuiButtonGroup-root MuiButtonGroup-contained"
+        role="group"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root makeStyles-style-28 makeStyles-style-30 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
+          data-testid="Label"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            ButtonLabel
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          aria-haspopup="menu"
+          aria-label="select button action"
+          class="MuiButtonBase-root MuiButton-root makeStyles-style-28 makeStyles-style-30 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+          role="show-actions"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`should render a readOnly button and his actions 1`] = `
+<div>
+  <div>
+    <div
+      class="makeStyles-propertySectionLabel-16"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-subtitle2"
+      >
+        Label
+      </h6>
+      <div
+        class="makeStyles-subscribers-17"
+      />
+    </div>
+    <div
+      aria-label="split button"
+      class="MuiButtonGroup-root MuiButtonGroup-contained"
+      role="group"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root makeStyles-style-10 makeStyles-style-12 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary Mui-disabled Mui-disabled"
+        data-testid="Label"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          ButtonLabel
+        </span>
+      </button>
+      <button
+        aria-haspopup="menu"
+        aria-label="select button action"
+        class="MuiButtonBase-root MuiButton-root makeStyles-style-10 makeStyles-style-12 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall Mui-disabled Mui-disabled"
+        disabled=""
+        role="show-actions"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`should render the button and his actions with style 1`] = `
+<body>
+  <div>
+    <div>
+      <div
+        class="makeStyles-propertySectionLabel-43"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle2"
+        >
+          Label
+        </h6>
+        <div
+          class="makeStyles-subscribers-44"
+        />
+      </div>
+      <div
+        aria-label="split button"
+        class="MuiButtonGroup-root MuiButtonGroup-contained"
+        role="group"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root makeStyles-style-37 makeStyles-style-39 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
+          data-testid="Label"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            ButtonLabel
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          aria-controls="split-button-menu"
+          aria-expanded="true"
+          aria-haspopup="menu"
+          aria-label="select button action"
+          class="MuiButtonBase-root MuiButton-root makeStyles-style-37 makeStyles-style-39 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+          role="show-actions"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px;"
+    x-placement="bottom"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+      style="opacity: 1; transform: scale(1, 1); transform-origin: center top; transition: opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    >
+      <ul
+        class="MuiList-root MuiList-padding"
+        id="split-button-menu"
+        role="menu"
+        tabindex="-1"
+      >
+        <li
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root makeStyles-style-37 makeStyles-style-39 Mui-selected MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
+          role="menuitem"
+          tabindex="0"
+        >
+          ButtonLabel
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </li>
+        <li
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root makeStyles-style-37 makeStyles-style-41 MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="menuitem"
+          tabindex="-1"
+        >
+          ButtonLabel
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`should render the button with help hint 1`] = `
+<body>
+  <div>
+     
+    <div>
+      <div
+        class="makeStyles-propertySectionLabel-52"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle2"
+        >
+          Label
+        </h6>
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-colorSecondary"
+          focusable="false"
+          style="margin-left: 8px; font-size: 16px;"
+          title=""
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
+          />
+        </svg>
+        <div
+          class="makeStyles-subscribers-53"
+        />
+      </div>
+      <div
+        aria-label="split button"
+        class="MuiButtonGroup-root MuiButtonGroup-contained"
+        role="group"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root makeStyles-style-46 makeStyles-style-48 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
+          data-testid="Label"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            ButtonLabel
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          aria-haspopup="menu"
+          aria-label="select button action"
+          class="MuiButtonBase-root MuiButton-root makeStyles-style-46 makeStyles-style-48 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+          role="show-actions"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`should render the split button and his actions 1`] = `
+<div>
+  <div>
+    <div
+      class="makeStyles-propertySectionLabel-7"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-subtitle2"
+      >
+        Label
+      </h6>
+      <div
+        class="makeStyles-subscribers-8"
+      />
+    </div>
+    <div
+      aria-label="split button"
+      class="MuiButtonGroup-root MuiButtonGroup-contained"
+      role="group"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root makeStyles-style-1 makeStyles-style-3 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
+        data-testid="Label"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          ButtonLabel
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        aria-controls="split-button-menu"
+        aria-expanded="true"
+        aria-haspopup="menu"
+        aria-label="select button action"
+        class="MuiButtonBase-root MuiButton-root makeStyles-style-1 makeStyles-style-3 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+        role="show-actions"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`should send mutation when clicked 1`] = `
+<div>
+  <div>
+    <div
+      class="makeStyles-propertySectionLabel-25"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-subtitle2"
+      >
+        Label
+      </h6>
+      <div
+        class="makeStyles-subscribers-26"
+      />
+    </div>
+    <div
+      aria-label="split button"
+      class="MuiButtonGroup-root MuiButtonGroup-contained"
+      role="group"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root makeStyles-style-19 makeStyles-style-21 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
+        data-testid="Label"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          ButtonLabel
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        aria-haspopup="menu"
+        aria-label="select button action"
+        class="MuiButtonBase-root MuiButton-root makeStyles-style-19 makeStyles-style-21 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+        role="show-actions"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`should send mutation when clicked 2`] = `
+<div>
+  <div>
+    <div
+      class="makeStyles-propertySectionLabel-25"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-subtitle2"
+      >
+        Label
+      </h6>
+      <div
+        class="makeStyles-subscribers-26"
+      />
+    </div>
+    <div
+      aria-label="split button"
+      class="MuiButtonGroup-root MuiButtonGroup-contained"
+      role="group"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root makeStyles-style-19 makeStyles-style-21 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
+        data-testid="Label"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          ButtonLabel
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        aria-haspopup="menu"
+        aria-label="select button action"
+        class="MuiButtonBase-root MuiButton-root makeStyles-style-19 makeStyles-style-21 MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+        role="show-actions"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/view/backend/sirius-components-view-emf/src/test/java/org/eclipse/sirius/components/view/emf/view/DynamicFormsTests.java
+++ b/packages/view/backend/sirius-components-view-emf/src/test/java/org/eclipse/sirius/components/view/emf/view/DynamicFormsTests.java
@@ -59,6 +59,7 @@ import org.eclipse.sirius.components.forms.Radio;
 import org.eclipse.sirius.components.forms.RadioStyle;
 import org.eclipse.sirius.components.forms.Select;
 import org.eclipse.sirius.components.forms.SelectStyle;
+import org.eclipse.sirius.components.forms.SplitButton;
 import org.eclipse.sirius.components.forms.Textarea;
 import org.eclipse.sirius.components.forms.TextareaStyle;
 import org.eclipse.sirius.components.forms.Textfield;
@@ -118,6 +119,7 @@ import org.eclipse.sirius.components.view.form.RadioDescription;
 import org.eclipse.sirius.components.view.form.RadioDescriptionStyle;
 import org.eclipse.sirius.components.view.form.SelectDescription;
 import org.eclipse.sirius.components.view.form.SelectDescriptionStyle;
+import org.eclipse.sirius.components.view.form.SplitButtonDescription;
 import org.eclipse.sirius.components.view.form.TextAreaDescription;
 import org.eclipse.sirius.components.view.form.TextareaDescriptionStyle;
 import org.eclipse.sirius.components.view.form.TextfieldDescription;
@@ -145,7 +147,7 @@ public class DynamicFormsTests {
         assertThat(result.getPages()).extracting(Page::getGroups).hasSize(1);
 
         Group group = result.getPages().get(0).getGroups().get(0);
-        assertThat(group.getWidgets()).hasSize(15);
+        assertThat(group.getWidgets()).hasSize(16);
         Textfield textfield = (Textfield) group.getWidgets().get(0);
         Textarea textarea = (Textarea) group.getWidgets().get(1);
         MultiSelect multiSelect = (MultiSelect) group.getWidgets().get(2);
@@ -161,6 +163,7 @@ public class DynamicFormsTests {
         org.eclipse.sirius.components.forms.List list = (org.eclipse.sirius.components.forms.List) group.getWidgets().get(12);
         Image image = (Image) group.getWidgets().get(13);
         TreeWidget tree = (TreeWidget) group.getWidgets().get(14);
+        SplitButton splitButton = (SplitButton) group.getWidgets().get(15);
 
         this.checkTextfield(textfield, false, false);
         this.checkTextarea(textarea, false, false);
@@ -177,6 +180,7 @@ public class DynamicFormsTests {
         this.checkImage(image);
         this.checkFlexboxContainer(flexboxContainer, false, false);
         this.checkTree(tree);
+        this.checkSplitButton(splitButton, false, false);
     }
 
     @Test
@@ -190,7 +194,7 @@ public class DynamicFormsTests {
         assertThat(result.getPages()).extracting(Page::getGroups).hasSize(1);
 
         Group group = result.getPages().get(0).getGroups().get(0);
-        assertThat(group.getWidgets()).hasSize(15);
+        assertThat(group.getWidgets()).hasSize(16);
         Textfield textfield = (Textfield) group.getWidgets().get(0);
         Textarea textarea = (Textarea) group.getWidgets().get(1);
         MultiSelect multiSelect = (MultiSelect) group.getWidgets().get(2);
@@ -204,6 +208,7 @@ public class DynamicFormsTests {
         LabelWidget labelWidget = (LabelWidget) group.getWidgets().get(10);
         Link link = (Link) group.getWidgets().get(11);
         org.eclipse.sirius.components.forms.List list = (org.eclipse.sirius.components.forms.List) group.getWidgets().get(12);
+        SplitButton splitButton = (SplitButton) group.getWidgets().get(15);
 
         this.checkTextfield(textfield, true, false);
         this.checkTextarea(textarea, true, false);
@@ -219,6 +224,7 @@ public class DynamicFormsTests {
         this.checkPieChart(chartWidgetWithPieChart, true, false);
         // image widget doesn't have style
         this.checkFlexboxContainer(flexboxContainer, true, false);
+        this.checkSplitButton(splitButton, true, false);
     }
 
     @Test
@@ -232,7 +238,7 @@ public class DynamicFormsTests {
         assertThat(result.getPages()).extracting(Page::getGroups).hasSize(1);
 
         Group group = result.getPages().get(0).getGroups().get(0);
-        assertThat(group.getWidgets()).hasSize(15);
+        assertThat(group.getWidgets()).hasSize(16);
         Textfield textfield = (Textfield) group.getWidgets().get(0);
         Textarea textarea = (Textarea) group.getWidgets().get(1);
         MultiSelect multiSelect = (MultiSelect) group.getWidgets().get(2);
@@ -246,6 +252,7 @@ public class DynamicFormsTests {
         LabelWidget labelWidget = (LabelWidget) group.getWidgets().get(10);
         Link link = (Link) group.getWidgets().get(11);
         org.eclipse.sirius.components.forms.List list = (org.eclipse.sirius.components.forms.List) group.getWidgets().get(12);
+        SplitButton splitButton = (SplitButton) group.getWidgets().get(15);
 
         this.checkTextfield(textfield, false, true);
         this.checkTextarea(textarea, false, true);
@@ -261,6 +268,7 @@ public class DynamicFormsTests {
         this.checkPieChart(chartWidgetWithPieChart, false, true);
         // image widget doesn't have conditional style
         this.checkFlexboxContainer(flexboxContainer, false, true);
+        this.checkSplitButton(splitButton, false, true);
     }
 
     @Test
@@ -268,7 +276,7 @@ public class DynamicFormsTests {
         this.buildFixture();
         FormDescription eClassFormDescription = this.createClassFormDescription(false, false);
         Form form = this.render(eClassFormDescription, this.eClasses[0]);
-        assertThat(form.getPages()).flatExtracting(Page::getGroups).flatExtracting(Group::getWidgets).hasSize(15);
+        assertThat(form.getPages()).flatExtracting(Page::getGroups).flatExtracting(Group::getWidgets).hasSize(16);
 
         this.checkValuesEditing(this.eClasses[0], this.eClasses[1], form);
     }
@@ -524,6 +532,13 @@ public class DynamicFormsTests {
         assertThat(tree.getNodes().get(1).getEndIconsURL().get(0).get(0)).isEqualTo("icons/Class3.svg");
     }
 
+    private void checkSplitButton(SplitButton splitButton, boolean checkStyle, boolean checkConditionalStyle) {
+        assertThat(splitButton.getLabel()).isEqualTo("SplitButton for EClass Class1");
+        assertThat(splitButton.getActions()).hasSize(2);
+        checkButton(splitButton.getActions().get(0), checkStyle, checkConditionalStyle);
+        checkButton(splitButton.getActions().get(1), checkStyle, checkConditionalStyle);
+    }
+
     private void checkFlexboxContainer(FlexboxContainer flexboxContainer, boolean checkStyle, boolean checkConditionalStyle) {
         assertThat(flexboxContainer.getLabel()).isEqualTo("A Widget Container");
         List<AbstractWidget> children = flexboxContainer.getChildren();
@@ -556,7 +571,7 @@ public class DynamicFormsTests {
 
     private void checkValuesEditing(EClass eClass, EClass eClass2, Form form) {
         Group group = form.getPages().get(0).getGroups().get(0);
-        assertThat(group.getWidgets()).hasSize(15);
+        assertThat(group.getWidgets()).hasSize(16);
 
         Textfield textfield = (Textfield) group.getWidgets().get(0);
         assertThat(textfield.getValue()).isEqualTo("Class1");
@@ -670,6 +685,8 @@ public class DynamicFormsTests {
         groupDescription.getChildren().add(imageDescription);
         TreeDescription treeDescription = this.createTreeDescription();
         groupDescription.getChildren().add(treeDescription);
+        SplitButtonDescription splitButtonDescription = this.createSplitButton(withStyle, withConditionalStyle);
+        groupDescription.getChildren().add(splitButtonDescription);
         return formDescription;
     }
 
@@ -1041,6 +1058,18 @@ public class DynamicFormsTests {
         checkboxSetValue.setValueExpression("aql:newValue");
         treeDescription.getBody().add(checkboxSetValue);
         return treeDescription;
+    }
+
+    private SplitButtonDescription createSplitButton(boolean withStyle, boolean withConditionalStyle) {
+        SplitButtonDescription splitButtonDescription = FormFactory.eINSTANCE.createSplitButtonDescription();
+        splitButtonDescription.setName("EClass SplitButton");
+        splitButtonDescription.setLabelExpression("aql:'SplitButton for EClass ' + self.name");
+
+        ButtonDescription buttonDescription = this.createButton(withStyle, withConditionalStyle);
+        ButtonDescription buttonDescription2 = this.createButton(withStyle, withConditionalStyle);
+
+        splitButtonDescription.getActions().addAll(List.of(buttonDescription, buttonDescription2));
+        return splitButtonDescription;
     }
 
     private void setFontStyle(LabelStyle labelStyle) {

--- a/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/FlexboxContainerDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/FlexboxContainerDescriptionItemProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Obeo.
+ * Copyright (c) 2021, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -251,6 +251,8 @@ public class FlexboxContainerDescriptionItemProvider extends WidgetDescriptionIt
         selectDescription.setStyle(FormFactory.eINSTANCE.createSelectDescriptionStyle());
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FLEXBOX_CONTAINER_DESCRIPTION__CHILDREN, selectDescription));
 
+        newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FLEXBOX_CONTAINER_DESCRIPTION__CHILDREN, FormFactory.eINSTANCE.createSplitButtonDescription()));
+
         TextAreaDescription textareaDescription = FormFactory.eINSTANCE.createTextAreaDescription();
         textareaDescription.setStyle(FormFactory.eINSTANCE.createTextareaDescriptionStyle());
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FLEXBOX_CONTAINER_DESCRIPTION__CHILDREN, textareaDescription));
@@ -258,6 +260,8 @@ public class FlexboxContainerDescriptionItemProvider extends WidgetDescriptionIt
         TextfieldDescription textfieldDescription = FormFactory.eINSTANCE.createTextfieldDescription();
         textfieldDescription.setStyle(FormFactory.eINSTANCE.createTextfieldDescriptionStyle());
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FLEXBOX_CONTAINER_DESCRIPTION__CHILDREN, textfieldDescription));
+
+        newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FLEXBOX_CONTAINER_DESCRIPTION__CHILDREN, FormFactory.eINSTANCE.createTreeDescription()));
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FLEXBOX_CONTAINER_DESCRIPTION__BORDER_STYLE, FormFactory.eINSTANCE.createContainerBorderStyle()));
 

--- a/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/FormElementForItemProvider.java
+++ b/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/FormElementForItemProvider.java
@@ -194,8 +194,6 @@ public class FormElementForItemProvider extends FormElementDescriptionItemProvid
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_FOR__CHILDREN, FormFactory.eINSTANCE.createMultiSelectDescription()));
 
-        newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_FOR__CHILDREN, FormFactory.eINSTANCE.createTreeDescription()));
-
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_FOR__CHILDREN, FormFactory.eINSTANCE.createPieChartDescription()));
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_FOR__CHILDREN, FormFactory.eINSTANCE.createRadioDescription()));
@@ -204,9 +202,13 @@ public class FormElementForItemProvider extends FormElementDescriptionItemProvid
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_FOR__CHILDREN, FormFactory.eINSTANCE.createSelectDescription()));
 
+        newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_FOR__CHILDREN, FormFactory.eINSTANCE.createSplitButtonDescription()));
+
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_FOR__CHILDREN, FormFactory.eINSTANCE.createTextAreaDescription()));
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_FOR__CHILDREN, FormFactory.eINSTANCE.createTextfieldDescription()));
+
+        newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_FOR__CHILDREN, FormFactory.eINSTANCE.createTreeDescription()));
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_FOR__CHILDREN, FormFactory.eINSTANCE.createFormElementFor()));
 

--- a/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/FormElementIfItemProvider.java
+++ b/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/FormElementIfItemProvider.java
@@ -181,8 +181,6 @@ public class FormElementIfItemProvider extends FormElementDescriptionItemProvide
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_IF__CHILDREN, FormFactory.eINSTANCE.createMultiSelectDescription()));
 
-        newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_IF__CHILDREN, FormFactory.eINSTANCE.createTreeDescription()));
-
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_IF__CHILDREN, FormFactory.eINSTANCE.createPieChartDescription()));
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_IF__CHILDREN, FormFactory.eINSTANCE.createRadioDescription()));
@@ -191,9 +189,13 @@ public class FormElementIfItemProvider extends FormElementDescriptionItemProvide
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_IF__CHILDREN, FormFactory.eINSTANCE.createSelectDescription()));
 
+        newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_IF__CHILDREN, FormFactory.eINSTANCE.createSplitButtonDescription()));
+
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_IF__CHILDREN, FormFactory.eINSTANCE.createTextAreaDescription()));
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_IF__CHILDREN, FormFactory.eINSTANCE.createTextfieldDescription()));
+
+        newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_IF__CHILDREN, FormFactory.eINSTANCE.createTreeDescription()));
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.FORM_ELEMENT_IF__CHILDREN, FormFactory.eINSTANCE.createFormElementFor()));
 

--- a/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/FormItemProviderAdapterFactory.java
+++ b/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/FormItemProviderAdapterFactory.java
@@ -194,6 +194,30 @@ public class FormItemProviderAdapterFactory extends FormAdapterFactory implement
 
     /**
      * This keeps track of the one adapter used for all
+     * {@link org.eclipse.sirius.components.view.form.SplitButtonDescription} instances. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     */
+    protected SplitButtonDescriptionItemProvider splitButtonDescriptionItemProvider;
+
+    /**
+     * This creates an adapter for a {@link org.eclipse.sirius.components.view.form.SplitButtonDescription}. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public Adapter createSplitButtonDescriptionAdapter() {
+        if (this.splitButtonDescriptionItemProvider == null) {
+            this.splitButtonDescriptionItemProvider = new SplitButtonDescriptionItemProvider(this);
+        }
+
+        return this.splitButtonDescriptionItemProvider;
+    }
+
+    /**
+     * This keeps track of the one adapter used for all
      * {@link org.eclipse.sirius.components.view.form.ButtonDescription} instances. <!-- begin-user-doc --> <!--
      * end-user-doc -->
      *
@@ -1375,8 +1399,6 @@ public class FormItemProviderAdapterFactory extends FormAdapterFactory implement
             this.listDescriptionItemProvider.dispose();
         if (this.multiSelectDescriptionItemProvider != null)
             this.multiSelectDescriptionItemProvider.dispose();
-        if (this.treeDescriptionItemProvider != null)
-            this.treeDescriptionItemProvider.dispose();
         if (this.pieChartDescriptionItemProvider != null)
             this.pieChartDescriptionItemProvider.dispose();
         if (this.radioDescriptionItemProvider != null)
@@ -1385,10 +1407,14 @@ public class FormItemProviderAdapterFactory extends FormAdapterFactory implement
             this.richTextDescriptionItemProvider.dispose();
         if (this.selectDescriptionItemProvider != null)
             this.selectDescriptionItemProvider.dispose();
+        if (this.splitButtonDescriptionItemProvider != null)
+            this.splitButtonDescriptionItemProvider.dispose();
         if (this.textAreaDescriptionItemProvider != null)
             this.textAreaDescriptionItemProvider.dispose();
         if (this.textfieldDescriptionItemProvider != null)
             this.textfieldDescriptionItemProvider.dispose();
+        if (this.treeDescriptionItemProvider != null)
+            this.treeDescriptionItemProvider.dispose();
         if (this.barChartDescriptionStyleItemProvider != null)
             this.barChartDescriptionStyleItemProvider.dispose();
         if (this.conditionalBarChartDescriptionStyleItemProvider != null)

--- a/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/GroupDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/GroupDescriptionItemProvider.java
@@ -251,6 +251,8 @@ public class GroupDescriptionItemProvider extends ItemProviderAdapter
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.GROUP_DESCRIPTION__CHILDREN, FormFactory.eINSTANCE.createSelectDescription()));
 
+        newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.GROUP_DESCRIPTION__CHILDREN, FormFactory.eINSTANCE.createSplitButtonDescription()));
+
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.GROUP_DESCRIPTION__CHILDREN, FormFactory.eINSTANCE.createTextAreaDescription()));
 
         newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.GROUP_DESCRIPTION__CHILDREN, FormFactory.eINSTANCE.createTextfieldDescription()));

--- a/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/SplitButtonDescriptionItemProvider.java
+++ b/packages/view/backend/sirius-components-view-form-edit/src/main/java/org/eclipse/sirius/components/view/form/provider/SplitButtonDescriptionItemProvider.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.view.form.provider;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
+import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
+import org.eclipse.emf.edit.provider.ItemPropertyDescriptor;
+import org.eclipse.emf.edit.provider.ViewerNotification;
+import org.eclipse.sirius.components.view.form.FormFactory;
+import org.eclipse.sirius.components.view.form.FormPackage;
+import org.eclipse.sirius.components.view.form.SplitButtonDescription;
+
+/**
+ * This is the item provider adapter for a {@link org.eclipse.sirius.components.view.form.SplitButtonDescription}
+ * object. <!-- begin-user-doc --> <!-- end-user-doc -->
+ *
+ * @generated
+ */
+public class SplitButtonDescriptionItemProvider extends WidgetDescriptionItemProvider {
+    /**
+     * This constructs an instance from a factory and a notifier. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    public SplitButtonDescriptionItemProvider(AdapterFactory adapterFactory) {
+        super(adapterFactory);
+    }
+
+    /**
+     * This returns the property descriptors for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public List<IItemPropertyDescriptor> getPropertyDescriptors(Object object) {
+        if (this.itemPropertyDescriptors == null) {
+            super.getPropertyDescriptors(object);
+
+            this.addIsEnabledExpressionPropertyDescriptor(object);
+        }
+        return this.itemPropertyDescriptors;
+    }
+
+    /**
+     * This adds a property descriptor for the Is Enabled Expression feature. <!-- begin-user-doc --> <!-- end-user-doc
+     * -->
+     *
+     * @generated
+     */
+    protected void addIsEnabledExpressionPropertyDescriptor(Object object) {
+        this.itemPropertyDescriptors.add(this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(),
+                this.getString("_UI_SplitButtonDescription_IsEnabledExpression_feature"),
+                this.getString("_UI_PropertyDescriptor_description", "_UI_SplitButtonDescription_IsEnabledExpression_feature", "_UI_SplitButtonDescription_type"),
+                FormPackage.Literals.SPLIT_BUTTON_DESCRIPTION__IS_ENABLED_EXPRESSION, true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
+    }
+
+    /**
+     * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
+     * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
+     * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
+        if (this.childrenFeatures == null) {
+            super.getChildrenFeatures(object);
+            this.childrenFeatures.add(FormPackage.Literals.SPLIT_BUTTON_DESCRIPTION__ACTIONS);
+        }
+        return this.childrenFeatures;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    protected EStructuralFeature getChildFeature(Object object, Object child) {
+        // Check the type of the specified child object and return the proper feature to use for
+        // adding (see {@link AddCommand}) it as a child.
+
+        return super.getChildFeature(object, child);
+    }
+
+    /**
+     * This returns SplitButtonDescription.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated NOT
+     */
+    @Override
+    public Object getImage(Object object) {
+        return this.overlayImage(object, this.getResourceLocator().getImage("full/obj16/ButtonDescription.svg"));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    protected boolean shouldComposeCreationImage() {
+        return true;
+    }
+
+    /**
+     * This returns the label text for the adapted class. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public String getText(Object object) {
+        String label = ((SplitButtonDescription) object).getName();
+        return label == null || label.length() == 0 ? this.getString("_UI_SplitButtonDescription_type") : this.getString("_UI_SplitButtonDescription_type") + " " + label;
+    }
+
+    /**
+     * This handles model notifications by calling {@link #updateChildren} to update any cached children and by creating
+     * a viewer notification, which it passes to {@link #fireNotifyChanged}. <!-- begin-user-doc --> <!-- end-user-doc
+     * -->
+     *
+     * @generated
+     */
+    @Override
+    public void notifyChanged(Notification notification) {
+        this.updateChildren(notification);
+
+        switch (notification.getFeatureID(SplitButtonDescription.class)) {
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__IS_ENABLED_EXPRESSION:
+                this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+                return;
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__ACTIONS:
+                this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
+                return;
+        }
+        super.notifyChanged(notification);
+    }
+
+    /**
+     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children that can be created
+     * under this object. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
+        super.collectNewChildDescriptors(newChildDescriptors, object);
+
+        newChildDescriptors.add(this.createChildParameter(FormPackage.Literals.SPLIT_BUTTON_DESCRIPTION__ACTIONS, FormFactory.eINSTANCE.createButtonDescription()));
+    }
+
+}

--- a/packages/view/backend/sirius-components-view-form-edit/src/main/resources/plugin.properties
+++ b/packages/view/backend/sirius-components-view-form-edit/src/main/resources/plugin.properties
@@ -211,6 +211,10 @@ _UI_FormElementIf_predicateExpression_feature = Predicate Expression
 _UI_FormElementIf_children_feature = Children
 _UI_Unknown_feature = Unspecified
 
+_UI_SplitButtonDescription_type = SplitButton Description
+_UI_SplitButtonDescription_actions_feature = SplitButton actions
+_UI_SplitButtonDescription_IsEnabledExpression_feature = Is Enabled Expression
+
 _UI_FlexDirection_row_literal = row
 _UI_FlexDirection_rowReverse_literal = row-reverse
 _UI_FlexDirection_column_literal = column

--- a/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/FormFactory.java
+++ b/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/FormFactory.java
@@ -62,6 +62,14 @@ public interface FormFactory extends EFactory {
     BarChartDescription createBarChartDescription();
 
     /**
+     * Returns a new object of class '<em>Split Button Description</em>'. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return a new object of class '<em>Split Button Description</em>'.
+     * @generated
+     */
+    SplitButtonDescription createSplitButtonDescription();
+
+    /**
      * Returns a new object of class '<em>Button Description</em>'. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @return a new object of class '<em>Button Description</em>'.

--- a/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/FormPackage.java
+++ b/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/FormPackage.java
@@ -521,6 +521,16 @@ public interface FormPackage extends EPackage {
     int BAR_CHART_DESCRIPTION_OPERATION_COUNT = WIDGET_DESCRIPTION_OPERATION_COUNT + 0;
 
     /**
+     * The meta object id for the '{@link org.eclipse.sirius.components.view.form.impl.SplitButtonDescriptionImpl
+     * <em>Split Button Description</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @see org.eclipse.sirius.components.view.form.impl.SplitButtonDescriptionImpl
+     * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getSplitButtonDescription()
+     * @generated
+     */
+    int SPLIT_BUTTON_DESCRIPTION = 18;
+
+    /**
      * The meta object id for the '{@link org.eclipse.sirius.components.view.form.impl.ButtonDescriptionImpl <em>Button
      * Description</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
@@ -1288,130 +1298,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getTreeDescription()
      * @generated
      */
-    int TREE_DESCRIPTION = 14;
-
-    /**
-     * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__NAME = WIDGET_DESCRIPTION__NAME;
-
-    /**
-     * The feature id for the '<em><b>Label Expression</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc
-     * -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__LABEL_EXPRESSION = WIDGET_DESCRIPTION__LABEL_EXPRESSION;
-
-    /**
-     * The feature id for the '<em><b>Help Expression</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__HELP_EXPRESSION = WIDGET_DESCRIPTION__HELP_EXPRESSION;
-
-    /**
-     * The feature id for the '<em><b>Children Expression</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc
-     * -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__CHILDREN_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 0;
-
-    /**
-     * The feature id for the '<em><b>Tree Item Label Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
-     * end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__TREE_ITEM_LABEL_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 1;
-
-    /**
-     * The feature id for the '<em><b>Is Tree Item Selectable Expression</b></em>' attribute. <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__IS_TREE_ITEM_SELECTABLE_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 2;
-
-    /**
-     * The feature id for the '<em><b>Tree Item Begin Icon Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
-     * end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__TREE_ITEM_BEGIN_ICON_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 3;
-
-    /**
-     * The feature id for the '<em><b>Tree Item End Icons Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
-     * end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__TREE_ITEM_END_ICONS_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 4;
-
-    /**
-     * The feature id for the '<em><b>Is Checkable Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
-     * end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__IS_CHECKABLE_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 5;
-
-    /**
-     * The feature id for the '<em><b>Checked Value Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
-     * end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__CHECKED_VALUE_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 6;
-
-    /**
-     * The feature id for the '<em><b>Is Enabled Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
-     * end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__IS_ENABLED_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 7;
-
-    /**
-     * The feature id for the '<em><b>Body</b></em>' containment reference list. <!-- begin-user-doc --> <!--
-     * end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION__BODY = WIDGET_DESCRIPTION_FEATURE_COUNT + 8;
-
-    /**
-     * The number of structural features of the '<em>Tree Description</em>' class. <!-- begin-user-doc --> <!--
-     * end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION_FEATURE_COUNT = WIDGET_DESCRIPTION_FEATURE_COUNT + 9;
-
-    /**
-     * The number of operations of the '<em>Tree Description</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int TREE_DESCRIPTION_OPERATION_COUNT = WIDGET_DESCRIPTION_OPERATION_COUNT + 0;
+    int TREE_DESCRIPTION = 21;
 
     /**
      * The meta object id for the '{@link org.eclipse.sirius.components.view.form.impl.PieChartDescriptionImpl <em>Pie
@@ -1421,7 +1308,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getPieChartDescription()
      * @generated
      */
-    int PIE_CHART_DESCRIPTION = 15;
+    int PIE_CHART_DESCRIPTION = 14;
 
     /**
      * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1509,7 +1396,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getRadioDescription()
      * @generated
      */
-    int RADIO_DESCRIPTION = 16;
+    int RADIO_DESCRIPTION = 15;
 
     /**
      * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1624,7 +1511,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getRichTextDescription()
      * @generated
      */
-    int RICH_TEXT_DESCRIPTION = 17;
+    int RICH_TEXT_DESCRIPTION = 16;
 
     /**
      * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1704,7 +1591,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getSelectDescription()
      * @generated
      */
-    int SELECT_DESCRIPTION = 18;
+    int SELECT_DESCRIPTION = 17;
 
     /**
      * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1811,6 +1698,67 @@ public interface FormPackage extends EPackage {
      * @ordered
      */
     int SELECT_DESCRIPTION_OPERATION_COUNT = WIDGET_DESCRIPTION_OPERATION_COUNT + 0;
+
+    /**
+     * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int SPLIT_BUTTON_DESCRIPTION__NAME = WIDGET_DESCRIPTION__NAME;
+
+    /**
+     * The feature id for the '<em><b>Label Expression</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc
+     * -->
+     *
+     * @generated
+     * @ordered
+     */
+    int SPLIT_BUTTON_DESCRIPTION__LABEL_EXPRESSION = WIDGET_DESCRIPTION__LABEL_EXPRESSION;
+
+    /**
+     * The feature id for the '<em><b>Help Expression</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int SPLIT_BUTTON_DESCRIPTION__HELP_EXPRESSION = WIDGET_DESCRIPTION__HELP_EXPRESSION;
+
+    /**
+     * The feature id for the '<em><b>Actions</b></em>' containment reference list. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int SPLIT_BUTTON_DESCRIPTION__ACTIONS = WIDGET_DESCRIPTION_FEATURE_COUNT + 0;
+
+    /**
+     * The feature id for the '<em><b>Is Enabled Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int SPLIT_BUTTON_DESCRIPTION__IS_ENABLED_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 1;
+
+    /**
+     * The number of structural features of the '<em>Split Button Description</em>' class. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int SPLIT_BUTTON_DESCRIPTION_FEATURE_COUNT = WIDGET_DESCRIPTION_FEATURE_COUNT + 2;
+
+    /**
+     * The number of operations of the '<em>Split Button Description</em>' class. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int SPLIT_BUTTON_DESCRIPTION_OPERATION_COUNT = WIDGET_DESCRIPTION_OPERATION_COUNT + 0;
 
     /**
      * The meta object id for the '{@link org.eclipse.sirius.components.view.form.impl.TextAreaDescriptionImpl <em>Text
@@ -2009,6 +1957,129 @@ public interface FormPackage extends EPackage {
     int TEXTFIELD_DESCRIPTION_OPERATION_COUNT = WIDGET_DESCRIPTION_OPERATION_COUNT + 0;
 
     /**
+     * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__NAME = WIDGET_DESCRIPTION__NAME;
+
+    /**
+     * The feature id for the '<em><b>Label Expression</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc
+     * -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__LABEL_EXPRESSION = WIDGET_DESCRIPTION__LABEL_EXPRESSION;
+
+    /**
+     * The feature id for the '<em><b>Help Expression</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__HELP_EXPRESSION = WIDGET_DESCRIPTION__HELP_EXPRESSION;
+
+    /**
+     * The feature id for the '<em><b>Children Expression</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc
+     * -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__CHILDREN_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 0;
+
+    /**
+     * The feature id for the '<em><b>Tree Item Label Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__TREE_ITEM_LABEL_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 1;
+
+    /**
+     * The feature id for the '<em><b>Is Tree Item Selectable Expression</b></em>' attribute. <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__IS_TREE_ITEM_SELECTABLE_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 2;
+
+    /**
+     * The feature id for the '<em><b>Tree Item Begin Icon Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__TREE_ITEM_BEGIN_ICON_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 3;
+
+    /**
+     * The feature id for the '<em><b>Tree Item End Icons Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__TREE_ITEM_END_ICONS_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 4;
+
+    /**
+     * The feature id for the '<em><b>Is Checkable Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__IS_CHECKABLE_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 5;
+
+    /**
+     * The feature id for the '<em><b>Checked Value Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__CHECKED_VALUE_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 6;
+
+    /**
+     * The feature id for the '<em><b>Is Enabled Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__IS_ENABLED_EXPRESSION = WIDGET_DESCRIPTION_FEATURE_COUNT + 7;
+
+    /**
+     * The feature id for the '<em><b>Body</b></em>' containment reference list. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION__BODY = WIDGET_DESCRIPTION_FEATURE_COUNT + 8;
+
+    /**
+     * The number of structural features of the '<em>Tree Description</em>' class. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION_FEATURE_COUNT = WIDGET_DESCRIPTION_FEATURE_COUNT + 9;
+
+    /**
+     * The number of operations of the '<em>Tree Description</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int TREE_DESCRIPTION_OPERATION_COUNT = WIDGET_DESCRIPTION_OPERATION_COUNT + 0;
+
+    /**
      * The meta object id for the '{@link org.eclipse.sirius.components.view.form.impl.WidgetDescriptionStyleImpl
      * <em>Widget Description Style</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
@@ -2016,7 +2087,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getWidgetDescriptionStyle()
      * @generated
      */
-    int WIDGET_DESCRIPTION_STYLE = 21;
+    int WIDGET_DESCRIPTION_STYLE = 22;
 
     /**
      * The number of structural features of the '<em>Widget Description Style</em>' class. <!-- begin-user-doc --> <!--
@@ -2044,7 +2115,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getBarChartDescriptionStyle()
      * @generated
      */
-    int BAR_CHART_DESCRIPTION_STYLE = 22;
+    int BAR_CHART_DESCRIPTION_STYLE = 23;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2121,7 +2192,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalBarChartDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_BAR_CHART_DESCRIPTION_STYLE = 23;
+    int CONDITIONAL_BAR_CHART_DESCRIPTION_STYLE = 24;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2205,7 +2276,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getButtonDescriptionStyle()
      * @generated
      */
-    int BUTTON_DESCRIPTION_STYLE = 24;
+    int BUTTON_DESCRIPTION_STYLE = 25;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2292,7 +2363,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalButtonDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_BUTTON_DESCRIPTION_STYLE = 25;
+    int CONDITIONAL_BUTTON_DESCRIPTION_STYLE = 26;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2386,7 +2457,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getCheckboxDescriptionStyle()
      * @generated
      */
-    int CHECKBOX_DESCRIPTION_STYLE = 26;
+    int CHECKBOX_DESCRIPTION_STYLE = 27;
 
     /**
      * The feature id for the '<em><b>Color</b></em>' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2431,7 +2502,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalCheckboxDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_CHECKBOX_DESCRIPTION_STYLE = 27;
+    int CONDITIONAL_CHECKBOX_DESCRIPTION_STYLE = 28;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2483,7 +2554,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getLabelDescriptionStyle()
      * @generated
      */
-    int LABEL_DESCRIPTION_STYLE = 28;
+    int LABEL_DESCRIPTION_STYLE = 29;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2560,7 +2631,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalLabelDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_LABEL_DESCRIPTION_STYLE = 29;
+    int CONDITIONAL_LABEL_DESCRIPTION_STYLE = 30;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2644,7 +2715,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getLinkDescriptionStyle()
      * @generated
      */
-    int LINK_DESCRIPTION_STYLE = 30;
+    int LINK_DESCRIPTION_STYLE = 31;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2721,7 +2792,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalLinkDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_LINK_DESCRIPTION_STYLE = 31;
+    int CONDITIONAL_LINK_DESCRIPTION_STYLE = 32;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2805,7 +2876,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getListDescriptionStyle()
      * @generated
      */
-    int LIST_DESCRIPTION_STYLE = 32;
+    int LIST_DESCRIPTION_STYLE = 33;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2882,7 +2953,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalListDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_LIST_DESCRIPTION_STYLE = 33;
+    int CONDITIONAL_LIST_DESCRIPTION_STYLE = 34;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2966,7 +3037,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getMultiSelectDescriptionStyle()
      * @generated
      */
-    int MULTI_SELECT_DESCRIPTION_STYLE = 34;
+    int MULTI_SELECT_DESCRIPTION_STYLE = 35;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3061,7 +3132,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalMultiSelectDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_MULTI_SELECT_DESCRIPTION_STYLE = 35;
+    int CONDITIONAL_MULTI_SELECT_DESCRIPTION_STYLE = 36;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3163,7 +3234,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getPieChartDescriptionStyle()
      * @generated
      */
-    int PIE_CHART_DESCRIPTION_STYLE = 36;
+    int PIE_CHART_DESCRIPTION_STYLE = 37;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3256,7 +3327,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalPieChartDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_PIE_CHART_DESCRIPTION_STYLE = 37;
+    int CONDITIONAL_PIE_CHART_DESCRIPTION_STYLE = 38;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3356,7 +3427,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getRadioDescriptionStyle()
      * @generated
      */
-    int RADIO_DESCRIPTION_STYLE = 38;
+    int RADIO_DESCRIPTION_STYLE = 39;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3433,7 +3504,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalRadioDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_RADIO_DESCRIPTION_STYLE = 39;
+    int CONDITIONAL_RADIO_DESCRIPTION_STYLE = 40;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3517,7 +3588,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getSelectDescriptionStyle()
      * @generated
      */
-    int SELECT_DESCRIPTION_STYLE = 40;
+    int SELECT_DESCRIPTION_STYLE = 41;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3612,7 +3683,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalSelectDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_SELECT_DESCRIPTION_STYLE = 41;
+    int CONDITIONAL_SELECT_DESCRIPTION_STYLE = 42;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3714,7 +3785,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getTextareaDescriptionStyle()
      * @generated
      */
-    int TEXTAREA_DESCRIPTION_STYLE = 42;
+    int TEXTAREA_DESCRIPTION_STYLE = 43;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3801,7 +3872,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalTextareaDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_TEXTAREA_DESCRIPTION_STYLE = 43;
+    int CONDITIONAL_TEXTAREA_DESCRIPTION_STYLE = 44;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3895,7 +3966,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getTextfieldDescriptionStyle()
      * @generated
      */
-    int TEXTFIELD_DESCRIPTION_STYLE = 44;
+    int TEXTFIELD_DESCRIPTION_STYLE = 45;
 
     /**
      * The feature id for the '<em><b>Font Size</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -3982,7 +4053,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalTextfieldDescriptionStyle()
      * @generated
      */
-    int CONDITIONAL_TEXTFIELD_DESCRIPTION_STYLE = 45;
+    int CONDITIONAL_TEXTFIELD_DESCRIPTION_STYLE = 46;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -4076,7 +4147,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getContainerBorderStyle()
      * @generated
      */
-    int CONTAINER_BORDER_STYLE = 46;
+    int CONTAINER_BORDER_STYLE = 47;
 
     /**
      * The feature id for the '<em><b>Border Color</b></em>' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -4138,7 +4209,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getConditionalContainerBorderStyle()
      * @generated
      */
-    int CONDITIONAL_CONTAINER_BORDER_STYLE = 47;
+    int CONDITIONAL_CONTAINER_BORDER_STYLE = 48;
 
     /**
      * The feature id for the '<em><b>Condition</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -4207,7 +4278,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getFormElementFor()
      * @generated
      */
-    int FORM_ELEMENT_FOR = 48;
+    int FORM_ELEMENT_FOR = 49;
 
     /**
      * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -4268,7 +4339,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getFormElementIf()
      * @generated
      */
-    int FORM_ELEMENT_IF = 49;
+    int FORM_ELEMENT_IF = 50;
 
     /**
      * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -4321,7 +4392,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getFlexDirection()
      * @generated
      */
-    int FLEX_DIRECTION = 50;
+    int FLEX_DIRECTION = 51;
 
     /**
      * The meta object id for the '{@link org.eclipse.sirius.components.view.form.GroupDisplayMode <em>Group Display
@@ -4331,7 +4402,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getGroupDisplayMode()
      * @generated
      */
-    int GROUP_DISPLAY_MODE = 51;
+    int GROUP_DISPLAY_MODE = 52;
 
     /**
      * The meta object id for the '{@link org.eclipse.sirius.components.view.form.LabelPlacement <em>Label
@@ -4341,7 +4412,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getLabelPlacement()
      * @generated
      */
-    int LABEL_PLACEMENT = 52;
+    int LABEL_PLACEMENT = 53;
 
     /**
      * The meta object id for the '{@link org.eclipse.sirius.components.view.form.ContainerBorderLineStyle <em>Container
@@ -4351,7 +4422,7 @@ public interface FormPackage extends EPackage {
      * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getContainerBorderLineStyle()
      * @generated
      */
-    int CONTAINER_BORDER_LINE_STYLE = 53;
+    int CONTAINER_BORDER_LINE_STYLE = 54;
 
     /**
      * Returns the meta object for class '{@link org.eclipse.sirius.components.view.form.FormDescription
@@ -4723,6 +4794,40 @@ public interface FormPackage extends EPackage {
      * @generated
      */
     EAttribute getBarChartDescription_Height();
+
+    /**
+     * Returns the meta object for class '{@link org.eclipse.sirius.components.view.form.SplitButtonDescription
+     * <em>Split Button Description</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the meta object for class '<em>Split Button Description</em>'.
+     * @see org.eclipse.sirius.components.view.form.SplitButtonDescription
+     * @generated
+     */
+    EClass getSplitButtonDescription();
+
+    /**
+     * Returns the meta object for the containment reference list
+     * '{@link org.eclipse.sirius.components.view.form.SplitButtonDescription#getActions <em>Actions</em>}'. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the meta object for the containment reference list '<em>Actions</em>'.
+     * @see org.eclipse.sirius.components.view.form.SplitButtonDescription#getActions()
+     * @see #getSplitButtonDescription()
+     * @generated
+     */
+    EReference getSplitButtonDescription_Actions();
+
+    /**
+     * Returns the meta object for the attribute
+     * '{@link org.eclipse.sirius.components.view.form.SplitButtonDescription#getIsEnabledExpression <em>Is Enabled
+     * Expression</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the meta object for the attribute '<em>Is Enabled Expression</em>'.
+     * @see org.eclipse.sirius.components.view.form.SplitButtonDescription#getIsEnabledExpression()
+     * @see #getSplitButtonDescription()
+     * @generated
+     */
+    EAttribute getSplitButtonDescription_IsEnabledExpression();
 
     /**
      * Returns the meta object for class '{@link org.eclipse.sirius.components.view.form.ButtonDescription <em>Button
@@ -6812,6 +6917,33 @@ public interface FormPackage extends EPackage {
          * @generated
          */
         EAttribute BAR_CHART_DESCRIPTION__HEIGHT = eINSTANCE.getBarChartDescription_Height();
+
+        /**
+         * The meta object literal for the
+         * '{@link org.eclipse.sirius.components.view.form.impl.SplitButtonDescriptionImpl <em>Split Button
+         * Description</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+         *
+         * @see org.eclipse.sirius.components.view.form.impl.SplitButtonDescriptionImpl
+         * @see org.eclipse.sirius.components.view.form.impl.FormPackageImpl#getSplitButtonDescription()
+         * @generated
+         */
+        EClass SPLIT_BUTTON_DESCRIPTION = eINSTANCE.getSplitButtonDescription();
+
+        /**
+         * The meta object literal for the '<em><b>Actions</b></em>' containment reference list feature. <!--
+         * begin-user-doc --> <!-- end-user-doc -->
+         *
+         * @generated
+         */
+        EReference SPLIT_BUTTON_DESCRIPTION__ACTIONS = eINSTANCE.getSplitButtonDescription_Actions();
+
+        /**
+         * The meta object literal for the '<em><b>Is Enabled Expression</b></em>' attribute feature. <!--
+         * begin-user-doc --> <!-- end-user-doc -->
+         *
+         * @generated
+         */
+        EAttribute SPLIT_BUTTON_DESCRIPTION__IS_ENABLED_EXPRESSION = eINSTANCE.getSplitButtonDescription_IsEnabledExpression();
 
         /**
          * The meta object literal for the '{@link org.eclipse.sirius.components.view.form.impl.ButtonDescriptionImpl

--- a/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/SplitButtonDescription.java
+++ b/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/SplitButtonDescription.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.view.form;
+
+import org.eclipse.emf.common.util.EList;
+
+/**
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Split Button Description</b></em>'. <!--
+ * end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ * <li>{@link org.eclipse.sirius.components.view.form.SplitButtonDescription#getActions <em>Actions</em>}</li>
+ * <li>{@link org.eclipse.sirius.components.view.form.SplitButtonDescription#getIsEnabledExpression <em>Is Enabled
+ * Expression</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.sirius.components.view.form.FormPackage#getSplitButtonDescription()
+ * @model
+ * @generated
+ */
+public interface SplitButtonDescription extends WidgetDescription {
+    /**
+     * Returns the value of the '<em><b>Actions</b></em>' containment reference list. The list contents are of type
+     * {@link org.eclipse.sirius.components.view.form.ButtonDescription}. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the value of the '<em>Actions</em>' containment reference list.
+     * @see org.eclipse.sirius.components.view.form.FormPackage#getSplitButtonDescription_Actions()
+     * @model containment="true"
+     * @generated
+     */
+    EList<ButtonDescription> getActions();
+
+    /**
+     * Returns the value of the '<em><b>Is Enabled Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @return the value of the '<em>Is Enabled Expression</em>' attribute.
+     * @see #setIsEnabledExpression(String)
+     * @see org.eclipse.sirius.components.view.form.FormPackage#getSplitButtonDescription_IsEnabledExpression()
+     * @model dataType="org.eclipse.sirius.components.view.InterpretedExpression"
+     * @generated
+     */
+    String getIsEnabledExpression();
+
+    /**
+     * Sets the value of the
+     * '{@link org.eclipse.sirius.components.view.form.SplitButtonDescription#getIsEnabledExpression <em>Is Enabled
+     * Expression</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @param value
+     *            the new value of the '<em>Is Enabled Expression</em>' attribute.
+     * @see #getIsEnabledExpression()
+     * @generated
+     */
+    void setIsEnabledExpression(String value);
+
+} // SplitButtonDescription

--- a/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/adapters/FormColorAdapter.java
+++ b/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/adapters/FormColorAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,7 @@ import org.eclipse.sirius.components.view.form.RadioDescription;
 import org.eclipse.sirius.components.view.form.RadioDescriptionStyle;
 import org.eclipse.sirius.components.view.form.SelectDescription;
 import org.eclipse.sirius.components.view.form.SelectDescriptionStyle;
+import org.eclipse.sirius.components.view.form.SplitButtonDescription;
 import org.eclipse.sirius.components.view.form.TextAreaDescription;
 import org.eclipse.sirius.components.view.form.TextareaDescriptionStyle;
 import org.eclipse.sirius.components.view.form.TextfieldDescription;
@@ -83,6 +84,12 @@ public class FormColorAdapter extends EContentAdapter {
             this.formStyleSwitch.doSwitch(style);
         } else if (Notification.ADD == notification.getEventType() && notification.getNotifier() instanceof WidgetDescription && notification.getNewValue() instanceof WidgetDescriptionStyle style) {
             this.formStyleSwitch.doSwitch(style);
+        } else if (Notification.ADD == notification.getEventType() && notification.getNotifier() instanceof SplitButtonDescription && notification.getNewValue() instanceof WidgetDescription widget
+                && FormPackage.SPLIT_BUTTON_DESCRIPTION__ACTIONS == notification.getFeatureID(SplitButtonDescription.class)) {
+            WidgetDescriptionStyle style = this.getStyle(widget);
+            if (style != null) {
+                this.formStyleSwitch.doSwitch(style);
+            }
         }
     }
 

--- a/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/impl/FormFactoryImpl.java
+++ b/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/impl/FormFactoryImpl.java
@@ -66,6 +66,7 @@ import org.eclipse.sirius.components.view.form.RadioDescriptionStyle;
 import org.eclipse.sirius.components.view.form.RichTextDescription;
 import org.eclipse.sirius.components.view.form.SelectDescription;
 import org.eclipse.sirius.components.view.form.SelectDescriptionStyle;
+import org.eclipse.sirius.components.view.form.SplitButtonDescription;
 import org.eclipse.sirius.components.view.form.TextAreaDescription;
 import org.eclipse.sirius.components.view.form.TextareaDescriptionStyle;
 import org.eclipse.sirius.components.view.form.TextfieldDescription;
@@ -136,8 +137,6 @@ public class FormFactoryImpl extends EFactoryImpl implements FormFactory {
                 return this.createListDescription();
             case FormPackage.MULTI_SELECT_DESCRIPTION:
                 return this.createMultiSelectDescription();
-            case FormPackage.TREE_DESCRIPTION:
-                return this.createTreeDescription();
             case FormPackage.PIE_CHART_DESCRIPTION:
                 return this.createPieChartDescription();
             case FormPackage.RADIO_DESCRIPTION:
@@ -146,10 +145,14 @@ public class FormFactoryImpl extends EFactoryImpl implements FormFactory {
                 return this.createRichTextDescription();
             case FormPackage.SELECT_DESCRIPTION:
                 return this.createSelectDescription();
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION:
+                return this.createSplitButtonDescription();
             case FormPackage.TEXT_AREA_DESCRIPTION:
                 return this.createTextAreaDescription();
             case FormPackage.TEXTFIELD_DESCRIPTION:
                 return this.createTextfieldDescription();
+            case FormPackage.TREE_DESCRIPTION:
+                return this.createTreeDescription();
             case FormPackage.BAR_CHART_DESCRIPTION_STYLE:
                 return this.createBarChartDescriptionStyle();
             case FormPackage.CONDITIONAL_BAR_CHART_DESCRIPTION_STYLE:
@@ -295,6 +298,17 @@ public class FormFactoryImpl extends EFactoryImpl implements FormFactory {
     public BarChartDescription createBarChartDescription() {
         BarChartDescriptionImpl barChartDescription = new BarChartDescriptionImpl();
         return barChartDescription;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public SplitButtonDescription createSplitButtonDescription() {
+        SplitButtonDescriptionImpl splitButtonDescription = new SplitButtonDescriptionImpl();
+        return splitButtonDescription;
     }
 
     /**

--- a/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/impl/FormPackageImpl.java
+++ b/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/impl/FormPackageImpl.java
@@ -68,6 +68,7 @@ import org.eclipse.sirius.components.view.form.RadioDescriptionStyle;
 import org.eclipse.sirius.components.view.form.RichTextDescription;
 import org.eclipse.sirius.components.view.form.SelectDescription;
 import org.eclipse.sirius.components.view.form.SelectDescriptionStyle;
+import org.eclipse.sirius.components.view.form.SplitButtonDescription;
 import org.eclipse.sirius.components.view.form.TextAreaDescription;
 import org.eclipse.sirius.components.view.form.TextareaDescriptionStyle;
 import org.eclipse.sirius.components.view.form.TextfieldDescription;
@@ -123,6 +124,13 @@ public class FormPackageImpl extends EPackageImpl implements FormPackage {
      * @generated
      */
     private EClass barChartDescriptionEClass = null;
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    private EClass splitButtonDescriptionEClass = null;
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -842,6 +850,36 @@ public class FormPackageImpl extends EPackageImpl implements FormPackage {
     @Override
     public EAttribute getBarChartDescription_Height() {
         return (EAttribute) this.barChartDescriptionEClass.getEStructuralFeatures().get(6);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public EClass getSplitButtonDescription() {
+        return this.splitButtonDescriptionEClass;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public EReference getSplitButtonDescription_Actions() {
+        return (EReference) this.splitButtonDescriptionEClass.getEStructuralFeatures().get(0);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public EAttribute getSplitButtonDescription_IsEnabledExpression() {
+        return (EAttribute) this.splitButtonDescriptionEClass.getEStructuralFeatures().get(1);
     }
 
     /**
@@ -2535,17 +2573,6 @@ public class FormPackageImpl extends EPackageImpl implements FormPackage {
         this.createEReference(this.multiSelectDescriptionEClass, MULTI_SELECT_DESCRIPTION__CONDITIONAL_STYLES);
         this.createEAttribute(this.multiSelectDescriptionEClass, MULTI_SELECT_DESCRIPTION__IS_ENABLED_EXPRESSION);
 
-        this.treeDescriptionEClass = this.createEClass(TREE_DESCRIPTION);
-        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__CHILDREN_EXPRESSION);
-        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__TREE_ITEM_LABEL_EXPRESSION);
-        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__IS_TREE_ITEM_SELECTABLE_EXPRESSION);
-        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__TREE_ITEM_BEGIN_ICON_EXPRESSION);
-        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__TREE_ITEM_END_ICONS_EXPRESSION);
-        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__IS_CHECKABLE_EXPRESSION);
-        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__CHECKED_VALUE_EXPRESSION);
-        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__IS_ENABLED_EXPRESSION);
-        this.createEReference(this.treeDescriptionEClass, TREE_DESCRIPTION__BODY);
-
         this.pieChartDescriptionEClass = this.createEClass(PIE_CHART_DESCRIPTION);
         this.createEAttribute(this.pieChartDescriptionEClass, PIE_CHART_DESCRIPTION__VALUES_EXPRESSION);
         this.createEAttribute(this.pieChartDescriptionEClass, PIE_CHART_DESCRIPTION__KEYS_EXPRESSION);
@@ -2575,6 +2602,10 @@ public class FormPackageImpl extends EPackageImpl implements FormPackage {
         this.createEReference(this.selectDescriptionEClass, SELECT_DESCRIPTION__CONDITIONAL_STYLES);
         this.createEAttribute(this.selectDescriptionEClass, SELECT_DESCRIPTION__IS_ENABLED_EXPRESSION);
 
+        this.splitButtonDescriptionEClass = this.createEClass(SPLIT_BUTTON_DESCRIPTION);
+        this.createEReference(this.splitButtonDescriptionEClass, SPLIT_BUTTON_DESCRIPTION__ACTIONS);
+        this.createEAttribute(this.splitButtonDescriptionEClass, SPLIT_BUTTON_DESCRIPTION__IS_ENABLED_EXPRESSION);
+
         this.textAreaDescriptionEClass = this.createEClass(TEXT_AREA_DESCRIPTION);
         this.createEAttribute(this.textAreaDescriptionEClass, TEXT_AREA_DESCRIPTION__VALUE_EXPRESSION);
         this.createEReference(this.textAreaDescriptionEClass, TEXT_AREA_DESCRIPTION__BODY);
@@ -2588,6 +2619,17 @@ public class FormPackageImpl extends EPackageImpl implements FormPackage {
         this.createEReference(this.textfieldDescriptionEClass, TEXTFIELD_DESCRIPTION__STYLE);
         this.createEReference(this.textfieldDescriptionEClass, TEXTFIELD_DESCRIPTION__CONDITIONAL_STYLES);
         this.createEAttribute(this.textfieldDescriptionEClass, TEXTFIELD_DESCRIPTION__IS_ENABLED_EXPRESSION);
+
+        this.treeDescriptionEClass = this.createEClass(TREE_DESCRIPTION);
+        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__CHILDREN_EXPRESSION);
+        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__TREE_ITEM_LABEL_EXPRESSION);
+        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__IS_TREE_ITEM_SELECTABLE_EXPRESSION);
+        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__TREE_ITEM_BEGIN_ICON_EXPRESSION);
+        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__TREE_ITEM_END_ICONS_EXPRESSION);
+        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__IS_CHECKABLE_EXPRESSION);
+        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__CHECKED_VALUE_EXPRESSION);
+        this.createEAttribute(this.treeDescriptionEClass, TREE_DESCRIPTION__IS_ENABLED_EXPRESSION);
+        this.createEReference(this.treeDescriptionEClass, TREE_DESCRIPTION__BODY);
 
         this.widgetDescriptionStyleEClass = this.createEClass(WIDGET_DESCRIPTION_STYLE);
 
@@ -2727,13 +2769,14 @@ public class FormPackageImpl extends EPackageImpl implements FormPackage {
         this.linkDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
         this.listDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
         this.multiSelectDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
-        this.treeDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
         this.pieChartDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
         this.radioDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
         this.richTextDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
         this.selectDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
+        this.splitButtonDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
         this.textAreaDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
         this.textfieldDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
+        this.treeDescriptionEClass.getESuperTypes().add(this.getWidgetDescription());
         this.barChartDescriptionStyleEClass.getESuperTypes().add(this.getWidgetDescriptionStyle());
         this.barChartDescriptionStyleEClass.getESuperTypes().add(theViewPackage.getLabelStyle());
         this.conditionalBarChartDescriptionStyleEClass.getESuperTypes().add(theViewPackage.getConditional());
@@ -2943,26 +2986,6 @@ public class FormPackageImpl extends EPackageImpl implements FormPackage {
         this.initEAttribute(this.getMultiSelectDescription_IsEnabledExpression(), theViewPackage.getInterpretedExpression(), "IsEnabledExpression", null, 0, 1, MultiSelectDescription.class,
                 !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        this.initEClass(this.treeDescriptionEClass, TreeDescription.class, "TreeDescription", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        this.initEAttribute(this.getTreeDescription_ChildrenExpression(), theViewPackage.getInterpretedExpression(), "childrenExpression", null, 0, 1, TreeDescription.class, !IS_TRANSIENT,
-                !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEAttribute(this.getTreeDescription_TreeItemLabelExpression(), theViewPackage.getInterpretedExpression(), "treeItemLabelExpression", null, 0, 1, TreeDescription.class, !IS_TRANSIENT,
-                !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEAttribute(this.getTreeDescription_IsTreeItemSelectableExpression(), theViewPackage.getInterpretedExpression(), "isTreeItemSelectableExpression", null, 0, 1, TreeDescription.class,
-                !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEAttribute(this.getTreeDescription_TreeItemBeginIconExpression(), theViewPackage.getInterpretedExpression(), "treeItemBeginIconExpression", null, 0, 1, TreeDescription.class,
-                !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEAttribute(this.getTreeDescription_TreeItemEndIconsExpression(), theViewPackage.getInterpretedExpression(), "treeItemEndIconsExpression", null, 0, 1, TreeDescription.class,
-                !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEAttribute(this.getTreeDescription_IsCheckableExpression(), theViewPackage.getInterpretedExpression(), "isCheckableExpression", null, 0, 1, TreeDescription.class, !IS_TRANSIENT,
-                !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEAttribute(this.getTreeDescription_CheckedValueExpression(), theViewPackage.getInterpretedExpression(), "checkedValueExpression", null, 0, 1, TreeDescription.class, !IS_TRANSIENT,
-                !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEAttribute(this.getTreeDescription_IsEnabledExpression(), theViewPackage.getInterpretedExpression(), "IsEnabledExpression", null, 0, 1, TreeDescription.class, !IS_TRANSIENT,
-                !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEReference(this.getTreeDescription_Body(), theViewPackage.getOperation(), null, "body", null, 0, -1, TreeDescription.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
-                !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-
         this.initEClass(this.pieChartDescriptionEClass, PieChartDescription.class, "PieChartDescription", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
         this.initEAttribute(this.getPieChartDescription_ValuesExpression(), theViewPackage.getInterpretedExpression(), "valuesExpression", null, 0, 1, PieChartDescription.class, !IS_TRANSIENT,
                 !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -3013,6 +3036,12 @@ public class FormPackageImpl extends EPackageImpl implements FormPackage {
         this.initEAttribute(this.getSelectDescription_IsEnabledExpression(), theViewPackage.getInterpretedExpression(), "IsEnabledExpression", null, 0, 1, SelectDescription.class, !IS_TRANSIENT,
                 !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
+        this.initEClass(this.splitButtonDescriptionEClass, SplitButtonDescription.class, "SplitButtonDescription", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+        this.initEReference(this.getSplitButtonDescription_Actions(), this.getButtonDescription(), null, "actions", null, 0, -1, SplitButtonDescription.class, !IS_TRANSIENT, !IS_VOLATILE,
+                IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getSplitButtonDescription_IsEnabledExpression(), theViewPackage.getInterpretedExpression(), "IsEnabledExpression", null, 0, 1, SplitButtonDescription.class,
+                !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
         this.initEClass(this.textAreaDescriptionEClass, TextAreaDescription.class, "TextAreaDescription", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
         this.initEAttribute(this.getTextAreaDescription_ValueExpression(), theViewPackage.getInterpretedExpression(), "valueExpression", null, 0, 1, TextAreaDescription.class, !IS_TRANSIENT,
                 !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -3036,6 +3065,26 @@ public class FormPackageImpl extends EPackageImpl implements FormPackage {
                 !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         this.initEAttribute(this.getTextfieldDescription_IsEnabledExpression(), theViewPackage.getInterpretedExpression(), "IsEnabledExpression", null, 0, 1, TextfieldDescription.class, !IS_TRANSIENT,
                 !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+        this.initEClass(this.treeDescriptionEClass, TreeDescription.class, "TreeDescription", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+        this.initEAttribute(this.getTreeDescription_ChildrenExpression(), theViewPackage.getInterpretedExpression(), "childrenExpression", null, 0, 1, TreeDescription.class, !IS_TRANSIENT,
+                !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getTreeDescription_TreeItemLabelExpression(), theViewPackage.getInterpretedExpression(), "treeItemLabelExpression", null, 0, 1, TreeDescription.class, !IS_TRANSIENT,
+                !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getTreeDescription_IsTreeItemSelectableExpression(), theViewPackage.getInterpretedExpression(), "isTreeItemSelectableExpression", null, 0, 1, TreeDescription.class,
+                !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getTreeDescription_TreeItemBeginIconExpression(), theViewPackage.getInterpretedExpression(), "treeItemBeginIconExpression", null, 0, 1, TreeDescription.class,
+                !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getTreeDescription_TreeItemEndIconsExpression(), theViewPackage.getInterpretedExpression(), "treeItemEndIconsExpression", null, 0, 1, TreeDescription.class,
+                !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getTreeDescription_IsCheckableExpression(), theViewPackage.getInterpretedExpression(), "isCheckableExpression", null, 0, 1, TreeDescription.class, !IS_TRANSIENT,
+                !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getTreeDescription_CheckedValueExpression(), theViewPackage.getInterpretedExpression(), "checkedValueExpression", null, 0, 1, TreeDescription.class, !IS_TRANSIENT,
+                !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getTreeDescription_IsEnabledExpression(), theViewPackage.getInterpretedExpression(), "IsEnabledExpression", null, 0, 1, TreeDescription.class, !IS_TRANSIENT,
+                !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEReference(this.getTreeDescription_Body(), theViewPackage.getOperation(), null, "body", null, 0, -1, TreeDescription.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
+                !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.widgetDescriptionStyleEClass, WidgetDescriptionStyle.class, "WidgetDescriptionStyle", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 

--- a/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/impl/SplitButtonDescriptionImpl.java
+++ b/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/impl/SplitButtonDescriptionImpl.java
@@ -1,0 +1,230 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.view.form.impl;
+
+import java.util.Collection;
+
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.NotificationChain;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.util.EObjectContainmentEList;
+import org.eclipse.emf.ecore.util.InternalEList;
+import org.eclipse.sirius.components.view.form.ButtonDescription;
+import org.eclipse.sirius.components.view.form.FormPackage;
+import org.eclipse.sirius.components.view.form.SplitButtonDescription;
+
+/**
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Split Button Description</b></em>'. <!--
+ * end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ * <li>{@link org.eclipse.sirius.components.view.form.impl.SplitButtonDescriptionImpl#getActions <em>Actions</em>}</li>
+ * <li>{@link org.eclipse.sirius.components.view.form.impl.SplitButtonDescriptionImpl#getIsEnabledExpression <em>Is
+ * Enabled Expression</em>}</li>
+ * </ul>
+ *
+ * @generated
+ */
+public class SplitButtonDescriptionImpl extends WidgetDescriptionImpl implements SplitButtonDescription {
+    /**
+     * The cached value of the '{@link #getActions() <em>Actions</em>}' containment reference list. <!-- begin-user-doc
+     * --> <!-- end-user-doc -->
+     *
+     * @see #getActions()
+     * @generated
+     * @ordered
+     */
+    protected EList<ButtonDescription> actions;
+
+    /**
+     * The default value of the '{@link #getIsEnabledExpression() <em>Is Enabled Expression</em>}' attribute. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @see #getIsEnabledExpression()
+     * @generated
+     * @ordered
+     */
+    protected static final String IS_ENABLED_EXPRESSION_EDEFAULT = null;
+
+    /**
+     * The cached value of the '{@link #getIsEnabledExpression() <em>Is Enabled Expression</em>}' attribute. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @see #getIsEnabledExpression()
+     * @generated
+     * @ordered
+     */
+    protected String isEnabledExpression = IS_ENABLED_EXPRESSION_EDEFAULT;
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    protected SplitButtonDescriptionImpl() {
+        super();
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    protected EClass eStaticClass() {
+        return FormPackage.Literals.SPLIT_BUTTON_DESCRIPTION;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public EList<ButtonDescription> getActions() {
+        if (this.actions == null) {
+            this.actions = new EObjectContainmentEList<>(ButtonDescription.class, this, FormPackage.SPLIT_BUTTON_DESCRIPTION__ACTIONS);
+        }
+        return this.actions;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public String getIsEnabledExpression() {
+        return this.isEnabledExpression;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void setIsEnabledExpression(String newIsEnabledExpression) {
+        String oldIsEnabledExpression = this.isEnabledExpression;
+        this.isEnabledExpression = newIsEnabledExpression;
+        if (this.eNotificationRequired())
+            this.eNotify(new ENotificationImpl(this, Notification.SET, FormPackage.SPLIT_BUTTON_DESCRIPTION__IS_ENABLED_EXPRESSION, oldIsEnabledExpression, this.isEnabledExpression));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+        switch (featureID) {
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__ACTIONS:
+                return ((InternalEList<?>) this.getActions()).basicRemove(otherEnd, msgs);
+        }
+        return super.eInverseRemove(otherEnd, featureID, msgs);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public Object eGet(int featureID, boolean resolve, boolean coreType) {
+        switch (featureID) {
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__ACTIONS:
+                return this.getActions();
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__IS_ENABLED_EXPRESSION:
+                return this.getIsEnabledExpression();
+        }
+        return super.eGet(featureID, resolve, coreType);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public void eSet(int featureID, Object newValue) {
+        switch (featureID) {
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__ACTIONS:
+                this.getActions().clear();
+                this.getActions().addAll((Collection<? extends ButtonDescription>) newValue);
+                return;
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__IS_ENABLED_EXPRESSION:
+                this.setIsEnabledExpression((String) newValue);
+                return;
+        }
+        super.eSet(featureID, newValue);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void eUnset(int featureID) {
+        switch (featureID) {
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__ACTIONS:
+                this.getActions().clear();
+                return;
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__IS_ENABLED_EXPRESSION:
+                this.setIsEnabledExpression(IS_ENABLED_EXPRESSION_EDEFAULT);
+                return;
+        }
+        super.eUnset(featureID);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public boolean eIsSet(int featureID) {
+        switch (featureID) {
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__ACTIONS:
+                return this.actions != null && !this.actions.isEmpty();
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION__IS_ENABLED_EXPRESSION:
+                return IS_ENABLED_EXPRESSION_EDEFAULT == null ? this.isEnabledExpression != null : !IS_ENABLED_EXPRESSION_EDEFAULT.equals(this.isEnabledExpression);
+        }
+        return super.eIsSet(featureID);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public String toString() {
+        if (this.eIsProxy())
+            return super.toString();
+
+        StringBuilder result = new StringBuilder(super.toString());
+        result.append(" (IsEnabledExpression: ");
+        result.append(this.isEnabledExpression);
+        result.append(')');
+        return result.toString();
+    }
+
+} // SplitButtonDescriptionImpl

--- a/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/util/FormAdapterFactory.java
+++ b/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/util/FormAdapterFactory.java
@@ -63,6 +63,7 @@ import org.eclipse.sirius.components.view.form.RadioDescriptionStyle;
 import org.eclipse.sirius.components.view.form.RichTextDescription;
 import org.eclipse.sirius.components.view.form.SelectDescription;
 import org.eclipse.sirius.components.view.form.SelectDescriptionStyle;
+import org.eclipse.sirius.components.view.form.SplitButtonDescription;
 import org.eclipse.sirius.components.view.form.TextAreaDescription;
 import org.eclipse.sirius.components.view.form.TextareaDescriptionStyle;
 import org.eclipse.sirius.components.view.form.TextfieldDescription;
@@ -193,11 +194,6 @@ public class FormAdapterFactory extends AdapterFactoryImpl {
         }
 
         @Override
-        public Adapter caseTreeDescription(TreeDescription object) {
-            return FormAdapterFactory.this.createTreeDescriptionAdapter();
-        }
-
-        @Override
         public Adapter casePieChartDescription(PieChartDescription object) {
             return FormAdapterFactory.this.createPieChartDescriptionAdapter();
         }
@@ -218,6 +214,11 @@ public class FormAdapterFactory extends AdapterFactoryImpl {
         }
 
         @Override
+        public Adapter caseSplitButtonDescription(SplitButtonDescription object) {
+            return FormAdapterFactory.this.createSplitButtonDescriptionAdapter();
+        }
+
+        @Override
         public Adapter caseTextAreaDescription(TextAreaDescription object) {
             return FormAdapterFactory.this.createTextAreaDescriptionAdapter();
         }
@@ -225,6 +226,11 @@ public class FormAdapterFactory extends AdapterFactoryImpl {
         @Override
         public Adapter caseTextfieldDescription(TextfieldDescription object) {
             return FormAdapterFactory.this.createTextfieldDescriptionAdapter();
+        }
+
+        @Override
+        public Adapter caseTreeDescription(TreeDescription object) {
+            return FormAdapterFactory.this.createTreeDescriptionAdapter();
         }
 
         @Override
@@ -487,6 +493,20 @@ public class FormAdapterFactory extends AdapterFactoryImpl {
      * @generated
      */
     public Adapter createBarChartDescriptionAdapter() {
+        return null;
+    }
+
+    /**
+     * Creates a new adapter for an object of class
+     * '{@link org.eclipse.sirius.components.view.form.SplitButtonDescription <em>Split Button Description</em>}'. <!--
+     * begin-user-doc --> This default implementation returns null so that we can easily ignore cases; it's useful to
+     * ignore a case when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+     *
+     * @return the new adapter.
+     * @see org.eclipse.sirius.components.view.form.SplitButtonDescription
+     * @generated
+     */
+    public Adapter createSplitButtonDescriptionAdapter() {
         return null;
     }
 

--- a/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/util/FormSwitch.java
+++ b/packages/view/backend/sirius-components-view-form/src/main/java/org/eclipse/sirius/components/view/form/util/FormSwitch.java
@@ -62,6 +62,7 @@ import org.eclipse.sirius.components.view.form.RadioDescriptionStyle;
 import org.eclipse.sirius.components.view.form.RichTextDescription;
 import org.eclipse.sirius.components.view.form.SelectDescription;
 import org.eclipse.sirius.components.view.form.SelectDescriptionStyle;
+import org.eclipse.sirius.components.view.form.SplitButtonDescription;
 import org.eclipse.sirius.components.view.form.TextAreaDescription;
 import org.eclipse.sirius.components.view.form.TextareaDescriptionStyle;
 import org.eclipse.sirius.components.view.form.TextfieldDescription;
@@ -259,17 +260,6 @@ public class FormSwitch<T> extends Switch<T> {
                     result = this.defaultCase(theEObject);
                 return result;
             }
-            case FormPackage.TREE_DESCRIPTION: {
-                TreeDescription treeDescription = (TreeDescription) theEObject;
-                T result = this.caseTreeDescription(treeDescription);
-                if (result == null)
-                    result = this.caseWidgetDescription(treeDescription);
-                if (result == null)
-                    result = this.caseFormElementDescription(treeDescription);
-                if (result == null)
-                    result = this.defaultCase(theEObject);
-                return result;
-            }
             case FormPackage.PIE_CHART_DESCRIPTION: {
                 PieChartDescription pieChartDescription = (PieChartDescription) theEObject;
                 T result = this.casePieChartDescription(pieChartDescription);
@@ -314,6 +304,17 @@ public class FormSwitch<T> extends Switch<T> {
                     result = this.defaultCase(theEObject);
                 return result;
             }
+            case FormPackage.SPLIT_BUTTON_DESCRIPTION: {
+                SplitButtonDescription splitButtonDescription = (SplitButtonDescription) theEObject;
+                T result = this.caseSplitButtonDescription(splitButtonDescription);
+                if (result == null)
+                    result = this.caseWidgetDescription(splitButtonDescription);
+                if (result == null)
+                    result = this.caseFormElementDescription(splitButtonDescription);
+                if (result == null)
+                    result = this.defaultCase(theEObject);
+                return result;
+            }
             case FormPackage.TEXT_AREA_DESCRIPTION: {
                 TextAreaDescription textAreaDescription = (TextAreaDescription) theEObject;
                 T result = this.caseTextAreaDescription(textAreaDescription);
@@ -332,6 +333,17 @@ public class FormSwitch<T> extends Switch<T> {
                     result = this.caseWidgetDescription(textfieldDescription);
                 if (result == null)
                     result = this.caseFormElementDescription(textfieldDescription);
+                if (result == null)
+                    result = this.defaultCase(theEObject);
+                return result;
+            }
+            case FormPackage.TREE_DESCRIPTION: {
+                TreeDescription treeDescription = (TreeDescription) theEObject;
+                T result = this.caseTreeDescription(treeDescription);
+                if (result == null)
+                    result = this.caseWidgetDescription(treeDescription);
+                if (result == null)
+                    result = this.caseFormElementDescription(treeDescription);
                 if (result == null)
                     result = this.defaultCase(theEObject);
                 return result;
@@ -778,6 +790,21 @@ public class FormSwitch<T> extends Switch<T> {
      * @generated
      */
     public T caseBarChartDescription(BarChartDescription object) {
+        return null;
+    }
+
+    /**
+     * Returns the result of interpreting the object as an instance of '<em>Split Button Description</em>'. <!--
+     * begin-user-doc --> This implementation returns null; returning a non-null result will terminate the switch. <!--
+     * end-user-doc -->
+     *
+     * @param object
+     *            the target of the switch.
+     * @return the result of interpreting the object as an instance of '<em>Split Button Description</em>'.
+     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+     * @generated
+     */
+    public T caseSplitButtonDescription(SplitButtonDescription object) {
         return null;
     }
 

--- a/packages/view/backend/sirius-components-view-form/src/main/resources/model/form.ecore
+++ b/packages/view/backend/sirius-components-view-form/src/main/resources/model/form.ecore
@@ -157,24 +157,6 @@
         eType="#//ConditionalMultiSelectDescriptionStyle" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="IsEnabledExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="TreeDescription" eSuperTypes="#//WidgetDescription">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="childrenExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="treeItemLabelExpression"
-        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isTreeItemSelectableExpression"
-        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="treeItemBeginIconExpression"
-        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="treeItemEndIconsExpression"
-        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isCheckableExpression"
-        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="checkedValueExpression"
-        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="IsEnabledExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="body" upperBound="-1" eType="ecore:EClass ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//Operation"
-        containment="true"/>
-  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="PieChartDescription" eSuperTypes="#//WidgetDescription">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="valuesExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="keysExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
@@ -215,6 +197,11 @@
         eType="#//ConditionalSelectDescriptionStyle" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="IsEnabledExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="SplitButtonDescription" eSuperTypes="#//WidgetDescription">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="actions" upperBound="-1"
+        eType="#//ButtonDescription" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="IsEnabledExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TextAreaDescription" eSuperTypes="#//WidgetDescription">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="valueExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="body" upperBound="-1" eType="ecore:EClass ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//Operation"
@@ -234,6 +221,24 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="conditionalStyles" upperBound="-1"
         eType="#//ConditionalTextfieldDescriptionStyle" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="IsEnabledExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TreeDescription" eSuperTypes="#//WidgetDescription">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="childrenExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="treeItemLabelExpression"
+        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isTreeItemSelectableExpression"
+        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="treeItemBeginIconExpression"
+        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="treeItemEndIconsExpression"
+        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="isCheckableExpression"
+        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="checkedValueExpression"
+        eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="IsEnabledExpression" eType="ecore:EDataType ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//InterpretedExpression"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="body" upperBound="-1" eType="ecore:EClass ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//Operation"
+        containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="WidgetDescriptionStyle" abstract="true"/>
   <eClassifiers xsi:type="ecore:EClass" name="BarChartDescriptionStyle" eSuperTypes="#//WidgetDescriptionStyle ../../../../../sirius-components-view/src/main/resources/model/view.ecore#//LabelStyle">

--- a/packages/view/backend/sirius-components-view-form/src/main/resources/model/form.genmodel
+++ b/packages/view/backend/sirius-components-view-form/src/main/resources/model/form.genmodel
@@ -127,17 +127,6 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference form.ecore#//MultiSelectDescription/conditionalStyles"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//MultiSelectDescription/IsEnabledExpression"/>
     </genClasses>
-    <genClasses ecoreClass="form.ecore#//TreeDescription">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/childrenExpression"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/treeItemLabelExpression"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/isTreeItemSelectableExpression"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/treeItemBeginIconExpression"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/treeItemEndIconsExpression"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/isCheckableExpression"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/checkedValueExpression"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/IsEnabledExpression"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference form.ecore#//TreeDescription/body"/>
-    </genClasses>
     <genClasses ecoreClass="form.ecore#//PieChartDescription">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//PieChartDescription/valuesExpression"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//PieChartDescription/keysExpression"/>
@@ -167,6 +156,10 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference form.ecore#//SelectDescription/conditionalStyles"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//SelectDescription/IsEnabledExpression"/>
     </genClasses>
+    <genClasses ecoreClass="form.ecore#//SplitButtonDescription">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference form.ecore#//SplitButtonDescription/actions"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//SplitButtonDescription/IsEnabledExpression"/>
+    </genClasses>
     <genClasses ecoreClass="form.ecore#//TextAreaDescription">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TextAreaDescription/valueExpression"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference form.ecore#//TextAreaDescription/body"/>
@@ -180,6 +173,17 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference form.ecore#//TextfieldDescription/style"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference form.ecore#//TextfieldDescription/conditionalStyles"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TextfieldDescription/IsEnabledExpression"/>
+    </genClasses>
+    <genClasses ecoreClass="form.ecore#//TreeDescription">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/childrenExpression"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/treeItemLabelExpression"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/isTreeItemSelectableExpression"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/treeItemBeginIconExpression"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/treeItemEndIconsExpression"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/isCheckableExpression"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/checkedValueExpression"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute form.ecore#//TreeDescription/IsEnabledExpression"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference form.ecore#//TreeDescription/body"/>
     </genClasses>
     <genClasses image="false" ecoreClass="form.ecore#//WidgetDescriptionStyle"/>
     <genClasses ecoreClass="form.ecore#//BarChartDescriptionStyle">


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/3084

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?