### PR TITLE
[fix] Fix error reporting when project deletion fails

### DIFF
--- a/packages/sirius-web/frontend/sirius-web-application/src/modals/delete-project/useDeleteProject.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/modals/delete-project/useDeleteProject.ts
@@ -42,7 +42,7 @@ export const useDeleteProject = (): UseDeleteProjectValue => {
     GQLDeleteProjectMutationVariables
   >(deleteProjectMutation);
 
-  const { addErrorMessage, addMessages } = useMultiToast();
+  const { addErrorMessage } = useMultiToast();
   useEffect(() => {
     if (error) {
       addErrorMessage('An unexpected error has occurred, please refresh the page');
@@ -50,7 +50,7 @@ export const useDeleteProject = (): UseDeleteProjectValue => {
     if (data) {
       const { deleteProject } = data;
       if (isErrorPayload(deleteProject)) {
-        addMessages(deleteProject.messages);
+        addErrorMessage(deleteProject.message);
       }
     }
   }, [data, error]);

--- a/packages/sirius-web/frontend/sirius-web-application/src/modals/delete-project/useDeleteProject.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/modals/delete-project/useDeleteProject.types.ts
@@ -11,8 +11,6 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { GQLMessage } from '@eclipse-sirius/sirius-components-core';
-
 export interface UseDeleteProjectValue {
   deleteProject: (projectId: string) => void;
   loading: boolean;
@@ -28,7 +26,7 @@ export interface GQLDeleteProjectPayload {
 }
 
 export interface GQLErrorPayload extends GQLDeleteProjectPayload {
-  messages: GQLMessage[];
+  message: string;
 }
 
 export interface GQLDeleteProjectMutationVariables {


### PR DESCRIPTION
Since the move to DDD, `MutationDeleteProjectDataFetcher` invokes `IProjectApplicationService.deleteProject()` directly, who return an `ErrorPayload` with a _single_ message on failure.
