### PR TITLE
[3443] Prevent outside label to be truncated

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -89,6 +89,7 @@ Accordingly, `IObjectSearchService` and `IIdentityService` now handle actual `IE
 - https://github.com/eclipse-sirius/sirius-web/issues/3422[#3422] [diagram] Fix an issue that prevents element not present on diagram to be selected on first click.
 - https://github.com/eclipse-sirius/sirius-web/issues/3407[#3407] [diagram] Fix performance issue during node drag.
 - https://github.com/eclipse-sirius/sirius-web/issues/3424[#3424] [emf] Fix wrong document migration data when creating a document.
+- https://github.com/eclipse-sirius/sirius-web/issues/3443[#3443] [diagram] Prevent outside label to be truncated.
 
 === New Features
 

--- a/integration-tests/cypress/e2e/project/diagrams/diagram-label.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/diagram-label.cy.ts
@@ -323,4 +323,83 @@ describe('Diagram - inside outside labels', () => {
       });
     });
   });
+
+  context('Given a view with outside label on rectangular node with none strategy', () => {
+    let studioProjectId: string = '';
+    let domainName: string = '';
+
+    before(() => {
+      cy.createProjectFromTemplate('studio-template').then((res) => {
+        const payload = res.body.data.createProjectFromTemplate;
+        if (isCreateProjectFromTemplateSuccessPayload(payload)) {
+          const projectId = payload.project.id;
+          studioProjectId = projectId;
+
+          const project = new Project();
+          project.visit(projectId);
+          project.disableDeletionConfirmationDialog();
+
+          const explorer = new Explorer();
+          explorer.getTreeItemByLabel('DomainNewModel').dblclick();
+          cy.get('[title="domain::Domain"]').then(($div) => {
+            domainName = $div.data().testid;
+            explorer.expand('ViewNewModel');
+            explorer.expand('View');
+            explorer.expand(`${domainName} Diagram Description`);
+            explorer.expand('Entity1 Node');
+            explorer.delete('aql:self.name');
+            explorer.createObject('Entity1 Node', 'Outside Label Description');
+          });
+        }
+      });
+    });
+
+    after(() => cy.deleteProject(studioProjectId));
+    context('When we create a new instance project', () => {
+      let instanceProjectId: string = '';
+
+      beforeEach(() => {
+        const studio = new Studio();
+        studio.createProjectFromDomain('Cypress - Studio Instance', domainName, 'Root').then((res) => {
+          instanceProjectId = res.projectId;
+
+          new Explorer().createRepresentation('Root', `${domainName} Diagram Description`, 'diagram');
+        });
+      });
+
+      afterEach(() => cy.deleteProject(instanceProjectId));
+
+      it('Then the outside label is not truncated', () => {
+        const explorer = new Explorer();
+        const diagram = new Diagram();
+        const details = new Details();
+        explorer.createObject('Root', 'Entity1s Entity1');
+        details.getTextField('Name').type('small{enter}');
+        diagram.fitToScreen();
+        let initialWidth: number;
+        let initialHeight: number;
+        diagram.getDiagramScale('diagram').then((scale) => {
+          diagram.getNodeCssValue('diagram', 'small', 'width').then((nodeWidth) => {
+            initialWidth = nodeWidth / scale;
+          });
+          diagram.getNodeCssValue('diagram', 'small', 'height').then((nodeHeight) => {
+            initialHeight = nodeHeight / scale;
+          });
+        });
+        details.getTextField('Name').type('{selectAll}very large label without wrap{enter}');
+        diagram.getDiagramScale('diagram').then((scale) => {
+          diagram.getNodeCssValue('diagram', 'very large label without wrap', 'width').then((nodeWidth) => {
+            expect(nodeWidth / scale).to.approximately(initialWidth, 2);
+          });
+          diagram.getNodeCssValue('diagram', 'very large label without wrap', 'height').then((nodeHeight) => {
+            expect(nodeHeight / scale).to.approximately(initialHeight, 2);
+          });
+        });
+        diagram.getLabel('very large label without wrap').should('exist');
+        details.getTextField('Name').type('{selectAll}very large label {shift}{enter}with wrap');
+        details.getTextField('Name').type('{enter}');
+        diagram.getLabel('very large label \nwith wrap').should('exist');
+      });
+    });
+  });
 });

--- a/integration-tests/cypress/workbench/Diagram.ts
+++ b/integration-tests/cypress/workbench/Diagram.ts
@@ -42,6 +42,7 @@ export class Diagram {
   public getGroupPalette(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.getByTestId('GroupPalette');
   }
+
   public getDiagramScale(diagramLabel: string): Cypress.Chainable<number> {
     return this.getDiagram(diagramLabel)
       .find('.react-flow__viewport')
@@ -134,7 +135,7 @@ export class Diagram {
 
     for (let i = 0; i < pathValues.length; i++) {
       const pathValue = pathValues[i];
-      if(pathValue) {
+      if (pathValue) {
         if (pathValue.match(/[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?/g)) {
           roundedPathValues.push(parseFloat(pathValue).toFixed(2));
         } else {
@@ -148,5 +149,9 @@ export class Diagram {
       roundedPathData += roundedPathValues[i];
     }
     return roundedPathData;
+  }
+
+  public getLabel(labelId: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.getByTestId(`Label - ${labelId}`);
   }
 }

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/Label.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/Label.tsx
@@ -19,10 +19,14 @@ import { DiagramContextValue } from '../contexts/DiagramContext.types';
 import { DiagramDirectEditInput } from './direct-edit/DiagramDirectEditInput';
 import { useDiagramDirectEdit } from './direct-edit/useDiagramDirectEdit';
 import { LabelProps } from './Label.types';
-import { EdgeLabel, InsideLabel, OutsideLabel } from './DiagramRenderer.types';
+import { EdgeLabel, InsideLabel, LabelOverflowStrategy, OutsideLabel } from './DiagramRenderer.types';
 
-const isInsideLabel = (label: EdgeLabel | InsideLabel | OutsideLabel): label is InsideLabel =>
-  (label as InsideLabel).overflowStrategy !== undefined;
+const getOverflowStrategy = (label: EdgeLabel | InsideLabel | OutsideLabel): LabelOverflowStrategy | undefined => {
+  if ('overflowStrategy' in label) {
+    return label.overflowStrategy;
+  }
+  return undefined;
+};
 
 const labelStyle = (
   theme: Theme,
@@ -49,29 +53,35 @@ const labelContentStyle = (label: EdgeLabel | InsideLabel | OutsideLabel): React
     display: 'flex',
     alignItems: 'center',
   };
-  if (isInsideLabel(label)) {
-    labelContentStyle.overflow = 'hidden';
+  switch (getOverflowStrategy(label)) {
+    case 'WRAP':
+    case 'ELLIPSIS':
+      labelContentStyle.overflow = 'hidden';
+      break;
+    case 'NONE':
+      labelContentStyle.whiteSpace = 'pre';
+      break;
+    default:
+      break;
   }
   return labelContentStyle;
 };
 
 const labelOverflowStyle = (label: EdgeLabel | InsideLabel | OutsideLabel): React.CSSProperties => {
   const style: React.CSSProperties = {};
-  if (isInsideLabel(label)) {
-    switch (label.overflowStrategy) {
-      case 'WRAP':
-        style.overflow = 'hidden';
-        style.overflowWrap = 'break-word';
-        break;
-      case 'ELLIPSIS':
-        style.whiteSpace = 'nowrap';
-        style.overflow = 'hidden';
-        style.textOverflow = 'ellipsis';
-        break;
-      case 'NONE':
-      default:
-        break;
-    }
+  switch (getOverflowStrategy(label)) {
+    case 'WRAP':
+      style.overflow = 'hidden';
+      style.overflowWrap = 'break-word';
+      break;
+    case 'ELLIPSIS':
+      style.whiteSpace = 'nowrap';
+      style.overflow = 'hidden';
+      style.textOverflow = 'ellipsis';
+      break;
+    case 'NONE':
+    default:
+      break;
   }
   return style;
 };


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/3443

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?