### PR TITLE
[3666] Enable EMF's intrinsicIDToEObjectMap for JSON resources

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,7 +45,7 @@ More existing APIs will be migrated to this new common pattern.
 - [releng] Switch to `maven-checkstyle-plugin` 3.3.1
 - [releng] Remove the dependency to `reflect-metadata`
 - [releng] Switch to `subscriptions-transport-ws` 0.11.0
-- [releng] Switch to EMF Json 2.3.11
+- [releng] Switch to EMF Json 2.3.12
 - https://github.com/eclipse-sirius/sirius-web/issues/3523[#3523] [gantt] Move to @ObeoNetwork/gantt-task-react 0.4.19 to benefit for enhancements
 
 === Bug fixes
@@ -67,6 +67,7 @@ More existing APIs will be migrated to this new common pattern.
 - https://github.com/eclipse-sirius/sirius-web/issues/3650[#3650] [diagram] Fix potential NPE in DiagramNavigator and Node toString method 
 - https://github.com/eclipse-sirius/sirius-web/issues/3649[#3649] [sirius-web] Restore support for Related elements view icons
 - https://github.com/eclipse-sirius/sirius-web/issues/3630[#3630] [sirius-web] Restore support for the deletion of dangling representations
+- https://github.com/eclipse-sirius/sirius-web/issues/3666[#3666] [core] Enable EMF's intrinsicIDToEObjectMap for JSON resources to support languages which use modeled identifiers (e.g. SysMLv2).
 
 === New Features
 

--- a/packages/emf/backend/sirius-components-emf/pom.xml
+++ b/packages/emf/backend/sirius-components-emf/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2019, 2023 Obeo.
+ Copyright (c) 2019, 2024 Obeo.
  This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v2.0
  which accompanies this distribution, and is available at
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.emfjson</groupId>
 			<artifactId>org.eclipse.sirius.emfjson</artifactId>
-			<version>2.3.11-SNAPSHOT</version>
+			<version>2.3.12-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/services/JSONResourceFactory.java
+++ b/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/services/JSONResourceFactory.java
@@ -34,20 +34,20 @@ public class JSONResourceFactory extends ResourceFactoryImpl {
 
     @Override
     public JsonResource createResource(URI uri) {
-        // @formatter:off
         Optional.ofNullable(uri)
             .map(URI::scheme)
             .filter(Objects::nonNull)
             .filter(Predicate.not(String::isEmpty))
             .orElseThrow(() -> new IllegalArgumentException(String.format("Missing scheme for URI %s", uri)));
-        // @formatter:on
 
         Map<String, Object> options = new HashMap<>();
 
         options.put(JsonResource.OPTION_ID_MANAGER, new EObjectIDManager());
         options.put(JsonResource.OPTION_DISPLAY_DYNAMIC_INSTANCES, true);
 
-        return new JsonResourceImpl(uri, options);
+        var resource = new JsonResourceImpl(uri, options);
+        resource.setIntrinsicIDToEObjectMap(new HashMap<>());
+        return resource;
     }
 
     /**


### PR DESCRIPTION
This will actually require the integration of a new version of EMF JSON with https://github.com/eclipse-sirius/sirius-emf-json/pull/47 in it before it fully works.
