### PR TITLE
[1546] Automatically select newly created documents in the explorer

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -176,6 +176,8 @@ image:doc/screenshots/borderNodeCreationArea.png[BorderNode creation area,50%]
 In other scenarios, the default creation position border remains the eastern one.
 - https://github.com/eclipse-sirius/sirius-web/issues/2785[#2785] [gantt] Add cypress tests
 
+- https://github.com/eclipse-sirius/sirius-web/issues/1546[#1546] [sirius-web] Newly created documents are not automatically selected in the _Explorer_ view.
+
 == v2024.1.0
 
 === Shapes

--- a/integration-tests/cypress/e2e/project/explorer/explorer-toolbar.cy.ts
+++ b/integration-tests/cypress/e2e/project/explorer/explorer-toolbar.cy.ts
@@ -78,6 +78,7 @@ describe('/projects/:projectId/edit - Tree toolbar', () => {
 
         cy.get('.MuiDialog-container').should('not.exist');
         cy.getByTestId('explorer://').contains('nobel');
+        cy.getByTestId('selected').should('have.attr', 'data-treeitemlabel', 'nobel');
       });
 
       it('can open the upload document modal', () => {

--- a/packages/sirius-web/frontend/sirius-web-application/src/modals/new-document/NewDocumentModal.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/modals/new-document/NewDocumentModal.types.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Obeo.
+ * Copyright (c) 2021, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -58,6 +58,11 @@ export interface GQLCreateDocumentPayload {
 }
 
 export interface GQLSuccessPayload extends GQLCreateDocumentPayload {
+  id: string;
+  document: GQLDocument;
+}
+
+export interface GQLDocument {
   id: string;
 }
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/1546
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
