### PR TITLE
[3669] Add migration participant to hide label borders by default

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -131,6 +131,7 @@ image:doc/screenshots/insideLabelPositions.png[Inside label positions, 70%]
 The error messages displayed in case of an error while uploading a file have been uploaded to mention that the file may be too large since it can be a common error.
 We cannot rely on the error message recaived from the backend since Cross Origin Resource Sharing may prevent us from seeing both the message and the 413 status code.
 - https://github.com/eclipse-sirius/sirius-web/issues/3697[#3697] [diagram] Improve arrange-all performance by reducing overlap management complexity
+- https://github.com/eclipse-sirius/sirius-web/issues/3669[#3669] [diagram] Add migration participant to hide label borders by default
 
 == v2024.5.0
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/editingcontext/migration/participants/DiagramLabelStyleBorderSizeMigrationParticipant.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/editingcontext/migration/participants/DiagramLabelStyleBorderSizeMigrationParticipant.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.editingcontext.migration.participants;
+
+import com.google.gson.JsonObject;
+
+import java.util.Optional;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.components.emf.migration.api.IMigrationParticipant;
+import org.eclipse.sirius.components.view.diagram.EdgeDescription;
+import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.springframework.stereotype.Service;
+
+/**
+ * MigrationParticipant that update the BorderStyle of NodeLabelStyle.
+ *
+ * @author mcharfadi
+ */
+@Service
+public class DiagramLabelStyleBorderSizeMigrationParticipant implements IMigrationParticipant {
+
+    private static final String PARTICIPANT_VERSION = "2024.7.0-202407090945";
+
+    @Override
+    public String getVersion() {
+        return PARTICIPANT_VERSION;
+    }
+
+    @Override
+    public void postObjectLoading(EObject eObject, JsonObject jsonObject) {
+        if (eObject instanceof NodeDescription nodeDescription) {
+            var optionalNodeDescriptionData = Optional.ofNullable(jsonObject.getAsJsonObject("data"));
+            optionalNodeDescriptionData.ifPresent(nodeDescriptionData -> {
+                var optionalInsideLabel = Optional.ofNullable(nodeDescriptionData.get("insideLabel"));
+                optionalInsideLabel.ifPresent(insideLabel -> {
+                    if (nodeDescription.getInsideLabel().getStyle() != null) {
+                        nodeDescription.getInsideLabel().getStyle().setBorderSize(0);
+                    }
+                });
+                var optionalOutsideLabels = Optional.ofNullable(nodeDescriptionData.get("outsideLabels"));
+                optionalOutsideLabels.ifPresent(outsideLabels -> nodeDescription.getOutsideLabels().forEach(outsideLabelDescription -> {
+                    if (outsideLabelDescription.getStyle() != null) {
+                        outsideLabelDescription.getStyle().setBorderSize(0);
+                    }
+                }));
+            });
+        } else if (eObject instanceof EdgeDescription edgeDescription) {
+            var optionalEdgeDescriptionData = Optional.ofNullable(jsonObject.getAsJsonObject("data"));
+            optionalEdgeDescriptionData.ifPresent(edgeDescriptionData -> {
+                if (edgeDescription.getStyle() != null) {
+                    edgeDescription.getStyle().setBorderSize(0);
+                }
+            });
+        }
+    }
+}

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/data/MigrationIdentifiers.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/data/MigrationIdentifiers.java
@@ -37,6 +37,10 @@ public final class MigrationIdentifiers {
 
     public static final UUID MIGRATION_STUDIO_DIAGRAM = UUID.fromString("9698833e-ffd4-435a-9aec-765622ce524e");
 
+    public static final UUID MIGRATION_DIAGRAM_LABEL_STYLE_BORDER_SIZE_STUDIO = UUID.fromString("8ce6147e-1f5b-426f-b1be-dfeabd37a50a");
+
+    public static final String MIGRATION_DIAGRAM_LABEL_STYLE_BORDER_SIZE_STUDIO_DIAGRAM = "DiagramLabelStyle#borderSize migration";
+
     private MigrationIdentifiers() {
         // Prevent instantiation
     }

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/migration/DiagramLabelStyleBorderSizeMigrationParticipantTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/migration/DiagramLabelStyleBorderSizeMigrationParticipantTests.java
@@ -1,0 +1,281 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.services.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jayway.jsonpath.JsonPath;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IEditingContextSearchService;
+import org.eclipse.sirius.components.core.api.IInput;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
+import org.eclipse.sirius.components.emf.migration.api.IMigrationParticipant;
+import org.eclipse.sirius.components.emf.migration.api.MigrationData;
+import org.eclipse.sirius.components.graphql.api.UploadFile;
+import org.eclipse.sirius.components.graphql.tests.ExecuteEditingContextFunctionInput;
+import org.eclipse.sirius.components.graphql.tests.ExecuteEditingContextFunctionRunner;
+import org.eclipse.sirius.components.graphql.tests.ExecuteEditingContextFunctionSuccessPayload;
+import org.eclipse.sirius.components.view.diagram.DiagramDescription;
+import org.eclipse.sirius.web.AbstractIntegrationTests;
+import org.eclipse.sirius.web.application.document.dto.UploadDocumentInput;
+import org.eclipse.sirius.web.application.document.dto.UploadDocumentSuccessPayload;
+import org.eclipse.sirius.web.application.editingcontext.EditingContext;
+import org.eclipse.sirius.web.data.MigrationIdentifiers;
+import org.eclipse.sirius.web.tests.graphql.UploadDocumentMutationRunner;
+import org.eclipse.sirius.web.tests.services.api.IGivenCommittedTransaction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import reactor.test.StepVerifier;
+
+/**
+ * Integration tests of DiagramLabelStyleBorderSizeMigrationParticipant.
+ *
+ * @author frouene
+ */
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class DiagramLabelStyleBorderSizeMigrationParticipantTests extends AbstractIntegrationTests {
+
+    public static final String DOCUMENT_CONTENT = """
+            {
+              "json": { "version": "1.0", "encoding": "utf-8" },
+              "ns": {
+                "diagram": "http://www.eclipse.org/sirius-web/diagram",
+                "view": "http://www.eclipse.org/sirius-web/view"
+              },
+              "content": [
+                {
+                  "id": "9674f8f7-ff1a-4061-bb32-a4a235a9c2ca",
+                  "eClass": "view:View",
+                  "data": {
+                    "descriptions": [
+                     {
+                       "id": "c1a0ae1c-8420-4aa7-b443-1a05044076e2",
+                       "eClass": "diagram:DiagramDescription",
+                       "data": {
+                         "name": "DiagramLabelStyle#borderSize migration",
+                         "domainType": "flow::System",
+                         "edgeDescriptions": [
+                           {
+                             "data": {
+                               "centerLabelExpression": "",
+                               "name": "LabelBorderSize Edge",
+                               "semanticCandidatesExpression": "",
+                               "sourceNodeDescriptions": [
+                                 "//@descriptions.0/@nodeDescriptions.0"
+                               ],
+                               "sourceNodesExpression": "aql:self",
+                               "style": {
+                                 "data": {
+                                   "color": "//@colorPalettes.0/@colors.0"
+                                 },
+                                 "eClass": "diagram:EdgeStyle",
+                                 "id": "748824cb-cd5f-42fe-95a8-4f21172ba2ce"
+                               },
+                               "targetNodeDescriptions": [
+                                 "//@descriptions.0/@nodeDescriptions.1"
+                               ],
+                               "targetNodesExpression": "aql:self.linkedTo"
+                             },
+                             "eClass": "diagram:EdgeDescription",
+                             "id": "c1077629-a4ec-4232-8eb5-5209b58c7464"
+                           }
+                         ],
+                         "nodeDescriptions": [
+                           {
+                             "id": "4d1ec4d1-dd2c-4cb2-bbed-df02f0babbd8",
+                             "eClass": "diagram:NodeDescription",
+                             "data": {
+                               "name": "LabelBorderSize migration",
+                               "domainType": "flow::CompositeProcessor",
+                               "insideLabel": {
+                                 "data": {
+                                   "style": {
+                                     "eClass": "diagram:InsideLabelStyle",
+                                     "id": "d70178c4-d36f-40d7-a3ab-ef8568e4ee2b"
+                                   }
+                                 },
+                                 "eClass": "diagram:InsideLabelDescription",
+                                 "id": "046b48ee-4554-4d8a-a457-5391b690d2a9"
+                               },
+                               "outsideLabels": [
+                                 {
+                                   "data": {
+                                     "style": {
+                                       "eClass": "diagram:OutsideLabelStyle",
+                                       "id": "c69b0853-26ab-40b0-979d-f0a4974ad865"
+                                     }
+                                   },
+                                   "eClass": "diagram:OutsideLabelDescription",
+                                   "id": "fd8638cc-8ebb-48e6-bf3f-2c09206f6a09"
+                                 },
+                                 {
+                                   "data": {
+                                     "style": {
+                                       "eClass": "diagram:OutsideLabelStyle",
+                                       "id": "601e5a1d-3d8a-49bc-96b9-f0c47ee594ee"
+                                     }
+                                   },
+                                   "eClass": "diagram:OutsideLabelDescription",
+                                   "id": "a8a2bf4c-82b7-4050-b4e7-09fd26a2f7c0"
+                                 }
+                               ],
+                               "childrenLayoutStrategy": {
+                                 "id": "558f8558-bee6-4ae9-8dc7-4344efe2b83e",
+                                 "eClass": "diagram:FreeFormLayoutStrategyDescription"
+                               },
+                               "style": {
+                                 "data": {
+                                    "background": "//@colorPalettes.0/@colors.0",
+                                    "borderColor": "//@colorPalettes.0/@colors.0"
+                                 },
+                                 "eClass": "diagram:RectangularNodeStyleDescription",
+                                 "id": "dacddb12-7c2c-4463-bf71-a7c3e68e2132"
+                               }
+                             }
+                           }
+                         ]
+                       }
+                     }
+                   ]
+                  }
+                }
+              ]
+            }
+            """;
+    @Autowired
+    private IEditingContextSearchService editingContextSearchService;
+
+    @Autowired
+    private IGivenCommittedTransaction givenCommittedTransaction;
+
+    @Autowired
+    private ExecuteEditingContextFunctionRunner executeEditingContextFunctionRunner;
+
+    @Autowired
+    private UploadDocumentMutationRunner uploadDocumentMutationRunner;
+
+    @Autowired
+    private List<IMigrationParticipant> migrationParticipants;
+
+    @Test
+    @DisplayName("Given a project with an old model, DiagramLabelStyleBorderSizeMigrationParticipant migrates the model correctly")
+    @Sql(scripts = { "/scripts/migration.sql" }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenAnOldModelMigrationParticipantCanBeContributedToUpdateTheModel() {
+        var optionalEditingContext = this.editingContextSearchService.findById(MigrationIdentifiers.MIGRATION_DIAGRAM_LABEL_STYLE_BORDER_SIZE_STUDIO.toString());
+        assertThat(optionalEditingContext).isPresent();
+        this.testIsMigrationSuccessful(optionalEditingContext.get());
+    }
+
+    @Test
+    @DisplayName("Given an uploaded project with an old model, DiagramLabelStyleBorderSizeMigrationParticipant migrates the model correctly")
+    @Sql(scripts = { "/scripts/migration.sql" }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    public void givenAnOldViewDiagramMigrationServiceIsExecutedProperly() {
+        this.uploadDocument(MigrationIdentifiers.MIGRATION_DIAGRAM_LABEL_STYLE_BORDER_SIZE_STUDIO.toString(), "test_upload", DOCUMENT_CONTENT);
+    }
+
+    private void uploadDocument(String editingContextId, String name, String content) {
+        this.givenCommittedTransaction.commit();
+
+        var file = new UploadFile(name, new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+        var input = new UploadDocumentInput(UUID.randomUUID(), editingContextId, file);
+        var result = this.uploadDocumentMutationRunner.run(input);
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        String typename = JsonPath.read(result, "$.data.uploadDocument.__typename");
+        assertThat(typename).isEqualTo(UploadDocumentSuccessPayload.class.getSimpleName());
+
+        Predicate<IPayload> predicate = payload -> Optional.of(payload)
+                .filter(ExecuteEditingContextFunctionSuccessPayload.class::isInstance)
+                .map(ExecuteEditingContextFunctionSuccessPayload.class::cast)
+                .map(ExecuteEditingContextFunctionSuccessPayload::result)
+                .filter(Boolean.class::isInstance)
+                .map(Boolean.class::cast)
+                .orElse(false);
+
+        var optionalLastMigrationData = this.migrationParticipants.stream()
+                .sorted(Comparator.comparing(IMigrationParticipant::getVersion).reversed())
+                .map(migrationParticipant -> new MigrationData(migrationParticipant.getClass().getSimpleName(), migrationParticipant.getVersion()))
+                .findFirst();
+        assertThat(optionalLastMigrationData).isPresent();
+        var lastMigrationData = optionalLastMigrationData.get();
+
+        BiFunction<IEditingContext, IInput, IPayload> function = (editingContext, executeEditingContextFunctionInput) -> {
+            var isMigrated = Optional.of(editingContext)
+                    .filter(EditingContext.class::isInstance)
+                    .map(EditingContext.class::cast)
+                    .map(siriusWebEditingContext -> siriusWebEditingContext.getViews().stream()
+                            .anyMatch(view -> view.eResource().eAdapters().stream()
+                                    .filter(ResourceMetadataAdapter.class::isInstance)
+                                    .map(ResourceMetadataAdapter.class::cast)
+                                    .filter(resourceMetadataAdapter -> resourceMetadataAdapter.getMigrationData() != null)
+                                    .anyMatch(resourceMetadataAdapter -> resourceMetadataAdapter.getMigrationData().migrationVersion().equals(lastMigrationData.migrationVersion())
+                                            && resourceMetadataAdapter.getMigrationData().lastMigrationPerformed().equals(lastMigrationData.lastMigrationPerformed()))
+                            ))
+                    .orElse(false);
+            return new ExecuteEditingContextFunctionSuccessPayload(executeEditingContextFunctionInput.id(), isMigrated);
+        };
+
+        var mono = this.executeEditingContextFunctionRunner.execute(new ExecuteEditingContextFunctionInput(UUID.randomUUID(), editingContextId, function));
+        StepVerifier.create(mono)
+                .expectNextMatches(predicate)
+                .thenCancel()
+                .verify();
+    }
+
+    private void testIsMigrationSuccessful(IEditingContext editingContext) {
+        if (editingContext instanceof EditingContext siriusWebEditingContext) {
+            var optionalDiagramDescription = siriusWebEditingContext.getViews().stream().flatMap(view -> view.getDescriptions().stream())
+                    .filter(representationDescription -> representationDescription.getName().equals(MigrationIdentifiers.MIGRATION_DIAGRAM_LABEL_STYLE_BORDER_SIZE_STUDIO_DIAGRAM)).findFirst();
+            assertThat(optionalDiagramDescription).isPresent();
+            assertThat(optionalDiagramDescription.get()).isInstanceOf(DiagramDescription.class);
+            optionalDiagramDescription.ifPresent(representationDescription -> {
+                if (representationDescription instanceof DiagramDescription diagramDescription) {
+                    assertThat(diagramDescription.getNodeDescriptions()).hasSize(1);
+                    diagramDescription.getNodeDescriptions().forEach(nodeDescription -> {
+                        assertThat(nodeDescription.getInsideLabel().getStyle().getBorderSize()).isEqualTo(0);
+                        assertThat(nodeDescription.getOutsideLabels()).hasSize(2);
+                        assertThat(nodeDescription.getOutsideLabels()).allMatch(outsideLabelDescription -> outsideLabelDescription.getStyle().getBorderSize() == 0);
+                    });
+                    assertThat(diagramDescription.getEdgeDescriptions()).hasSize(1);
+                    diagramDescription.getEdgeDescriptions().forEach(edgeDescription -> {
+                        assertThat(edgeDescription.getStyle().getBorderSize()).isEqualTo(0);
+                    });
+                }
+            });
+        }
+    }
+
+}

--- a/packages/sirius-web/backend/sirius-web/src/test/resources/scripts/migration.sql
+++ b/packages/sirius-web/backend/sirius-web/src/test/resources/scripts/migration.sql
@@ -315,6 +315,7 @@ INSERT INTO representation_data (
   '0'
 );
 
+
 INSERT INTO project (
   id,
   name,
@@ -455,6 +456,7 @@ INSERT INTO document (
   '2024-01-01 9:42:0.000',
   '2024-01-02 9:42:0.000'
 );
+
 INSERT INTO representation_data (
   id,
   project_id,
@@ -584,4 +586,186 @@ INSERT INTO representation_data (
   '2024-07-04 9:42:0.000',
   'none',
   '0'
+);
+
+
+INSERT INTO project (
+  id,
+  name,
+  created_on,
+  last_modified_on
+) VALUES (
+  '8ce6147e-1f5b-426f-b1be-dfeabd37a50a',
+  'Migration DiagramLabelStyle#borderSize Studio',
+  '2024-07-01 15:00:0.000',
+  '2024-07-01 15:00:0.000'
+);
+INSERT INTO nature (
+  project_id,
+  name
+) VALUES (
+  '8ce6147e-1f5b-426f-b1be-dfeabd37a50a',
+  'siriusComponents://nature?kind=studio'
+);
+INSERT INTO semantic_data (
+  id,
+  project_id,
+  created_on,
+  last_modified_on
+) VALUES (
+  '65edc1f2-989c-4001-971b-29981179ebfa',
+  '8ce6147e-1f5b-426f-b1be-dfeabd37a50a',
+  '2024-07-01 15:00:0.000',
+  '2024-07-01 15:00:0.000'
+);
+INSERT INTO semantic_data_domain (
+  semantic_data_id,
+  uri
+) VALUES (
+  '65edc1f2-989c-4001-971b-29981179ebfa',
+  'http://www.eclipse.org/sirius-web/view'
+);
+INSERT INTO semantic_data_domain (
+  semantic_data_id,
+  uri
+) VALUES (
+  '65edc1f2-989c-4001-971b-29981179ebfa',
+  'http://www.eclipse.org/sirius-web/diagram'
+);
+INSERT INTO document (
+  id,
+  semantic_data_id,
+  name,
+  content,
+  created_on,
+  last_modified_on
+) VALUES (
+  'fa110225-6b86-4bc1-b707-54c7c995cebf',
+  '65edc1f2-989c-4001-971b-29981179ebfa',
+  'NodeDescription#labelBorderStyle migration',
+  '{
+     "json": { "version": "1.0", "encoding": "utf-8" },
+     "ns": {
+       "diagram": "http://www.eclipse.org/sirius-web/diagram",
+       "view": "http://www.eclipse.org/sirius-web/view"
+     },
+     "content": [
+       {
+         "id": "567668c6-f841-4330-af9c-1a17ef28492b",
+         "eClass": "view:View",
+         "data": {
+           "colorPalettes": [
+             {
+               "data": {
+                 "colors": [
+                   {
+                     "data": {
+                       "name": "color_empty",
+                       "value": ""
+                     },
+                     "eClass": "view:FixedColor",
+                     "id": "19e41e76-e016-4f15-abef-e762956f5275"
+                   }
+                 ]
+               },
+               "eClass": "view:ColorPalette",
+               "id": "8c4140a3-a696-4016-a862-da474028fc2c"
+             }
+           ],
+           "descriptions": [
+             {
+               "id": "c1a0ae1c-8420-4aa7-b443-1a05044076e2",
+               "eClass": "diagram:DiagramDescription",
+               "data": {
+                 "name": "DiagramLabelStyle#borderSize migration",
+                 "domainType": "flow::System",
+                 "edgeDescriptions": [
+                   {
+                     "data": {
+                       "centerLabelExpression": "",
+                       "name": "LabelBorderSize Edge",
+                       "semanticCandidatesExpression": "",
+                       "sourceNodeDescriptions": [
+                         "//@descriptions.0/@nodeDescriptions.0"
+                       ],
+                       "sourceNodesExpression": "aql:self",
+                       "style": {
+                         "data": {
+                           "color": "//@colorPalettes.0/@colors.0"
+                         },
+                         "eClass": "diagram:EdgeStyle",
+                         "id": "748824cb-cd5f-42fe-95a8-4f21172ba2ce"
+                       },
+                       "targetNodeDescriptions": [
+                         "//@descriptions.0/@nodeDescriptions.1"
+                       ],
+                       "targetNodesExpression": "aql:self.linkedTo"
+                     },
+                     "eClass": "diagram:EdgeDescription",
+                     "id": "c1077629-a4ec-4232-8eb5-5209b58c7464"
+                   }
+                 ],
+                 "nodeDescriptions": [
+                   {
+                     "id": "4d1ec4d1-dd2c-4cb2-bbed-df02f0babbd8",
+                     "eClass": "diagram:NodeDescription",
+                     "data": {
+                       "name": "LabelBorderSize migration",
+                       "domainType": "flow::CompositeProcessor",
+                       "insideLabel": {
+                         "data": {
+                           "style": {
+                             "eClass": "diagram:InsideLabelStyle",
+                             "id": "d70178c4-d36f-40d7-a3ab-ef8568e4ee2b"
+                           }
+                         },
+                         "eClass": "diagram:InsideLabelDescription",
+                         "id": "046b48ee-4554-4d8a-a457-5391b690d2a9"
+                       },
+                       "outsideLabels": [
+                         {
+                           "data": {
+                             "style": {
+                               "eClass": "diagram:OutsideLabelStyle",
+                               "id": "c69b0853-26ab-40b0-979d-f0a4974ad865"
+                             }
+                           },
+                           "eClass": "diagram:OutsideLabelDescription",
+                           "id": "fd8638cc-8ebb-48e6-bf3f-2c09206f6a09"
+                         },
+                         {
+                           "data": {
+                             "style": {
+                               "eClass": "diagram:OutsideLabelStyle",
+                               "id": "601e5a1d-3d8a-49bc-96b9-f0c47ee594ee"
+                             }
+                           },
+                           "eClass": "diagram:OutsideLabelDescription",
+                           "id": "a8a2bf4c-82b7-4050-b4e7-09fd26a2f7c0"
+                         }
+                       ],
+                       "childrenLayoutStrategy": {
+                         "id": "558f8558-bee6-4ae9-8dc7-4344efe2b83e",
+                         "eClass": "diagram:FreeFormLayoutStrategyDescription"
+                       },
+                       "style": {
+                         "data": {
+                            "background": "//@colorPalettes.0/@colors.0",
+                            "borderColor": "//@colorPalettes.0/@colors.0"
+                         },
+                         "eClass": "diagram:RectangularNodeStyleDescription",
+                         "id": "dacddb12-7c2c-4463-bf71-a7c3e68e2132"
+                       }
+                     }
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       }
+     ]
+   }',
+  '2024-07-01 15:00:0.000',
+  '2024-07-01 15:00:0.000'
 );

--- a/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/DefaultToolsFactory.java
+++ b/packages/view/backend/sirius-components-view-diagram-edit/src/main/java/org/eclipse/sirius/components/view/diagram/provider/DefaultToolsFactory.java
@@ -22,11 +22,13 @@ import org.eclipse.sirius.components.view.diagram.EdgePalette;
 import org.eclipse.sirius.components.view.diagram.EdgeTool;
 import org.eclipse.sirius.components.view.diagram.EdgeToolSection;
 import org.eclipse.sirius.components.view.diagram.InsideLabelDescription;
+import org.eclipse.sirius.components.view.diagram.InsideLabelStyle;
 import org.eclipse.sirius.components.view.diagram.LabelEditTool;
 import org.eclipse.sirius.components.view.diagram.NodePalette;
 import org.eclipse.sirius.components.view.diagram.NodeTool;
 import org.eclipse.sirius.components.view.diagram.NodeToolSection;
 import org.eclipse.sirius.components.view.diagram.OutsideLabelDescription;
+import org.eclipse.sirius.components.view.diagram.OutsideLabelStyle;
 import org.eclipse.sirius.components.view.diagram.SourceEdgeEndReconnectionTool;
 import org.eclipse.sirius.components.view.diagram.TargetEdgeEndReconnectionTool;
 
@@ -132,13 +134,17 @@ public class DefaultToolsFactory {
 
     public InsideLabelDescription createDefaultInsideLabelDescription() {
         InsideLabelDescription insideLabelDescription = DiagramFactory.eINSTANCE.createInsideLabelDescription();
-        insideLabelDescription.setStyle(DiagramFactory.eINSTANCE.createInsideLabelStyle());
+        InsideLabelStyle style = DiagramFactory.eINSTANCE.createInsideLabelStyle();
+        style.setBorderSize(0);
+        insideLabelDescription.setStyle(style);
         return insideLabelDescription;
     }
 
     public OutsideLabelDescription createDefaultOutsideLabelDescription() {
         OutsideLabelDescription outsideLabelDescription = DiagramFactory.eINSTANCE.createOutsideLabelDescription();
-        outsideLabelDescription.setStyle(DiagramFactory.eINSTANCE.createOutsideLabelStyle());
+        OutsideLabelStyle outsideLabelStyle = DiagramFactory.eINSTANCE.createOutsideLabelStyle();
+        outsideLabelStyle.setBorderSize(0);
+        outsideLabelDescription.setStyle(outsideLabelStyle);
         return outsideLabelDescription;
     }
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/3669

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?