### PR TITLE
[releng] Typecheck all frontend code (incl. tests)

### DIFF
--- a/packages/charts/frontend/sirius-components-charts/tsconfig.json
+++ b/packages/charts/frontend/sirius-components-charts/tsconfig.json
@@ -5,6 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": ["./src/index.ts"],
+  "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/core/frontend/sirius-components-core/tsconfig.json
+++ b/packages/core/frontend/sirius-components-core/tsconfig.json
@@ -5,6 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": ["./src/index.ts"],
+  "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/deck/frontend/sirius-components-deck/tsconfig.json
+++ b/packages/deck/frontend/sirius-components-deck/tsconfig.json
@@ -5,12 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": [
-    "./src/index.ts"
-  ],
-  "exclude": [
-    "dist",
-    "build",
-    "node_modules"
-  ]
+  "include": ["./src"],
+  "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/diagrams/frontend/sirius-components-diagrams/tsconfig.json
+++ b/packages/diagrams/frontend/sirius-components-diagrams/tsconfig.json
@@ -5,6 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": ["./src/index.ts"],
+  "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/__tests__/Group.test.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/__tests__/Group.test.tsx
@@ -14,7 +14,6 @@ import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { ConfirmationDialogContext, Selection, SelectionContext } from '@eclipse-sirius/sirius-components-core';
 import { GQLContainerBorderStyle, GQLGroup, GQLPage } from '@eclipse-sirius/sirius-components-forms';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { afterEach, expect, test, vi } from 'vitest';
 import { addGroupMutation, deleteGroupMutation, moveGroupMutation } from '../FormDescriptionEditorEventFragment';
 import {

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/__tests__/Page.test.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/__tests__/Page.test.tsx
@@ -16,7 +16,6 @@ import { GQLPage } from '@eclipse-sirius/sirius-components-forms';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, expect, test, vi } from 'vitest';
 
-import React from 'react';
 import { addPageMutation, deletePageMutation, movePageMutation } from '../FormDescriptionEditorEventFragment';
 import {
   GQLAddPageMutationData,

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/__tests__/ToolbarActions.test.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/__tests__/ToolbarActions.test.tsx
@@ -14,7 +14,6 @@ import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { Selection, SelectionContext } from '@eclipse-sirius/sirius-components-core';
 import { GQLGroup, GQLPage, GQLToolbarAction } from '@eclipse-sirius/sirius-components-forms';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { afterEach, expect, test, vi } from 'vitest';
 import {
   addToolbarActionMutation,
@@ -141,6 +140,8 @@ test('add ToolbarAction by clicking on the Add Toolbar Action button', async () 
     __typename: 'ToolbarAction',
     diagnostics: [],
     buttonLabel: 'ToolbarAction1',
+    hasHelpText: false,
+    readOnly: false,
     imageURL: null,
     style: {
       backgroundColor: null,
@@ -160,6 +161,7 @@ test('add ToolbarAction by clicking on the Add Toolbar Action button', async () 
     label: 'group1',
     widgets: [],
     toolbarActions: [toolbarAction],
+    borderStyle: null,
   };
 
   const page: GQLPage = {
@@ -212,6 +214,8 @@ test('delete the ToolbarAction from the ToolbarActions', async () => {
     iconURL: [],
     __typename: 'ToolbarAction',
     diagnostics: [],
+    hasHelpText: false,
+    readOnly: false,
     buttonLabel: 'ToolbarAction1',
     imageURL: null,
     style: {
@@ -231,6 +235,8 @@ test('delete the ToolbarAction from the ToolbarActions', async () => {
     __typename: 'ToolbarAction',
     diagnostics: [],
     buttonLabel: 'ToolbarAction2',
+    hasHelpText: false,
+    readOnly: false,
     imageURL: null,
     style: {
       backgroundColor: null,
@@ -250,6 +256,12 @@ test('delete the ToolbarAction from the ToolbarActions', async () => {
     label: 'group1',
     widgets: [],
     toolbarActions: [toolbarAction1, toolbarAction2],
+    borderStyle: {
+      color: null,
+      lineStyle: null,
+      radius: null,
+      size: null,
+    },
   };
 
   const page: GQLPage = {
@@ -304,6 +316,8 @@ test('move the existing ToolbarAction from/into the drop area', async () => {
     iconURL: [],
     __typename: 'ToolbarAction',
     diagnostics: [],
+    hasHelpText: false,
+    readOnly: false,
     buttonLabel: 'ToolbarAction1',
     imageURL: null,
     style: {
@@ -321,6 +335,8 @@ test('move the existing ToolbarAction from/into the drop area', async () => {
     label: 'ToolbarAction2',
     iconURL: [],
     __typename: 'ToolbarAction',
+    hasHelpText: false,
+    readOnly: false,
     diagnostics: [],
     buttonLabel: 'ToolbarAction2',
     imageURL: null,
@@ -342,6 +358,12 @@ test('move the existing ToolbarAction from/into the drop area', async () => {
     label: 'group1',
     widgets: [],
     toolbarActions: [toolbarAction1, toolbarAction2],
+    borderStyle: {
+      color: null,
+      lineStyle: null,
+      radius: null,
+      size: null,
+    },
   };
 
   const page: GQLPage = {
@@ -397,6 +419,8 @@ test('move the existing ToolbarAction from/into the drop area located at the end
     label: 'ToolbarAction1',
     iconURL: [],
     __typename: 'ToolbarAction',
+    hasHelpText: false,
+    readOnly: false,
     diagnostics: [],
     buttonLabel: 'ToolbarAction1',
     imageURL: null,
@@ -415,6 +439,8 @@ test('move the existing ToolbarAction from/into the drop area located at the end
     label: 'ToolbarAction2',
     iconURL: [],
     __typename: 'ToolbarAction',
+    hasHelpText: false,
+    readOnly: false,
     diagnostics: [],
     buttonLabel: 'ToolbarAction2',
     imageURL: null,
@@ -436,6 +462,12 @@ test('move the existing ToolbarAction from/into the drop area located at the end
     label: 'group1',
     widgets: [],
     toolbarActions: [toolbarAction1, toolbarAction2],
+    borderStyle: {
+      color: null,
+      lineStyle: null,
+      radius: null,
+      size: null,
+    },
   };
 
   const page: GQLPage = {
@@ -492,6 +524,8 @@ test('add ToolbarAction by clicking on the Add Toolbar Action button for a page'
     iconURL: [],
     __typename: 'ToolbarAction',
     diagnostics: [],
+    hasHelpText: false,
+    readOnly: false,
     buttonLabel: 'ToolbarAction1',
     imageURL: null,
     style: {

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/__tests__/WidgetEntry.test.tsx
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/src/__tests__/WidgetEntry.test.tsx
@@ -21,7 +21,6 @@ import {
   GQLTextfield,
 } from '@eclipse-sirius/sirius-components-forms';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { afterEach, expect, test, vi } from 'vitest';
 import { addWidgetMutation, deleteWidgetMutation, moveWidgetMutation } from '../FormDescriptionEditorEventFragment';
 import {

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/tsconfig.json
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/tsconfig.json
@@ -5,6 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": ["./src/index.ts"],
+  "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/vitestSetup.js
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/vitestSetup.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,4 +12,6 @@
  *******************************************************************************/
 import crypto from 'node:crypto';
 
-globalThis.crypto = crypto;
+globalThis.crypto = {
+  randomUUID: crypto.randomUUID,
+};

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/ButtonPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/ButtonPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,7 @@ const defaultButton: GQLButton = {
   label: 'Label',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   buttonLabel: 'ButtonLabel',
   imageURL: null,
@@ -79,6 +80,7 @@ const readOnlyButton: GQLButton = {
   imageURL: null,
   style: null,
   readOnly: true,
+  hasHelpText: false,
 };
 
 const pushButtonVariables: GQLPushButtonMutationVariables = {

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/ChartWidgetPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/ChartWidgetPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -205,6 +205,7 @@ test('render pie-chart widget', () => {
         formId="formId"
         widget={defaultPieChartWidget}
         subscribers={[]}
+        readOnly={false}
       />
     </MockedProvider>
   );
@@ -219,6 +220,7 @@ test('render pie-chart widget with style', () => {
         formId="formId"
         widget={defaultPieChartWidgetWithStyle}
         subscribers={[]}
+        readOnly={false}
       />
     </MockedProvider>
   );
@@ -233,6 +235,7 @@ test('render pie-chart widget with empty style', () => {
         formId="formId"
         widget={defaultPieChartWidgetWithEmptyStyle}
         subscribers={[]}
+        readOnly={false}
       />
     </MockedProvider>
   );
@@ -247,6 +250,7 @@ test('render the bar-chart widget', () => {
         formId="formId"
         widget={defaultBarChartWidget}
         subscribers={[]}
+        readOnly={false}
       />
     </MockedProvider>
   );
@@ -261,6 +265,7 @@ test('render the bar-chart widget with style', () => {
         formId="formId"
         widget={defaultBarChartWidgetWithStyle}
         subscribers={[]}
+        readOnly={false}
       />
     </MockedProvider>
   );
@@ -275,6 +280,7 @@ test('render the bar-chart widget with empty style', () => {
         formId="formId"
         widget={defaultBarChartWidgetWithEmptyStyle}
         subscribers={[]}
+        readOnly={false}
       />
     </MockedProvider>
   );
@@ -289,6 +295,7 @@ test('render pie-chart widget with help hint', () => {
         formId="formId"
         widget={{ ...defaultPieChartWidgetWithEmptyStyle, hasHelpText: true }}
         subscribers={[]}
+        readOnly={false}
       />
     </MockedProvider>
   );
@@ -302,6 +309,7 @@ test('render the bar-chart widget with help hint', () => {
         formId="formId"
         widget={{ ...defaultBarChartWidgetWithEmptyStyle, hasHelpText: true }}
         subscribers={[]}
+        readOnly={false}
       />
     </MockedProvider>
   );

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/CheckboxPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/CheckboxPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,7 @@ const defaultCheckbox: GQLCheckbox = {
   label: 'CheckboxLabel',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   booleanValue: false,
   style: null,
@@ -48,6 +49,7 @@ const checkboxWithStyle: GQLCheckbox = {
   label: 'CheckboxLabel',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   booleanValue: false,
   style: {
@@ -62,6 +64,7 @@ const checkboxWithEmptyStyle: GQLCheckbox = {
   label: 'CheckboxLabel',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   booleanValue: false,
   style: {
@@ -79,6 +82,7 @@ const readOnlyCheckbox: GQLCheckbox = {
   booleanValue: false,
   style: null,
   readOnly: true,
+  hasHelpText: false,
 };
 
 const editCheckboxVariables: GQLEditCheckboxMutationVariables = {

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/CompletionProposals.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/CompletionProposals.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,8 +12,8 @@
  *******************************************************************************/
 
 import { expect, test } from 'vitest';
-import { applyCompletionProposal, TextFieldState } from '../TextfieldPropertySection';
-import { GQLCompletionProposal } from '../TextfieldPropertySection.types';
+import { applyCompletionProposal } from '../TextfieldPropertySection';
+import { GQLCompletionProposal, TextFieldState } from '../TextfieldPropertySection.types';
 
 test('apply empty proposal anywhere', () => {
   const text = 'some text';

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/FlexboxContainerPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/FlexboxContainerPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ const defaultFlexboxContainer: GQLFlexboxContainer = {
   borderStyle: null,
   children: [],
   diagnostics: [],
+  readOnly: false,
   flexDirection: 'row',
   flexGrow: 1,
   flexWrap: 'nowrap',

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/ImagePropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/ImagePropertySection.test.tsx
@@ -26,6 +26,7 @@ const imageWithMaxWidth: GQLImage = {
   maxWidth: '42px',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   __typename: 'Image',
   diagnostics: [],
   id: 'imageId',
@@ -37,6 +38,7 @@ const imageWithNoMaxWidth: GQLImage = {
   maxWidth: null,
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   __typename: 'Image',
   diagnostics: [],
   id: 'imageId',
@@ -45,7 +47,13 @@ const imageWithNoMaxWidth: GQLImage = {
 test('render image widget with maxWidth', () => {
   const { container } = render(
     <MockedProvider>
-      <ImagePropertySection editingContextId="editingContextId" formId="formId" widget={imageWithMaxWidth} />
+      <ImagePropertySection
+        editingContextId="editingContextId"
+        formId="formId"
+        widget={imageWithMaxWidth}
+        readOnly={false}
+        subscribers={[]}
+      />
     </MockedProvider>
   );
   expect(container).toMatchSnapshot();
@@ -57,7 +65,13 @@ test('render image widget with maxWidth', () => {
 test('render image widget without maxWidth', () => {
   const { container } = render(
     <MockedProvider>
-      <ImagePropertySection editingContextId="editingContextId" formId="formId" widget={imageWithNoMaxWidth} />
+      <ImagePropertySection
+        editingContextId="editingContextId"
+        formId="formId"
+        widget={imageWithNoMaxWidth}
+        readOnly={false}
+        subscribers={[]}
+      />
     </MockedProvider>
   );
   expect(container).toMatchSnapshot();
@@ -73,6 +87,8 @@ test('render image widget with help hint', () => {
         editingContextId="editingContextId"
         formId="formId"
         widget={{ ...imageWithMaxWidth, hasHelpText: true }}
+        readOnly={false}
+        subscribers={[]}
       />
     </MockedProvider>
   );

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/LabelPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/LabelPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ const defaultLabel: GQLLabelWidget = {
   stringValue: 'theLabelValue',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   style: {
     color: null,
     bold: null,
@@ -43,6 +44,7 @@ const defaultLabelWithStyle: GQLLabelWidget = {
   stringValue: 'theLabelValue',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   style: {
     color: 'RebeccaPurple',
     bold: true,
@@ -63,6 +65,7 @@ test('render label widget', () => {
         editingContextId="editingContextId"
         formId="formId"
         widget={defaultLabel}
+        readOnly={false}
         subscribers={[]}
       />
     </MockedProvider>
@@ -77,6 +80,7 @@ test('render label widget with style', () => {
         editingContextId="editingContextId"
         formId="formId"
         widget={defaultLabelWithStyle}
+        readOnly={false}
         subscribers={[]}
       />
     </MockedProvider>
@@ -91,6 +95,7 @@ test('render label widget with help hint', () => {
         editingContextId="editingContextId"
         formId="formId"
         widget={{ ...defaultLabel, hasHelpText: true }}
+        readOnly={false}
         subscribers={[]}
       />
     </MockedProvider>

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/LinkPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/LinkPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ const defaultLink: GQLLink = {
   url: 'the/url/value',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   style: {
     color: null,
     bold: null,
@@ -43,6 +44,7 @@ const defaultLinkWithStyle: GQLLink = {
   url: 'the/url/value',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   style: {
     color: 'RebeccaPurple',
     bold: true,
@@ -59,7 +61,13 @@ const defaultLinkWithStyle: GQLLink = {
 test('render label widget', () => {
   const { container } = render(
     <MockedProvider>
-      <LinkPropertySection editingContextId="editingContextId" formId="formId" widget={defaultLink} />
+      <LinkPropertySection
+        editingContextId="editingContextId"
+        formId="formId"
+        widget={defaultLink}
+        readOnly={false}
+        subscribers={[]}
+      />
     </MockedProvider>
   );
   expect(container).toMatchSnapshot();
@@ -68,7 +76,13 @@ test('render label widget', () => {
 test('render label widget with style', () => {
   const { container } = render(
     <MockedProvider>
-      <LinkPropertySection editingContextId="editingContextId" formId="formId" widget={defaultLinkWithStyle} />
+      <LinkPropertySection
+        editingContextId="editingContextId"
+        formId="formId"
+        widget={defaultLinkWithStyle}
+        readOnly={false}
+        subscribers={[]}
+      />
     </MockedProvider>
   );
   expect(container).toMatchSnapshot();
@@ -81,6 +95,8 @@ test('render label widget with help hint', () => {
         editingContextId="editingContextId"
         formId="formId"
         widget={{ ...defaultLink, hasHelpText: true }}
+        readOnly={false}
+        subscribers={[]}
       />
     </MockedProvider>
   );

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/ListPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/ListPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, expect, test, vi } from 'vitest';
 import { GQLList, GQLListItem } from '../../form/FormEventFragments.types';
-import { clickListItemMutation, ListPropertySection } from '../ListPropertySection';
+import { ListPropertySection, clickListItemMutation } from '../ListPropertySection';
 import {
   GQLClickListItemMutationData,
   GQLClickListItemMutationVariables,
@@ -60,6 +60,7 @@ const defaultList: GQLList = {
   label: 'myList',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   items: defaultListItems,
   style: null,
   __typename: 'List',
@@ -71,6 +72,7 @@ const defaultListWithStyle: GQLList = {
   label: 'myList',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   items: defaultListItems,
   style: {
     color: 'RebeccaPurple',
@@ -94,6 +96,7 @@ const readOnlyList: GQLList = {
   diagnostics: [],
   id: 'listId',
   readOnly: true,
+  hasHelpText: false,
 };
 
 const clickListItemVariables: GQLClickListItemMutationVariables = {
@@ -128,8 +131,7 @@ test('render list widget', () => {
   const { container } = render(
     <MockedProvider>
       <ToastContext.Provider value={toastContextMock}>
-        <SelectionContext.Provider
-          value={{ selection: emptySelection, setSelection: emptySetSelection, selectedRepresentations: [] }}>
+        <SelectionContext.Provider value={{ selection: emptySelection, setSelection: emptySetSelection }}>
           <ListPropertySection
             editingContextId="editingContextId"
             formId="formId"
@@ -148,8 +150,7 @@ test('render list widget with style', () => {
   const { container } = render(
     <MockedProvider>
       <ToastContext.Provider value={toastContextMock}>
-        <SelectionContext.Provider
-          value={{ selection: emptySelection, setSelection: emptySetSelection, selectedRepresentations: [] }}>
+        <SelectionContext.Provider value={{ selection: emptySelection, setSelection: emptySetSelection }}>
           <ListPropertySection
             editingContextId="editingContextId"
             formId="formId"
@@ -180,8 +181,7 @@ test('should the click event sent on item click', async () => {
   const { container } = render(
     <MockedProvider mocks={[itemClickCalledCalledSuccessMock]}>
       <ToastContext.Provider value={toastContextMock}>
-        <SelectionContext.Provider
-          value={{ selection: emptySelection, setSelection: emptySetSelection, selectedRepresentations: [] }}>
+        <SelectionContext.Provider value={{ selection: emptySelection, setSelection: emptySetSelection }}>
           <ListPropertySection
             editingContextId="editingContextId"
             formId="formId"
@@ -212,8 +212,7 @@ test('render list widget with help hint', () => {
   const { container } = render(
     <MockedProvider>
       <ToastContext.Provider value={toastContextMock}>
-        <SelectionContext.Provider
-          value={{ selection: emptySelection, setSelection: emptySetSelection, selectedRepresentations: [] }}>
+        <SelectionContext.Provider value={{ selection: emptySelection, setSelection: emptySetSelection }}>
           <ListPropertySection
             editingContextId="editingContextId"
             formId="formId"
@@ -232,8 +231,7 @@ test('should render a readOnly list from widget properties', () => {
   const { container } = render(
     <MockedProvider>
       <ToastContext.Provider value={toastContextMock}>
-        <SelectionContext.Provider
-          value={{ selection: emptySelection, setSelection: emptySetSelection, selectedRepresentations: [] }}>
+        <SelectionContext.Provider value={{ selection: emptySelection, setSelection: emptySetSelection }}>
           <ListPropertySection
             editingContextId="editingContextId"
             formId="formId"

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/MultiSelectPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/MultiSelectPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ const defaultMultiSelect: GQLMultiSelect = {
   label: 'MultiSelectLabel',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   values: [],
   options: [],
@@ -39,6 +40,7 @@ const multiSelectWithStyle: GQLMultiSelect = {
   label: 'MultiSelectLabel',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   values: [],
   options: [],
@@ -59,6 +61,7 @@ const multiSelectWithEmptyStyle: GQLMultiSelect = {
   label: 'MultiSelectLabel',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   values: [],
   options: [],
@@ -83,6 +86,7 @@ const readOnlyMultiSelect: GQLMultiSelect = {
   options: [],
   style: null,
   readOnly: true,
+  hasHelpText: false,
 };
 
 const mockEnqueue = vi.fn<[string, MessageOptions?], void>();

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/RadioPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/RadioPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,8 +17,8 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, expect, test, vi } from 'vitest';
 import { GQLRadio } from '../../form/FormEventFragments.types';
 import {
-  editRadioMutation,
   RadioPropertySection,
+  editRadioMutation,
   updateWidgetFocusMutation,
 } from '../../propertysections/RadioPropertySection';
 import {
@@ -41,6 +41,7 @@ const defaultRadio: GQLRadio = {
   label: 'Status:',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   options: [
     {
@@ -63,6 +64,7 @@ const radioWithStyle: GQLRadio = {
   label: 'Status:',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   options: [
     {
@@ -92,6 +94,7 @@ const radioWithEmptyStyle: GQLRadio = {
   label: 'Status:',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   options: [
     {
@@ -135,6 +138,7 @@ const readOnlyRadio: GQLRadio = {
   ],
   style: null,
   readOnly: true,
+  hasHelpText: false,
 };
 
 const editRadioVariables: GQLEditRadioMutationVariables = {

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/SelectPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/SelectPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ const defaultSelect: GQLSelect = {
   label: 'SelectLabel',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   value: '',
   options: [],
@@ -39,6 +40,7 @@ const selectWithStyle: GQLSelect = {
   label: 'SelectLabel',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   value: '',
   options: [],
@@ -59,6 +61,7 @@ const selectWithEmptyStyle: GQLSelect = {
   label: 'SelectLabel',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   diagnostics: [],
   value: '',
   options: [],
@@ -83,6 +86,7 @@ const readOnlySelect: GQLSelect = {
   options: [],
   style: null,
   readOnly: true,
+  hasHelpText: false,
 };
 
 const mockEnqueue = vi.fn<[string, MessageOptions?], void>();

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/SplitButtonPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/SplitButtonPropertySection.test.tsx
@@ -14,7 +14,6 @@ import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { MessageOptions, ServerContext, ToastContext, ToastContextValue } from '@eclipse-sirius/sirius-components-core';
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { afterEach, expect, test, vi } from 'vitest';
 import { GQLButton, GQLSplitButton } from '../../form/FormEventFragments.types';
 import { pushButtonMutation, updateWidgetFocusMutation } from '../ButtonPropertySection';
@@ -78,27 +77,6 @@ const buttonWithStyle: GQLButton = {
   },
 };
 
-const readOnlyButton: GQLButton = {
-  __typename: 'Button',
-  id: 'buttonId',
-  label: 'Label',
-  iconURL: [],
-  diagnostics: [],
-  buttonLabel: 'ButtonLabel',
-  imageURL: null,
-  style: {
-    backgroundColor: null,
-    foregroundColor: null,
-    fontSize: null,
-    italic: null,
-    bold: null,
-    underline: null,
-    strikeThrough: null,
-  },
-  readOnly: true,
-  hasHelpText: false,
-};
-
 const splitButtonWithStyle: GQLSplitButton = {
   __typename: 'Button',
   id: 'buttonId',
@@ -108,17 +86,6 @@ const splitButtonWithStyle: GQLSplitButton = {
   diagnostics: [],
   readOnly: false,
   actions: [buttonWithStyle, buttonWithStyle],
-};
-
-const splitButtonWithReadOnlyAction: GQLSplitButton = {
-  __typename: 'Button',
-  id: 'buttonId',
-  label: 'Label',
-  iconURL: [],
-  hasHelpText: false,
-  diagnostics: [],
-  readOnly: false,
-  actions: [readOnlyButton, readOnlyButton],
 };
 
 const pushButtonVariables: GQLPushButtonMutationVariables = {

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/TextfieldPropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/TextfieldPropertySection.test.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,9 +17,9 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, expect, test, vi } from 'vitest';
 import { GQLTextfield } from '../../form/FormEventFragments.types';
 import {
+  TextfieldPropertySection,
   editTextfieldMutation,
   getCompletionProposalsQuery,
-  TextfieldPropertySection,
   updateWidgetFocusMutation,
 } from '../../propertysections/TextfieldPropertySection';
 import {
@@ -44,6 +44,7 @@ const defaultTextField: GQLTextfield = {
   label: 'Name:',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   stringValue: 'Composite Processor',
   supportsCompletion: false,
   diagnostics: [],
@@ -56,6 +57,7 @@ const textFieldWithStyle: GQLTextfield = {
   label: 'Name:',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   stringValue: 'Composite Processor',
   supportsCompletion: false,
   diagnostics: [],
@@ -76,6 +78,7 @@ const textFieldWithEmptyStyle: GQLTextfield = {
   label: 'Name:',
   iconURL: [],
   hasHelpText: false,
+  readOnly: false,
   stringValue: 'Composite Processor',
   supportsCompletion: false,
   diagnostics: [],
@@ -100,6 +103,7 @@ const readOnlyTextField: GQLTextfield = {
   diagnostics: [],
   style: null,
   readOnly: true,
+  hasHelpText: false,
 };
 
 const editTextfieldVariables: GQLEditTextfieldMutationVariables = {
@@ -351,6 +355,7 @@ test('should support completion if configured', async () => {
     label: 'Text:',
     iconURL: [],
     hasHelpText: false,
+    readOnly: false,
     stringValue: 'fo',
     supportsCompletion: true,
     diagnostics: [],
@@ -375,14 +380,12 @@ test('should support completion if configured', async () => {
     },
   };
 
-  let leaveWidgetFocusCalled = false;
   const leaveWidgetFocusSuccessMock: MockedResponse<Record<string, any>> = {
     request: {
       query: updateWidgetFocusMutation,
       variables: leaveWidgetFocusVariables,
     },
     result: () => {
-      leaveWidgetFocusCalled = true;
       return { data: updateWidgetFocusSuccessData };
     },
   };
@@ -502,6 +505,7 @@ test('should not trigger completion request if not configured', async () => {
     label: 'Text:',
     iconURL: [],
     hasHelpText: false,
+    readOnly: false,
     stringValue: 'fo',
     supportsCompletion: false,
     diagnostics: [],

--- a/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/TreePropertySection.test.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/TreePropertySection.test.tsx
@@ -22,12 +22,10 @@ import {
 } from '@eclipse-sirius/sirius-components-core';
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { afterEach, expect, test, vi } from 'vitest';
 import { GQLTree, GQLTreeNode } from '../../form/FormEventFragments.types';
 import { TreePropertySection, updateWidgetFocusMutation } from '../TreePropertySection';
 import {
-  GQLErrorPayload,
   GQLUpdateWidgetFocusMutationData,
   GQLUpdateWidgetFocusMutationVariables,
   GQLUpdateWidgetFocusSuccessPayload,
@@ -56,19 +54,6 @@ const updateWidgetFocusSuccessPayload: GQLUpdateWidgetFocusSuccessPayload = {
 };
 const updateWidgetFocusSuccessData: GQLUpdateWidgetFocusMutationData = {
   updateWidgetFocus: updateWidgetFocusSuccessPayload,
-};
-
-const updateWidgetFocusErrorPayload: GQLErrorPayload = {
-  __typename: 'ErrorPayload',
-  messages: [
-    {
-      body: 'An error has occurred, please refresh the page',
-      level: 'ERROR',
-    },
-  ],
-};
-const updateWidgetFocusErrorData: GQLUpdateWidgetFocusMutationData = {
-  updateWidgetFocus: updateWidgetFocusErrorPayload,
 };
 
 // Helper to make fixtures more readable
@@ -312,7 +297,6 @@ test('should only expand the specified nodes on initial render', () => {
 });
 
 test('should change the selection when a selectable node is clicked', () => {
-  let updateWidgetFocusCalled = false;
   const updateWidgetFocusSuccessMock: MockedResponse<
     GQLUpdateWidgetFocusMutationData,
     GQLUpdateWidgetFocusMutationVariables
@@ -322,7 +306,6 @@ test('should change the selection when a selectable node is clicked', () => {
       variables: updateWidgetFocusVariables,
     },
     result: () => {
-      updateWidgetFocusCalled = true;
       return { data: updateWidgetFocusSuccessData };
     },
   };

--- a/packages/forms/frontend/sirius-components-forms/tsconfig.json
+++ b/packages/forms/frontend/sirius-components-forms/tsconfig.json
@@ -5,6 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": ["./src/index.ts"],
+  "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/forms/frontend/sirius-components-forms/vitestSetup.js
+++ b/packages/forms/frontend/sirius-components-forms/vitestSetup.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,4 +12,6 @@
  *******************************************************************************/
 import crypto from 'node:crypto';
 
-globalThis.crypto = crypto;
+globalThis.crypto = {
+  randomUUID: crypto.randomUUID,
+};

--- a/packages/forms/frontend/sirius-components-widget-reference/tsconfig.json
+++ b/packages/forms/frontend/sirius-components-widget-reference/tsconfig.json
@@ -5,12 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": [
-    "./src/index.ts"
-  ],
-  "exclude": [
-    "dist",
-    "build",
-    "node_modules"
-  ]
+  "include": ["./src"],
+  "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/forms/frontend/sirius-components-widget-reference/vitestSetup.js
+++ b/packages/forms/frontend/sirius-components-widget-reference/vitestSetup.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,4 +12,6 @@
  *******************************************************************************/
 import crypto from 'node:crypto';
 
-globalThis.crypto = crypto;
+globalThis.crypto = {
+  randomUUID: crypto.randomUUID,
+};

--- a/packages/portals/frontend/sirius-components-portals/tsconfig.json
+++ b/packages/portals/frontend/sirius-components-portals/tsconfig.json
@@ -5,6 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": ["./src/index.ts"],
+  "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/portals/frontend/sirius-components-portals/vitestSetup.js
+++ b/packages/portals/frontend/sirius-components-portals/vitestSetup.js
@@ -12,4 +12,6 @@
  *******************************************************************************/
 import crypto from 'node:crypto';
 
-globalThis.crypto = crypto;
+globalThis.crypto = {
+  randomUUID: crypto.randomUUID,
+};

--- a/packages/selection/frontend/sirius-components-selection/tsconfig.json
+++ b/packages/selection/frontend/sirius-components-selection/tsconfig.json
@@ -5,6 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": ["./src/index.ts"],
+  "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/sirius-web/frontend/sirius-web-application/tsconfig.json
+++ b/packages/sirius-web/frontend/sirius-web-application/tsconfig.json
@@ -5,6 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": ["./src/index.ts"],
+  "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/sirius-web/frontend/sirius-web/tsconfig.json
+++ b/packages/sirius-web/frontend/sirius-web/tsconfig.json
@@ -22,13 +22,6 @@
     "noFallthroughCasesInSwitch": true,
     "strict": false
   },
-  "include": ["src/**/*"],
-  "exclude": [
-    "node_modules",
-    "build",
-    "src/**/*.stories.tsx",
-    "src/**/*.stories.js",
-    "src/**/*.test.tsx",
-    "src/**/*.test.js"
-  ]
+  "include": ["./src"],
+  "exclude": ["node_modules", "build", "src/**/*.test.tsx", "src/**/*.test.js"]
 }

--- a/packages/tools/frontend/sirius-components-specification-layout/tsconfig.json
+++ b/packages/tools/frontend/sirius-components-specification-layout/tsconfig.json
@@ -21,13 +21,6 @@
     "noFallthroughCasesInSwitch": true,
     "strict": false
   },
-  "include": ["src/**/*"],
-  "exclude": [
-    "node_modules",
-    "build",
-    "src/**/*.stories.tsx",
-    "src/**/*.stories.js",
-    "src/**/*.test.tsx",
-    "src/**/*.test.js"
-  ]
+  "include": ["./src"],
+  "exclude": ["node_modules", "build", "src/**/*.test.tsx", "src/**/*.test.js"]
 }

--- a/packages/trees/frontend/sirius-components-trees/tsconfig.json
+++ b/packages/trees/frontend/sirius-components-trees/tsconfig.json
@@ -5,6 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": ["./src/index.ts"],
+  "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/validation/frontend/sirius-components-validation/tsconfig.json
+++ b/packages/validation/frontend/sirius-components-validation/tsconfig.json
@@ -5,6 +5,6 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist"
   },
-  "include": ["./src/index.ts"],
+  "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }


### PR DESCRIPTION
This PR lets TypeScript check *all* relevant files in the source folders, not just the subset which is accessible from the top-level `index.tsx` files.

In particular it includes new files as soon as they are created, which was not the case before and could be annoying when working on a newly created file not yet accessible from the too index.

It also includes all the test files, which revealed a few issue. Most were missing `hasHelpText` or `readOnly` properties, which have been added (with default values).

A few errors were variables defined in the tests but not actually used/tested.

* In `packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/SplitButtonPropertySection.test.tsx`:
    ```js
    const readOnlyButton: GQLButton = ...;
    const splitButtonWithReadOnlyAction: GQLSplitButton = ...;
    ```
* In `packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/TextfieldPropertySection.test.tsx`:
    ```js
    let leaveWidgetFocusCalled = false;
    ```
* In `packages/forms/frontend/sirius-components-forms/src/propertysections/__tests__/TreePropertySection.test.tsx`:
    ```js
    const updateWidgetFocusErrorPayload: GQLErrorPayload = ...:
    const updateWidgetFocusErrorData: GQLUpdateWidgetFocusMutationData = ...;
    let updateWidgetFocusCalled = false;
    ```

For the moment hey have been simply removed but the tests should probably be improved to re-introduce them and properly exercise them.

Finally, the setup of the `randomUUID` function in Cypress tests has been changed from `globalThis.crypto = crypto` to
```js
globalThis.crypto = {
  randomUUID: crypto.randomUUID,
};
```
as the `node:crypto` object as a whole does not seem type-compatible with the expected `crypto` global object.
