### PR TITLE
[3313] Avoid sending domain events for no-op updates

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -94,6 +94,7 @@ They still support returning an `java.time.Instant` object directly.
 - https://github.com/eclipse-sirius/sirius-web/issues/3349[#3349] [diagram] Add a default label when creating a NodeDescription
 - https://github.com/eclipse-sirius/sirius-web/issues/3342[#3342] [deck] Update deck and gantt view metamodel and deck view examples
 - https://github.com/eclipse-sirius/sirius-web/issues/3346[#3346] [workbench] Make the _Explorer_ panel wider by default.
+- https://github.com/eclipse-sirius/sirius-web/issues/3313[#3313] [core] Avoid sending events for no-op updates of domain objects
 
 
 == v2024.3.0

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/project/Project.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/project/Project.java
@@ -66,10 +66,12 @@ public class Project extends AbstractValidatingAggregateRoot<Project> implements
     }
 
     public void updateName(String newName) {
-        this.name = newName;
-        this.lastModifiedOn = Instant.now();
+        if (!Objects.equals(this.name, newName)) {
+            this.name = newName;
+            this.lastModifiedOn = Instant.now();
 
-        this.registerEvent(new ProjectNameUpdatedEvent(UUID.randomUUID(), this.lastModifiedOn, this));
+            this.registerEvent(new ProjectNameUpdatedEvent(UUID.randomUUID(), this.lastModifiedOn, this));
+        }
     }
 
     public Set<Nature> getNatures() {

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/representationdata/RepresentationData.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/representationdata/RepresentationData.java
@@ -96,12 +96,14 @@ public class RepresentationData extends AbstractValidatingAggregateRoot<Represen
     }
 
     public void updateContent(String newContent) {
-        this.content = newContent;
+        if (!Objects.equals(this.content, newContent)) {
+            this.content = newContent;
 
-        var now = Instant.now();
-        this.lastModifiedOn = now;
+            var now = Instant.now();
+            this.lastModifiedOn = now;
 
-        this.registerEvent(new RepresentationDataContentUpdatedEvent(UUID.randomUUID(), now, this));
+            this.registerEvent(new RepresentationDataContentUpdatedEvent(UUID.randomUUID(), now, this));
+        }
     }
 
     public void dispose() {
@@ -176,7 +178,7 @@ public class RepresentationData extends AbstractValidatingAggregateRoot<Represen
         public RepresentationData build() {
             var representationData = new RepresentationData();
             representationData.isNew = true;
-            representationData.id = Objects.requireNonNull(id);
+            representationData.id = Objects.requireNonNull(this.id);
             representationData.project = Objects.requireNonNull(this.project);
             representationData.targetObjectId = Objects.requireNonNull(this.targetObjectId);
             representationData.descriptionId = Objects.requireNonNull(this.descriptionId);

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/representations/RepresentationLifecycleControllerIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/representations/RepresentationLifecycleControllerIntegrationTests.java
@@ -142,8 +142,9 @@ public class RepresentationLifecycleControllerIntegrationTests extends AbstractI
             String typename = JsonPath.read(result, "$.data.renameRepresentation.__typename");
             assertThat(typename).isEqualTo(RenameRepresentationSuccessPayload.class.getSimpleName());
 
-            assertThat(this.domainEventCollector.getDomainEvents()).hasSize(2);
-            assertThat(this.domainEventCollector.getDomainEvents()).allMatch(RepresentationDataContentUpdatedEvent.class::isInstance);
+            assertThat(this.domainEventCollector.getDomainEvents()).hasSize(1);
+            var event = this.domainEventCollector.getDomainEvents().get(0);
+            assertThat(event).isInstanceOf(RepresentationDataContentUpdatedEvent.class);
         };
 
         StepVerifier.create(flux)

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/domain/DomainEventsTest.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/domain/DomainEventsTest.java
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.eclipse.sirius.web.AbstractIntegrationTests;
+import org.eclipse.sirius.web.data.TestIdentifiers;
+import org.eclipse.sirius.web.domain.boundedcontexts.project.Project;
+import org.eclipse.sirius.web.domain.boundedcontexts.project.events.ProjectNameUpdatedEvent;
+import org.eclipse.sirius.web.domain.boundedcontexts.project.services.api.IProjectSearchService;
+import org.eclipse.sirius.web.domain.boundedcontexts.project.services.api.IProjectUpdateService;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.events.RepresentationDataContentUpdatedEvent;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.services.api.IRepresentationDataSearchService;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.services.api.IRepresentationDataUpdateService;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.Document;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.SemanticDataDomain;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.events.SemanticDataUpdatedEvent;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api.ISemanticDataSearchService;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api.ISemanticDataUpdateService;
+import org.eclipse.sirius.web.services.api.IDomainEventCollector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Integration tests for domain events publication.
+ *
+ * @author pcdavid
+ */
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class DomainEventsTest extends AbstractIntegrationTests {
+
+    @Autowired
+    private IDomainEventCollector domainEventCollector;
+
+    @Autowired
+    private IProjectSearchService projectSearchService;
+
+    @Autowired
+    private IProjectUpdateService projectUpdateService;
+
+    @Autowired
+    private ISemanticDataSearchService semanticDataSearchService;
+
+    @Autowired
+    private ISemanticDataUpdateService semanticDataUpdateService;
+
+    @Autowired
+    private IRepresentationDataSearchService representationDataSearchService;
+
+    @Autowired
+    private IRepresentationDataUpdateService representationDataUpdateService;
+
+    @BeforeEach
+    public void beforeEach() {
+        this.domainEventCollector.clear();
+    }
+
+    @Test
+    @DisplayName("Given a project, changing its name produces a domain event")
+    @Sql(scripts = {"/scripts/initialize.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenProjectWhenNameModifiedDomainEventPublished() {
+        assertThat(this.domainEventCollector.getDomainEvents()).isEmpty();
+
+        var newProjectName = "renamed project";
+        this.projectUpdateService.renameProject(TestIdentifiers.ECORE_SAMPLE_PROJECT, newProjectName);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        assertThat(this.domainEventCollector.getDomainEvents()).hasSize(1);
+        var event = this.domainEventCollector.getDomainEvents().get(0);
+        assertThat(event instanceof ProjectNameUpdatedEvent projectNameUpdateEvent && projectNameUpdateEvent.project().getName().equals(newProjectName)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Given a project, updating its name with the same value does not produce a domain event")
+    @Sql(scripts = {"/scripts/initialize.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenProjectWhenNameNotModifiedNoDomainEventPublished() {
+        assertThat(this.domainEventCollector.getDomainEvents()).isEmpty();
+
+        var sampleProject = this.projectSearchService.findById(TestIdentifiers.ECORE_SAMPLE_PROJECT).get();
+        this.projectUpdateService.renameProject(TestIdentifiers.ECORE_SAMPLE_PROJECT, sampleProject.getName());
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        assertThat(this.domainEventCollector.getDomainEvents()).isEmpty();
+    }
+
+
+    @Test
+    @DisplayName("Given a document, changing its name produces a domain event")
+    @Sql(scripts = {"/scripts/initialize.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenDocumentWhenNameModifiedDomainEventPublished() {
+        assertThat(this.domainEventCollector.getDomainEvents()).isEmpty();
+        AggregateReference<Project, UUID> projectId = AggregateReference.to(TestIdentifiers.ECORE_SAMPLE_PROJECT);
+
+        var optionalSemanticData = this.semanticDataSearchService.findByProject(projectId);
+        assertThat(optionalSemanticData).isPresent();
+
+        var semanticData = optionalSemanticData.get();
+
+        var optionalDocument = semanticData.getDocuments().stream().filter(doc -> doc.getId().equals(TestIdentifiers.ECORE_SAMPLE_DOCUMENT)).findFirst();
+        assertThat(optionalDocument).isPresent();
+        var originalDocument = optionalDocument.get();
+
+        var newDocumentName = "renamed document";
+        var updatedDocument = Document.newDocument(originalDocument.getId()).name(newDocumentName).content(originalDocument.getContent()).build();
+        this.semanticDataUpdateService.updateDocuments(projectId, Set.of(updatedDocument), semanticData.getDomains().stream().map(SemanticDataDomain::uri).collect(Collectors.toSet()));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        assertThat(this.domainEventCollector.getDomainEvents()).hasSize(1);
+        var event = this.domainEventCollector.getDomainEvents().get(0);
+        assertThat(event instanceof SemanticDataUpdatedEvent semanticDataUpdateEvent && semanticDataUpdateEvent.semanticData().getDocuments().iterator().next().getName().equals(newDocumentName)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Given a document, updating its name and content with the same value does not produce a domain event")
+    @Sql(scripts = {"/scripts/initialize.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenDocumentWhenNameAndContentNotModifiedNoDomainEventPublished() {
+        assertThat(this.domainEventCollector.getDomainEvents()).isEmpty();
+        AggregateReference<Project, UUID> projectId = AggregateReference.to(TestIdentifiers.ECORE_SAMPLE_PROJECT);
+
+        var optionalSemanticData = this.semanticDataSearchService.findByProject(projectId);
+        assertThat(optionalSemanticData).isPresent();
+
+        var semanticData = optionalSemanticData.get();
+
+        var optionalDocument = semanticData.getDocuments().stream().filter(doc -> doc.getId().equals(TestIdentifiers.ECORE_SAMPLE_DOCUMENT)).findFirst();
+        assertThat(optionalDocument).isPresent();
+        var originalDocument = optionalDocument.get();
+
+        var newDocumentName = originalDocument.getName();
+        // Identical to the original except for the timestamps
+        var updatedDocument = Document.newDocument(originalDocument.getId()).name(newDocumentName).content(originalDocument.getContent()).build();
+        this.semanticDataUpdateService.updateDocuments(projectId, Set.of(updatedDocument), semanticData.getDomains().stream().map(SemanticDataDomain::uri).collect(Collectors.toSet()));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        assertThat(this.domainEventCollector.getDomainEvents()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Given a document, updating its content with a diffrent value produces a domain event")
+    @Sql(scripts = {"/scripts/initialize.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenDocumentWhenContentModifiedDomainEventPublished() {
+        assertThat(this.domainEventCollector.getDomainEvents()).isEmpty();
+        AggregateReference<Project, UUID> projectId = AggregateReference.to(TestIdentifiers.ECORE_SAMPLE_PROJECT);
+
+        var optionalSemanticData = this.semanticDataSearchService.findByProject(projectId);
+        assertThat(optionalSemanticData).isPresent();
+
+        var semanticData = optionalSemanticData.get();
+
+        var optionalDocument = semanticData.getDocuments().stream().filter(doc -> doc.getId().equals(TestIdentifiers.ECORE_SAMPLE_DOCUMENT)).findFirst();
+        assertThat(optionalDocument).isPresent();
+        var originalDocument = optionalDocument.get();
+
+        var originalContent = originalDocument.getContent();
+        var newContent = originalContent + "modified";
+        var updatedDocument = Document.newDocument(originalDocument.getId()).name(originalDocument.getName()).content(newContent).build();
+        this.semanticDataUpdateService.updateDocuments(projectId, Set.of(updatedDocument), semanticData.getDomains().stream().map(SemanticDataDomain::uri).collect(Collectors.toSet()));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        assertThat(this.domainEventCollector.getDomainEvents()).hasSize(1);
+        var event = this.domainEventCollector.getDomainEvents().get(0);
+        assertThat(event instanceof SemanticDataUpdatedEvent semanticDataUpdateEvent && semanticDataUpdateEvent.semanticData().getDocuments().iterator().next().getContent().equals(newContent)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Given a representations, updating its content with a different value produces a domain event")
+    @Sql(scripts = {"/scripts/initialize.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenRepresentationWhenContentModifiedDomainEventPublished() {
+        assertThat(this.domainEventCollector.getDomainEvents()).isEmpty();
+        var optionalRepresentationData = this.representationDataSearchService.findById(TestIdentifiers.EPACKAGE_PORTAL_REPRESENTATION);
+        assertThat(optionalRepresentationData).isPresent();
+
+        var representationData = optionalRepresentationData.get();
+
+        var originalContent = representationData.getContent();
+        var newContent = originalContent + "modified";
+        this.representationDataUpdateService.updateContent(representationData.getId(), newContent);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        assertThat(this.domainEventCollector.getDomainEvents()).hasSize(1);
+        var event = this.domainEventCollector.getDomainEvents().get(0);
+        assertThat(event instanceof RepresentationDataContentUpdatedEvent represnetationDataContentUpdateEvent && represnetationDataContentUpdateEvent.representationData().getContent().equals(newContent)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Given a representations, updating its content with the same value does not produce a domain event")
+    @Sql(scripts = {"/scripts/initialize.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenRepresentationWhenContentNotModifiedNoDomainEventPublished() {
+        assertThat(this.domainEventCollector.getDomainEvents()).isEmpty();
+        var optionalRepresentationData = this.representationDataSearchService.findById(TestIdentifiers.EPACKAGE_PORTAL_REPRESENTATION);
+        assertThat(optionalRepresentationData).isPresent();
+
+        var representationData = optionalRepresentationData.get();
+
+        var newContent = representationData.getContent();
+        this.representationDataUpdateService.updateContent(representationData.getId(), newContent);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        assertThat(this.domainEventCollector.getDomainEvents()).isEmpty();
+    }
+
+}


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/3313
