### PR TITLE
[3638] Avoid hitting the DB in the common case in getOrCreateECEP

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -104,6 +104,7 @@ A migration participant has been added to automatically keep compatible all diag
 - https://github.com/eclipse-sirius/sirius-web/issues/3776[#3776] [trees] Remove unwanted dependency from the reference widget in the explorer
 - https://github.com/eclipse-sirius/sirius-web/issues/3777[#3777] [sirius-web] Add support for any kind of object as semantic element in the tree representation
 - https://github.com/eclipse-sirius/sirius-web/issues/3392[#3392] [diagram] Prevent edge from passing through another node
+- https://github.com/eclipse-sirius/sirius-web/issues/3638[#3638] [core] Avoid hitting the database when dispatching inputs to the proper editing context
 
 == v2024.7.0
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/project/controllers/MutationDeleteProjectDataFetcher.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/project/controllers/MutationDeleteProjectDataFetcher.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Objects;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.MutationDataFetcher;
+import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
 import org.eclipse.sirius.web.application.project.dto.DeleteProjectInput;
@@ -36,10 +37,13 @@ public class MutationDeleteProjectDataFetcher implements IDataFetcherWithFieldCo
 
     private final ObjectMapper objectMapper;
 
+    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+
     private final IProjectApplicationService projectApplicationService;
 
-    public MutationDeleteProjectDataFetcher(ObjectMapper objectMapper, IProjectApplicationService projectApplicationService) {
+    public MutationDeleteProjectDataFetcher(ObjectMapper objectMapper, IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry, IProjectApplicationService projectApplicationService) {
         this.objectMapper = Objects.requireNonNull(objectMapper);
+        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
         this.projectApplicationService = Objects.requireNonNull(projectApplicationService);
     }
 
@@ -47,6 +51,7 @@ public class MutationDeleteProjectDataFetcher implements IDataFetcherWithFieldCo
     public IPayload get(DataFetchingEnvironment environment) throws Exception {
         Object argument = environment.getArgument(INPUT_ARGUMENT);
         var input = this.objectMapper.convertValue(argument, DeleteProjectInput.class);
+        this.editingContextEventProcessorRegistry.disposeEditingContextEventProcessor(input.projectId().toString());
         return this.projectApplicationService.deleteProject(input);
     }
 }


### PR DESCRIPTION
On a simple scenario where a diagram is opened and the user clicks in the background to open the palette.

Before: 5 calls to the database, 2 via `EditingContextSearchService.existsById`

![Capture d’écran du 2024-08-23 10-36-43](https://github.com/user-attachments/assets/8505a600-ea7e-48ad-b31e-6923b9b90f42)

After: down to 3 calls.

![Capture d’écran du 2024-08-23 10-35-32](https://github.com/user-attachments/assets/d7b6057e-9154-4b31-b71a-c8c048922278)
