### PR TITLE
[3019] Clear the domain events collector before the tests

### DIFF
--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/semanticdata/listeners/SemanticDataInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/semanticdata/listeners/SemanticDataInitializer.java
@@ -18,6 +18,7 @@ import org.eclipse.sirius.web.domain.boundedcontexts.project.events.ProjectCreat
 import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api.ISemanticDataCreationService;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -35,7 +36,7 @@ public class SemanticDataInitializer {
         this.semanticDataCreationService = Objects.requireNonNull(semanticDataCreationService);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener
     public void onProjectCreatedEvent(ProjectCreatedEvent event) {
         this.semanticDataCreationService.initialize(AggregateReference.to(event.project().getId()));

--- a/packages/sirius-web/backend/sirius-web-persistence/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-persistence/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2019, 2023 Obeo.
+ Copyright (c) 2019, 2024 Obeo.
  This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v2.0
  which accompanies this distribution, and is available at
@@ -82,13 +82,11 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>1.15.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>1.15.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/sirius-web/backend/sirius-web-sample-application/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-sample-application/pom.xml
@@ -233,13 +233,11 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>1.15.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>1.15.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/sirius-web/backend/sirius-web/pom.xml
+++ b/packages/sirius-web/backend/sirius-web/pom.xml
@@ -62,13 +62,11 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>1.15.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>1.15.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/ProjectControllerIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/ProjectControllerIntegrationTests.java
@@ -38,7 +38,7 @@ import org.eclipse.sirius.web.domain.boundedcontexts.project.services.api.IProje
 import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api.ISemanticDataSearchService;
 import org.eclipse.sirius.web.services.api.IDomainEventCollector;
 import org.eclipse.sirius.web.services.api.IGraphQLRequestor;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -145,8 +145,8 @@ public class ProjectControllerIntegrationTests extends AbstractIntegrationTests 
     @Autowired
     private IDomainEventCollector domainEventCollector;
 
-    @AfterEach
-    public void afterEach() {
+    @BeforeEach
+    public void beforeEach() {
         this.domainEventCollector.clear();
     }
 

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/ProjectControllerIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/ProjectControllerIntegrationTests.java
@@ -226,7 +226,7 @@ public class ProjectControllerIntegrationTests extends AbstractIntegrationTests 
         assertThat(optionalProject).isPresent();
         optionalProject.ifPresent(project -> assertThat(project.getName()).isEqualTo(input.name()));
 
-        assertThat(this.domainEventCollector.getDomainEvents()).hasSize(1);
+        assertThat(this.domainEventCollector.getDomainEvents()).hasSize(2);
         var event = this.domainEventCollector.getDomainEvents().get(0);
         assertThat(event).isInstanceOf(ProjectCreatedEvent.class);
     }
@@ -241,7 +241,7 @@ public class ProjectControllerIntegrationTests extends AbstractIntegrationTests 
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
-        assertThat(this.domainEventCollector.getDomainEvents()).hasSize(1);
+        assertThat(this.domainEventCollector.getDomainEvents()).hasSize(2);
         var event = this.domainEventCollector.getDomainEvents().get(0);
         assertThat(event).isInstanceOf(ProjectCreatedEvent.class);
 

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/RepresentationControllerIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/RepresentationControllerIntegrationTests.java
@@ -33,7 +33,7 @@ import org.eclipse.sirius.web.services.TestRepresentation;
 import org.eclipse.sirius.web.services.TestRepresentationDescription;
 import org.eclipse.sirius.web.services.api.IDomainEventCollector;
 import org.eclipse.sirius.web.services.api.IGraphQLRequestor;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -146,8 +146,8 @@ public class RepresentationControllerIntegrationTests extends AbstractIntegratio
     @Autowired
     private IDomainEventCollector domainEventCollector;
 
-    @AfterEach
-    public void afterEach() {
+    @BeforeEach
+    public void beforeEach() {
         this.domainEventCollector.clear();
     }
 


### PR DESCRIPTION
Without this, running the complete suite of tests in `sirius-web` fails on `ProjectControllerIntegrationTests.givenValidProjectToCreateWhenMutationIsPerformedThenTheSemanticDataAreCreated()` because the `IDomainEventCollector` is reused and the previous test in the suite, from another test class, leaves an event in the collector:

![Capture d’écran du 2024-02-27 15-20-39](https://github.com/eclipse-sirius/sirius-web/assets/10608/09687d9c-f0ba-46d4-9e34-d6ab7db174aa)

