### PR TITLE
[3372] Add hide, reveal, fade, unfade diagram element services

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -88,6 +88,7 @@ image:doc/screenshots/inside_outside_labels.png[Isinde outside label example, 70
 - https://github.com/eclipse-sirius/sirius-web/issues/3277[#3277] [gantt] Add support for dependency creation
 - https://github.com/eclipse-sirius/sirius-web/issues/3371[#3371] [view] Add new expressions in `NodeDescription` to specify whether a node is hidden/faded/normal by default.
 - https://github.com/eclipse-sirius/sirius-web/issues/3371[#3371] [diagram] Add new predicates in `NodeDescription` to specify whether a node is hidden/faded/normal by default.
+- https://github.com/eclipse-sirius/sirius-web/issues/3372[#3372] [diagram] Add services in `DiagramServices` to hide, reveal, fade, and unfade nodes from AQL expressions and Java services.
 
 
 === Improvements

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramServices.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramServices.java
@@ -13,11 +13,15 @@
 package org.eclipse.sirius.components.collaborative.diagrams;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramServices;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramService;
+import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramServices;
 import org.eclipse.sirius.components.diagrams.CollapsingState;
 import org.eclipse.sirius.components.diagrams.Node;
+import org.eclipse.sirius.components.diagrams.events.FadeDiagramElementEvent;
+import org.eclipse.sirius.components.diagrams.events.HideDiagramElementEvent;
 import org.eclipse.sirius.components.diagrams.events.UpdateCollapsingStateEvent;
 import org.springframework.stereotype.Service;
 
@@ -45,4 +49,31 @@ public class DiagramServices implements IDiagramServices {
         return nodes;
     }
 
+    @Override
+    public Object hide(IDiagramService diagramService, List<Node> nodes) {
+        Set<String> nodeIds = nodes.stream().map(Node::getId).collect(Collectors.toSet());
+        diagramService.getDiagramContext().getDiagramEvents().add(new HideDiagramElementEvent(nodeIds, true));
+        return nodes;
+    }
+
+    @Override
+    public Object reveal(IDiagramService diagramService, List<Node> nodes) {
+        Set<String> nodeIds = nodes.stream().map(Node::getId).collect(Collectors.toSet());
+        diagramService.getDiagramContext().getDiagramEvents().add(new HideDiagramElementEvent(nodeIds, false));
+        return nodes;
+    }
+
+    @Override
+    public Object fade(IDiagramService diagramService, List<Node> nodes) {
+        Set<String> nodeIds = nodes.stream().map(Node::getId).collect(Collectors.toSet());
+        diagramService.getDiagramContext().getDiagramEvents().add(new FadeDiagramElementEvent(nodeIds, true));
+        return nodes;
+    }
+
+    @Override
+    public Object unfade(IDiagramService diagramService, List<Node> nodes) {
+        Set<String> nodeIds = nodes.stream().map(Node::getId).collect(Collectors.toSet());
+        diagramService.getDiagramContext().getDiagramEvents().add(new FadeDiagramElementEvent(nodeIds, false));
+        return nodes;
+    }
 }

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/api/IDiagramServices.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/api/IDiagramServices.java
@@ -23,8 +23,16 @@ import org.eclipse.sirius.components.diagrams.Node;
  */
 public interface IDiagramServices {
 
-    Object collapse(IDiagramService diagramService, List<Node> node);
+    Object collapse(IDiagramService diagramService, List<Node> nodes);
 
-    Object expand(IDiagramService diagramService, List<Node> node);
+    Object expand(IDiagramService diagramService, List<Node> nodes);
+
+    Object hide(IDiagramService diagramService, List<Node> nodes);
+
+    Object reveal(IDiagramService diagramService, List<Node> nodes);
+
+    Object fade(IDiagramService diagramService, List<Node> nodes);
+
+    Object unfade(IDiagramService diagramService, List<Node> nodes);
 
 }

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/diagrams/VisibilityDiagramControllerTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/diagrams/VisibilityDiagramControllerTests.java
@@ -16,15 +16,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.sirius.components.diagrams.tests.assertions.DiagramAssertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.jayway.jsonpath.JsonPath;
+
 import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import org.eclipse.sirius.components.collaborative.diagrams.dto.DiagramRefreshedEventPayload;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.InvokeSingleClickOnDiagramElementToolInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.InvokeSingleClickOnDiagramElementToolSuccessPayload;
 import org.eclipse.sirius.components.collaborative.dto.CreateRepresentationInput;
+import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.ViewModifier;
+import org.eclipse.sirius.components.diagrams.tests.graphql.InvokeSingleClickOnDiagramElementToolMutationRunner;
 import org.eclipse.sirius.components.diagrams.tests.navigation.DiagramNavigator;
 import org.eclipse.sirius.web.AbstractIntegrationTests;
 import org.eclipse.sirius.web.data.PapayaIdentifiers;
@@ -58,6 +66,9 @@ public class VisibilityDiagramControllerTests extends AbstractIntegrationTests {
 
     @Autowired
     private IGivenCreatedDiagramSubscription givenCreatedDiagramSubscription;
+
+    @Autowired
+    private InvokeSingleClickOnDiagramElementToolMutationRunner invokeSingleClickOnDiagramElementToolMutationRunner;
 
     @Autowired
     private VisibilityDiagramDescriptionProvider visibilityDiagramDescriptionProvider;
@@ -109,6 +120,193 @@ public class VisibilityDiagramControllerTests extends AbstractIntegrationTests {
 
         StepVerifier.create(flux)
             .consumeNextWith(initialDiagramContentConsumer)
+            .thenCancel()
+            .verify(Duration.ofSeconds(10));
+    }
+
+    @Test
+    @DisplayName("Given a diagram with hidden nodes by default, when a tool revealing nodes is invoked, then hidden nodes are revealed")
+    @Sql(scripts = {"/scripts/papaya.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenDiagramWithHiddenNodesByDefaultWhenToolRevealingNodesIsInvokedThenHiddenNodesAreRevealed() {
+        var flux = this.givenSubscriptionToVisibilityDiagram();
+
+        var diagramId = new AtomicReference<String>();
+        var hiddenNodeId = new AtomicReference<String>();
+
+        Consumer<DiagramRefreshedEventPayload> initialDiagramContentConsumer = payload -> Optional.of(payload)
+                .map(DiagramRefreshedEventPayload::diagram)
+                .ifPresentOrElse(diagram -> {
+                    diagramId.set(diagram.getId());
+                    var siriusWebDomainNode = new DiagramNavigator(diagram).nodeWithLabel("sirius-web-domain").getNode();
+                    assertThat(siriusWebDomainNode).hasModifiers(Set.of(ViewModifier.Hidden));
+                    hiddenNodeId.set(siriusWebDomainNode.getId());
+                }, () -> fail("Missing diagram"));
+
+        Runnable revealNodes = () -> {
+            String revealNodeToolId = this.visibilityDiagramDescriptionProvider.getRevealNodeToolId();
+            var input = new InvokeSingleClickOnDiagramElementToolInput(UUID.randomUUID(), PapayaIdentifiers.PAPAYA_PROJECT.toString(), diagramId.get(), hiddenNodeId.get(), revealNodeToolId, 0, 0, null);
+            var result = this.invokeSingleClickOnDiagramElementToolMutationRunner.run(input);
+
+            String typename = JsonPath.read(result, "$.data.invokeSingleClickOnDiagramElementTool.__typename");
+            assertThat(typename).isEqualTo(InvokeSingleClickOnDiagramElementToolSuccessPayload.class.getSimpleName());
+        };
+
+        Consumer<DiagramRefreshedEventPayload> updatedDiagramContentConsumer = payload -> Optional.of(payload)
+                .map(DiagramRefreshedEventPayload::diagram)
+                .ifPresentOrElse(diagram -> {
+                    var siriusWebDomainNode = new DiagramNavigator(diagram).nodeWithLabel("sirius-web-domain").getNode();
+                    assertThat(siriusWebDomainNode).hasModifiers(Set.of());
+                }, () -> fail("Missing diagram"));
+
+        StepVerifier.create(flux)
+            .consumeNextWith(initialDiagramContentConsumer)
+            .then(revealNodes)
+            .consumeNextWith(updatedDiagramContentConsumer)
+            .thenCancel()
+            .verify(Duration.ofSeconds(10));
+    }
+
+    @Test
+    @DisplayName("Given a diagram with hidden nodes by default, when a tool hidding nodes is invoked, then revealed nodes are hidden")
+    @Sql(scripts = {"/scripts/papaya.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenDiagramWithHiddenNodesByDefaultWhenToolHiddingNodesIsInvokedThenRevealedNodesAreHidden() {
+        var flux = this.givenSubscriptionToVisibilityDiagram();
+
+        var diagramId = new AtomicReference<String>();
+        var revealedNodeId = new AtomicReference<String>();
+
+        Consumer<DiagramRefreshedEventPayload> initialDiagramContentConsumer = payload -> Optional.of(payload)
+                .map(DiagramRefreshedEventPayload::diagram)
+                .ifPresentOrElse(diagram -> {
+                    diagramId.set(diagram.getId());
+
+                    diagram.getNodes().stream()
+                        .filter(node -> node.getModifiers().isEmpty())
+                        .map(Node::getId)
+                        .findFirst()
+                        .ifPresent(revealedNodeId::set);
+                }, () -> fail("Missing diagram"));
+
+        Runnable hideNodes = () -> {
+            String hideNodeToolId = this.visibilityDiagramDescriptionProvider.getHideNodeToolId();
+            var input = new InvokeSingleClickOnDiagramElementToolInput(UUID.randomUUID(), PapayaIdentifiers.PAPAYA_PROJECT.toString(), diagramId.get(), revealedNodeId.get(), hideNodeToolId, 0, 0, null);
+            var invokeSingleClickOnDiagramElementToolResult = this.invokeSingleClickOnDiagramElementToolMutationRunner.run(input);
+
+            String invokeSingleClickOnDiagramElementToolResultTypename = JsonPath.read(invokeSingleClickOnDiagramElementToolResult, "$.data.invokeSingleClickOnDiagramElementTool.__typename");
+            assertThat(invokeSingleClickOnDiagramElementToolResultTypename).isEqualTo(InvokeSingleClickOnDiagramElementToolSuccessPayload.class.getSimpleName());
+        };
+
+        Predicate<DiagramRefreshedEventPayload> updatedDiagramContentMatcher = payload -> Optional.of(payload)
+                .map(DiagramRefreshedEventPayload::diagram)
+                .filter(diagram -> {
+                    return diagram.getNodes().stream()
+                            .filter(node -> node.getId().equals(revealedNodeId.get()))
+                            .map(node -> node.getModifiers().contains(ViewModifier.Hidden))
+                            .findFirst()
+                            .orElse(false);
+                })
+                .isPresent();
+
+        StepVerifier.create(flux)
+            .consumeNextWith(initialDiagramContentConsumer)
+            .then(hideNodes)
+            .expectNextMatches(updatedDiagramContentMatcher)
+            .thenCancel()
+            .verify(Duration.ofSeconds(10));
+    }
+
+    @Test
+    @DisplayName("Given a diagram with faded nodes by default, when a tool fading nodes is invoked, then not faded nodes are faded")
+    @Sql(scripts = {"/scripts/papaya.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenDiagramWithFadedNodesByDefaultWhenToolFadingNodesIsInvokedThenNotFadedNodesAreFaded() {
+        var flux = this.givenSubscriptionToVisibilityDiagram();
+
+        var diagramId = new AtomicReference<String>();
+        var unfadedNodeId = new AtomicReference<String>();
+
+        Consumer<DiagramRefreshedEventPayload> initialDiagramContentConsumer = payload -> Optional.of(payload)
+                .map(DiagramRefreshedEventPayload::diagram)
+                .ifPresentOrElse(diagram -> {
+                    diagramId.set(diagram.getId());
+
+                    diagram.getNodes().stream()
+                        .filter(node -> node.getModifiers().isEmpty())
+                        .map(Node::getId)
+                        .findFirst()
+                        .ifPresent(unfadedNodeId::set);
+                }, () -> fail("Missing diagram"));
+
+        Runnable fadeNodes = () -> {
+            String fadeNodeToolId = this.visibilityDiagramDescriptionProvider.getFadeNodeToolId();
+            var input = new InvokeSingleClickOnDiagramElementToolInput(UUID.randomUUID(), PapayaIdentifiers.PAPAYA_PROJECT.toString(), diagramId.get(), unfadedNodeId.get(), fadeNodeToolId, 0, 0, null);
+            var invokeSingleClickOnDiagramElementToolResult = this.invokeSingleClickOnDiagramElementToolMutationRunner.run(input);
+
+            String invokeSingleClickOnDiagramElementToolResultTypename = JsonPath.read(invokeSingleClickOnDiagramElementToolResult, "$.data.invokeSingleClickOnDiagramElementTool.__typename");
+            assertThat(invokeSingleClickOnDiagramElementToolResultTypename).isEqualTo(InvokeSingleClickOnDiagramElementToolSuccessPayload.class.getSimpleName());
+        };
+
+        Predicate<DiagramRefreshedEventPayload> updatedDiagramContentMatcher = payload -> Optional.of(payload)
+                .map(DiagramRefreshedEventPayload::diagram)
+                .filter(diagram -> {
+                    return diagram.getNodes().stream()
+                            .filter(node -> node.getId().equals(unfadedNodeId.get()))
+                            .map(node -> node.getModifiers().contains(ViewModifier.Faded))
+                            .findFirst()
+                            .orElse(false);
+                })
+                .isPresent();
+
+        StepVerifier.create(flux)
+            .consumeNextWith(initialDiagramContentConsumer)
+            .then(fadeNodes)
+            .expectNextMatches(updatedDiagramContentMatcher)
+            .thenCancel()
+            .verify(Duration.ofSeconds(10));
+    }
+
+    @Test
+    @DisplayName("Given a diagram with faded nodes by default, when a tool unfading nodes is invoked, then faded nodes are unfaded")
+    @Sql(scripts = {"/scripts/papaya.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = {"/scripts/cleanup.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenDiagramWithFadedNodesByDefaultWhenToolUnFadingNodesIsInvokedThenFadedNodesAreUnFaded() {
+        var flux = this.givenSubscriptionToVisibilityDiagram();
+
+        var diagramId = new AtomicReference<String>();
+        var fadedNodeId = new AtomicReference<String>();
+
+        Consumer<DiagramRefreshedEventPayload> initialDiagramContentConsumer = payload -> Optional.of(payload)
+                .map(DiagramRefreshedEventPayload::diagram)
+                .ifPresentOrElse(diagram -> {
+                    diagramId.set(diagram.getId());
+
+                    var siriusWebApplicationNode = new DiagramNavigator(diagram).nodeWithLabel("sirius-web-application").getNode();
+                    assertThat(siriusWebApplicationNode).hasModifiers(Set.of(ViewModifier.Faded));
+                    fadedNodeId.set(siriusWebApplicationNode.getId());
+                }, () -> fail("Missing diagram"));
+
+        Runnable unfadeNodes = () -> {
+            String unfadeNodeToolId = this.visibilityDiagramDescriptionProvider.getUnfadeNodeToolId();
+            var input = new InvokeSingleClickOnDiagramElementToolInput(UUID.randomUUID(), PapayaIdentifiers.PAPAYA_PROJECT.toString(), diagramId.get(), fadedNodeId.get(), unfadeNodeToolId, 0, 0, null);
+            var result = this.invokeSingleClickOnDiagramElementToolMutationRunner.run(input);
+
+            String typename = JsonPath.read(result, "$.data.invokeSingleClickOnDiagramElementTool.__typename");
+            assertThat(typename).isEqualTo(InvokeSingleClickOnDiagramElementToolSuccessPayload.class.getSimpleName());
+        };
+
+        Consumer<DiagramRefreshedEventPayload> updatedDiagramContentConsumer = payload -> Optional.of(payload)
+                .map(DiagramRefreshedEventPayload::diagram)
+                .ifPresentOrElse(diagram -> {
+                    var siriusWebApplicationNode = new DiagramNavigator(diagram).nodeWithLabel("sirius-web-application").getNode();
+                    assertThat(siriusWebApplicationNode).hasModifiers(Set.of());
+                }, () -> fail("Missing diagram"));
+
+        StepVerifier.create(flux)
+            .consumeNextWith(initialDiagramContentConsumer)
+            .then(unfadeNodes)
+            .consumeNextWith(updatedDiagramContentConsumer)
             .thenCancel()
             .verify(Duration.ofSeconds(10));
     }

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/diagrams/VisibilityDiagramDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/diagrams/VisibilityDiagramDescriptionProvider.java
@@ -22,14 +22,18 @@ import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.IDAdapter;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
 import org.eclipse.sirius.components.view.View;
+import org.eclipse.sirius.components.view.builder.generated.ChangeContextBuilder;
 import org.eclipse.sirius.components.view.builder.generated.DiagramDescriptionBuilder;
 import org.eclipse.sirius.components.view.builder.generated.InsideLabelDescriptionBuilder;
 import org.eclipse.sirius.components.view.builder.generated.NodeDescriptionBuilder;
+import org.eclipse.sirius.components.view.builder.generated.NodePaletteBuilder;
+import org.eclipse.sirius.components.view.builder.generated.NodeToolBuilder;
 import org.eclipse.sirius.components.view.builder.generated.RectangularNodeStyleDescriptionBuilder;
 import org.eclipse.sirius.components.view.builder.generated.ViewBuilder;
 import org.eclipse.sirius.components.view.diagram.DiagramDescription;
 import org.eclipse.sirius.components.view.diagram.DiagramFactory;
 import org.eclipse.sirius.components.view.diagram.InsideLabelPosition;
+import org.eclipse.sirius.components.view.diagram.NodeTool;
 import org.eclipse.sirius.components.view.emf.diagram.IDiagramIdProvider;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
 import org.eclipse.sirius.web.application.editingcontext.EditingContext;
@@ -52,6 +56,14 @@ public class VisibilityDiagramDescriptionProvider implements IEditingContextProc
 
     private DiagramDescription diagramDescription;
 
+    private NodeTool hideNodeTool;
+
+    private NodeTool revealNodeTool;
+
+    private NodeTool fadeNodeTool;
+
+    private NodeTool unfadeNodeTool;
+
     public VisibilityDiagramDescriptionProvider(IDiagramIdProvider diagramIdProvider) {
         this.diagramIdProvider = Objects.requireNonNull(diagramIdProvider);
         this.view = this.createView();
@@ -66,6 +78,22 @@ public class VisibilityDiagramDescriptionProvider implements IEditingContextProc
 
     public String getRepresentationDescriptionId() {
         return this.diagramIdProvider.getId(this.diagramDescription);
+    }
+
+    public String getHideNodeToolId() {
+        return UUID.nameUUIDFromBytes(EcoreUtil.getURI(this.hideNodeTool).toString().getBytes()).toString();
+    }
+
+    public String getRevealNodeToolId() {
+        return UUID.nameUUIDFromBytes(EcoreUtil.getURI(this.revealNodeTool).toString().getBytes()).toString();
+    }
+
+    public String getFadeNodeToolId() {
+        return UUID.nameUUIDFromBytes(EcoreUtil.getURI(this.fadeNodeTool).toString().getBytes()).toString();
+    }
+
+    public String getUnfadeNodeToolId() {
+        return UUID.nameUUIDFromBytes(EcoreUtil.getURI(this.unfadeNodeTool).toString().getBytes()).toString();
     }
 
     private View createView() {
@@ -94,6 +122,48 @@ public class VisibilityDiagramDescriptionProvider implements IEditingContextProc
                 .position(InsideLabelPosition.TOP_CENTER)
                 .build();
 
+        this.hideNodeTool = new NodeToolBuilder()
+                .name("Hide")
+                .body(
+                        new ChangeContextBuilder()
+                            .expression("aql:diagramServices.hide(Sequence{ selectedNode })")
+                            .build()
+                )
+                .build();
+
+        this.revealNodeTool = new NodeToolBuilder()
+                .name("Reveal")
+                .body(
+                        new ChangeContextBuilder()
+                            .expression("aql:diagramServices.reveal(Sequence{ selectedNode })")
+                            .build()
+                )
+                .build();
+
+        this.fadeNodeTool = new NodeToolBuilder()
+                .name("Fade")
+                .body(
+                        new ChangeContextBuilder()
+                            .expression("aql:diagramServices.fade(Sequence{ selectedNode })")
+                            .build()
+                )
+                .build();
+
+        this.unfadeNodeTool = new NodeToolBuilder()
+                .name("Unfade")
+                .body(
+                        new ChangeContextBuilder()
+                            .expression("aql:diagramServices.unfade(Sequence{ selectedNode })")
+                            .build()
+                )
+                .build();
+
+
+
+        var nodePalette = new NodePaletteBuilder()
+                .nodeTools(this.hideNodeTool, this.revealNodeTool, this.fadeNodeTool, this.unfadeNodeTool)
+                .build();
+
         var nodeDescription = new NodeDescriptionBuilder()
                 .name("Component")
                 .domainType("papaya_logical_architecture:Component")
@@ -102,6 +172,7 @@ public class VisibilityDiagramDescriptionProvider implements IEditingContextProc
                 .style(nodeStyle)
                 .isHiddenByDefaultExpression("aql:self.name.endsWith('-domain')")
                 .isFadedByDefaultExpression("aql:self.name.endsWith('-application')")
+                .palette(nodePalette)
                 .build();
 
         this.diagramDescription = new DiagramDescriptionBuilder()

--- a/scripts/check-coverage.jsh
+++ b/scripts/check-coverage.jsh
@@ -39,7 +39,7 @@ var moduleCoverageData = List.of(
   new ModuleCoverage("sirius-components-charts", 52.0),
   new ModuleCoverage("sirius-components-collaborative-charts", 23.0),
   new ModuleCoverage("sirius-components-diagrams", 77.0),
-  new ModuleCoverage("sirius-components-collaborative-diagrams", 66.0),
+  new ModuleCoverage("sirius-components-collaborative-diagrams", 67.0),
   new ModuleCoverage("sirius-components-diagrams-graphql", 29.0),
   new ModuleCoverage("sirius-components-gantt", 86.0),
   new ModuleCoverage("sirius-components-collaborative-gantt", 36.0),


### PR DESCRIPTION
# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
Open a studio and create a tool that uses `diagramServices.hide`, `diagramServices.reveal`, `diagramServices.fade`, or `diagramServices.unfade`.
When the tool is used on a diagram, the expected elements are hidden, revealed, faded, or unfaded.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?