### PR TITLE
[3892] Only persist the editing context on actual changes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,8 +35,7 @@
 === Improvements
 
 - https://github.com/eclipse-sirius/sirius-web/issues/4219[#4219] [table] Improve front-end performance
-
-
+- https://github.com/eclipse-sirius/sirius-web/issues/3892[#3892] [core] Only persist the editing context if there's been actual semantic changes
 
 == v2024.11.0
 

--- a/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/services/JSONResourceFactory.java
+++ b/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/services/JSONResourceFactory.java
@@ -47,6 +47,7 @@ public class JSONResourceFactory extends ResourceFactoryImpl {
 
         var resource = new JsonResourceImpl(uri, options);
         resource.setIntrinsicIDToEObjectMap(new HashMap<>());
+        resource.setTrackingModification(true);
         return resource;
     }
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/editingcontext/services/EditingContextPersistenceService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/editingcontext/services/EditingContextPersistenceService.java
@@ -31,6 +31,8 @@ import org.eclipse.sirius.web.application.editingcontext.services.api.IResourceT
 import org.eclipse.sirius.web.domain.boundedcontexts.project.Project;
 import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.Document;
 import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api.ISemanticDataUpdateService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +49,8 @@ import io.micrometer.core.instrument.Timer;
 public class EditingContextPersistenceService implements IEditingContextPersistenceService {
 
     private static final String TIMER_NAME = "siriusweb_editingcontext_save";
+
+    private final Logger logger = LoggerFactory.getLogger(EditingContextPersistenceService.class);
 
     private final ISemanticDataUpdateService semanticDataUpdateService;
 
@@ -69,7 +73,7 @@ public class EditingContextPersistenceService implements IEditingContextPersiste
     @Override
     @Transactional
     public void persist(ICause cause, IEditingContext editingContext) {
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
 
         if (editingContext instanceof IEMFEditingContext emfEditingContext) {
             var applyMigrationParticipants = this.migrationParticipantPredicates.stream().anyMatch(predicate -> predicate.test(emfEditingContext));
@@ -95,7 +99,8 @@ public class EditingContextPersistenceService implements IEditingContextPersiste
                     });
         }
 
-        long end = System.currentTimeMillis();
-        this.timer.record(end - start, TimeUnit.MILLISECONDS);
+        long durationNs = System.nanoTime() - start;
+        this.timer.record(durationNs, TimeUnit.NANOSECONDS);
+        this.logger.debug("Editing context {} saved in {} ms", editingContext.getId(), TimeUnit.NANOSECONDS.toMillis(durationNs));
     }
 }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/editingcontext/services/ResourceLoader.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/editingcontext/services/ResourceLoader.java
@@ -68,6 +68,7 @@ public class ResourceLoader implements IResourceLoader {
         try (var inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))) {
             resourceSet.getResources().add(resource);
             resource.eAdapters().add(new ResourceMetadataAdapter(name));
+            resource.setTrackingModification(true);
             resource.load(inputStream, options);
 
             optionalResource = Optional.of(resource);


### PR DESCRIPTION
- **[3892] Log editing context save duration on debug**
- **[3892] Only persist the editing context on actual changes**

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?