### PR TITLE
[3301] Use outsideLabel during directEdit if there is no insideLabel

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -64,7 +64,7 @@ This will make the dependency to the old Sirius Web architecture more explicit.
 - https://github.com/eclipse-sirius/sirius-web/issues/3317[#3317] [diagram] Fix an issue that caused a crash when selection changes were made too quickly
 - https://github.com/eclipse-sirius/sirius-web/issues/3269[#3269] [diagram] Disable node drag and drop during multi selection
 - https://github.com/eclipse-sirius/sirius-web/issues/3352[#3352] [diagram] Fix an issue that prevents pinned elements from being unpinned unintentionally
-
+- https://github.com/eclipse-sirius/sirius-web/issues/3301[#3301] [diagram] Fix an issue that caused direct edit to fail if a node didn't have an inside label.
 
 === New Features
 

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramQueryService.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramQueryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Obeo.
+ * Copyright (c) 2021, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,12 @@ public class DiagramQueryService implements IDiagramQueryService {
 
     @Override
     public Optional<Node> findNodeByLabelId(Diagram diagram, String labelId) {
-        return this.findNode(node -> Objects.equals(node.getInsideLabel().getId(), labelId), diagram.getNodes());
+        return this.findNode(node -> {
+            if (node.getInsideLabel() != null) {
+                return Objects.equals(node.getInsideLabel().getId(), labelId);
+            }
+            return node.getOutsideLabels().stream().anyMatch(label -> Objects.equals(label.id(), labelId));
+        }, diagram.getNodes());
     }
 
     private Optional<Node> findNode(Predicate<Node> condition, List<Node> candidates) {

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/TestDiagramBuilder.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/TestDiagramBuilder.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.components.diagrams.LabelStyle;
 import org.eclipse.sirius.components.diagrams.LineStyle;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.NodeType;
+import org.eclipse.sirius.components.diagrams.OutsideLabel;
 import org.eclipse.sirius.components.diagrams.Position;
 import org.eclipse.sirius.components.diagrams.Ratio;
 import org.eclipse.sirius.components.diagrams.RectangularNodeStyle;
@@ -78,7 +79,15 @@ public class TestDiagramBuilder {
                 .build();
     }
 
-    public Node getNode(String id, boolean withLabel) {
+    public Node getNode(String id, boolean withInsideLabel) {
+        return this.getNode(id, withInsideLabel, List.of());
+    }
+
+    public Node getNodeWithOutsideLabels(String id, boolean withInsideLabel, List<OutsideLabel> outsideLabels) {
+        return this.getNode(id, withInsideLabel, outsideLabels);
+    }
+
+    private Node getNode(String id, boolean withInsideLabel, List<OutsideLabel> outsideLabels) {
         Node.Builder nodeBuilder = Node.newNode(id)
                 .type(NodeType.NODE_RECTANGLE)
                 .targetObjectId("nodeTargetObjectId")
@@ -93,9 +102,10 @@ public class TestDiagramBuilder {
                 .childNodes(List.of())
                 .modifiers(Set.of())
                 .state(ViewModifier.Normal)
-                .collapsingState(CollapsingState.EXPANDED);
+                .collapsingState(CollapsingState.EXPANDED)
+                .outsideLabels(outsideLabels);
 
-        if (withLabel) {
+        if (withInsideLabel) {
             LabelStyle labelStyle = LabelStyle.newLabelStyle()
                     .color("#000000")
                     .fontSize(16)

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/providers/ViewInitialDirectEditElementLabelProvider.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/providers/ViewInitialDirectEditElementLabelProvider.java
@@ -27,6 +27,7 @@ import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
 import org.eclipse.sirius.components.diagrams.Node;
+import org.eclipse.sirius.components.diagrams.OutsideLabel;
 import org.eclipse.sirius.components.diagrams.description.EdgeLabelKind;
 import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
 import org.eclipse.sirius.components.interpreter.AQLInterpreter;
@@ -76,7 +77,7 @@ public class ViewInitialDirectEditElementLabelProvider implements IInitialDirect
     private final ApplicationContext applicationContext;
 
     public ViewInitialDirectEditElementLabelProvider(IViewRepresentationDescriptionPredicate viewRepresentationDescriptionPredicate, IDiagramQueryService diagramQueryService, IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService, IObjectService objectService,
-                                                     List<IJavaServiceProvider> javaServiceProviders, IDiagramIdProvider idProvider, ApplicationContext applicationContext) {
+            List<IJavaServiceProvider> javaServiceProviders, IDiagramIdProvider idProvider, ApplicationContext applicationContext) {
         this.viewRepresentationDescriptionPredicate = Objects.requireNonNull(viewRepresentationDescriptionPredicate);
         this.diagramQueryService = Objects.requireNonNull(diagramQueryService);
         this.viewRepresentationDescriptionSearchService = Objects.requireNonNull(viewRepresentationDescriptionSearchService);
@@ -108,7 +109,11 @@ public class ViewInitialDirectEditElementLabelProvider implements IInitialDirect
                 String descriptionId = node.getDescriptionId();
                 optionalLabelEditTool = this.getNodeDescription(diagramDescription.getNodeDescriptions(), descriptionId).map(NodeDescription::getPalette).map(NodePalette::getLabelEditTool);
                 semanticElement = this.objectService.getObject(editingContext, node.getTargetObjectId());
-                initialDirectEditElementLabel = node.getInsideLabel().getText();
+                if (node.getInsideLabel() != null && Objects.equals(node.getInsideLabel().getId(), labelId)) {
+                    initialDirectEditElementLabel = node.getInsideLabel().getText();
+                } else {
+                    initialDirectEditElementLabel = node.getOutsideLabels().stream().filter(label -> Objects.equals(label.id(), labelId)).findFirst().map(OutsideLabel::text).orElse("");
+                }
             } else if (diagramElement instanceof Edge edge) {
                 String descriptionId = edge.getDescriptionId();
                 semanticElement = this.objectService.getObject(editingContext, edge.getTargetObjectId());


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/3301

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?