### PR TITLE
[3166] Fix Label Edit Tool on outside Labels

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -86,6 +86,7 @@ Having `Viewer` as a type did not bring any additional value and it created some
 - https://github.com/eclipse-sirius/sirius-web/issues/3127[#3127] [diagram] Fix an issue with handles position
 - https://github.com/eclipse-sirius/sirius-web/issues/3143[#3143] [diagram] Fix an issue where the default icon was consistently being used for EdgeTool
 The implemented fix does not allow to evaluate an AQL expression, but only to retrieve a static value.
+- https://github.com/eclipse-sirius/sirius-web/issues/3166[#3166] [diagram] Fix an issue where label edit tool did nothing on nodes with outside label.
 
 === New Features
 

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/useDiagramDirectEdit.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/useDiagramDirectEdit.tsx
@@ -39,14 +39,22 @@ export const useDiagramDirectEdit = (): UseDiagramDirectEditValue => {
       event.preventDefault();
       const validFirstInputChar =
         !event.metaKey && !event.ctrlKey && key.length === 1 && directEditActivationValidCharacters.test(key);
-      let currentlyEditedLabelId: string | undefined | null = getNodes().find((node) => node.selected)?.data.insideLabel
-        ?.id;
-      let isLabelEditable: boolean = getNodes().find((node) => node.selected)?.data.labelEditable || false;
+
+      let currentlyEditedLabelId: string | undefined | null;
+      let isLabelEditable: boolean = false;
+      const nodeData: NodeData | undefined = getNodes().find((node) => node.selected)?.data;
+      if (nodeData) {
+        if (nodeData.insideLabel) {
+          currentlyEditedLabelId = nodeData.insideLabel.id;
+        } else if (nodeData.outsideLabels.BOTTOM_MIDDLE) {
+          currentlyEditedLabelId = nodeData.outsideLabels.BOTTOM_MIDDLE.id;
+        }
+        isLabelEditable = nodeData.labelEditable;
+      }
       if (!currentlyEditedLabelId) {
         currentlyEditedLabelId = getEdges().find((edge) => edge.selected)?.data?.label?.id;
         isLabelEditable = getEdges().find((edge) => edge.selected)?.data?.centerLabelEditable || false;
       }
-
       if (currentlyEditedLabelId && isLabelEditable) {
         if (validFirstInputChar) {
           setCurrentlyEditedLabelId('keyDown', currentlyEditedLabelId, key);

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/node/FreeFormNode.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/node/FreeFormNode.tsx
@@ -94,6 +94,16 @@ export const FreeFormNode = memo(({ data, id, selected }: NodeProps<FreeFormNode
 
   useRefreshConnectionHandles(id, data.connectionHandles);
 
+  const getLabelId = (data: FreeFormNodeData): string | null => {
+    let labelId: string | null = null;
+    if (data.insideLabel) {
+      labelId = data.insideLabel.id;
+    } else if (data.outsideLabels.BOTTOM_MIDDLE) {
+      labelId = data.outsideLabels.BOTTOM_MIDDLE.id;
+    }
+    return labelId;
+  };
+
   return (
     <>
       <Resizer data={data} selected={selected} />
@@ -107,9 +117,7 @@ export const FreeFormNode = memo(({ data, id, selected }: NodeProps<FreeFormNode
         onDrop={handleOnDrop}
         data-testid={`FreeForm - ${data?.targetObjectLabel}`}>
         {data.insideLabel && <Label diagramElementId={id} label={data.insideLabel} faded={data.faded} transform="" />}
-        {selected ? (
-          <DiagramElementPalette diagramElementId={id} labelId={data.insideLabel ? data.insideLabel.id : null} />
-        ) : null}
+        {selected ? <DiagramElementPalette diagramElementId={id} labelId={getLabelId(data)} /> : null}
         {selected ? <ConnectionCreationHandles nodeId={id} /> : null}
         <ConnectionTargetHandle nodeId={id} nodeDescription={data.nodeDescription} />
         <ConnectionHandles connectionHandles={data.connectionHandles} />


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/3166

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?