### PR TITLE
[1707] Fix click while editing tree item label ends the edition

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -48,7 +48,7 @@ As a result, all the APIs relying on this code have been deleted too such as the
 - https://github.com/eclipse-sirius/sirius-web/issues/3042[#3042] [core] IObjectService have been divided in smaller API IContentService, IObjectSearchService, IIdentityService and ILabelService.
 If you used the default implementation of `IObjectService` you can still use it to retrieve the default implementation of the new services.
 Yet we are recommending using each individual services since this aggregated one may be deprecated in the future.
-If you want to add your own custom behaviour, please use the new services, see the related ADR for more details.
+If you want to add your own custom behavior, please use the new services, see the related ADR for more details.
 - https://github.com/eclipse-sirius/sirius-web/issues/3066[#3066] [core] `IObjectSearchService`, `IIdentityService`, `ILabelService` now can also find/resolve representations.
 This changes a core assumption from before where an element known to those services (i.e. an element for which `IIdentityService.getId` returned a non-null value) was a "semantic element" and thus *could not be* a representation.
 - https://github.com/eclipse-sirius/sirius-web/issues/3021[#3021] [sirius-web] Remove the interfaces `IRepresentationDescriptionRegistry` and `IRepresentationDescriptionRegistryConfigurer` to replace them with `IEditingContextRepresentationDescriptionProvider` which provides the same feature but also gives access to the editing context for conditional registration of representation descriptions.
@@ -66,7 +66,7 @@ Having `Viewer` as a type did not bring any additional value and it created some
 === Dependency update
 
 - https://github.com/eclipse-sirius/sirius-web/issues/2783[#2783] [diagram] Remove our dependency to Sprotty and Snabbdom
-- https://github.com/eclipse-sirius/sirius-web/issues/3105[#3105] [deck] Move to @obeonetwork/react-trello 2.4.11 to avoid warnings because of react-redux depending on react 16.
+- https://github.com/eclipse-sirius/sirius-web/issues/3105[#3105] [deck] Move to @ObeoNetwork/react-trello 2.4.11 to avoid warnings because of react-redux depending on react 16.
 
 === Bug fixes
 
@@ -87,6 +87,7 @@ Having `Viewer` as a type did not bring any additional value and it created some
 - https://github.com/eclipse-sirius/sirius-web/issues/3143[#3143] [diagram] Fix an issue where the default icon was consistently being used for EdgeTool
 The implemented fix does not allow to evaluate an AQL expression, but only to retrieve a static value.
 - https://github.com/eclipse-sirius/sirius-web/issues/3166[#3166] [diagram] Fix an issue where label edit tool did nothing on nodes with outside label.
+- https://github.com/eclipse-sirius/sirius-web/issues/1707[#1707] [diagram] Fix an issue where changing cursor position through a click while editing a tree item label lead to the end of the edition.
 
 === New Features
 

--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItem.types.ts
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItem.types.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Obeo.
+ * Copyright (c) 2021, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -24,4 +24,14 @@ export interface TreeItemProps {
   textToFilter: string | null;
   enableMultiSelection: boolean;
   markedItemIds: string[];
+}
+
+export interface TreeItemState {
+  showContextMenu: boolean;
+  menuAnchor: Element | null;
+  editingMode: boolean;
+  label: string;
+  prevSelectionId: string | null;
+  editingKey: string | null;
+  isHovered: boolean;
 }

--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemDirectEditInput.types.ts
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemDirectEditInput.types.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ export interface TreeItemDirectEditInputProps {
   editingContextId: string;
   treeId: string;
   treeItemId: string;
-  editingkey: string;
+  editingKey: string;
   onClose: () => void;
 }
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/1707

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?