### PR TITLE
[4096] Allow to trigger direct edit on paste

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -93,6 +93,8 @@ never, always and if_children (to display the separator only if children exist).
 - https://github.com/eclipse-sirius/sirius-web/issues/3856[#3856] [trees] Add tree representation in the view DSL
 - https://github.com/eclipse-sirius/sirius-web/issues/4000[#4000] [trees] Add support for styled labels in view model for trees
 - https://github.com/eclipse-sirius/sirius-web/issues/4037[#4037] [trees] Add mechanism to define actions in tree item context menu
+- https://github.com/eclipse-sirius/sirius-web/issues/4069[#4096] [diagrams] Allow to trigger direct edit on paste
+Hitting `ctrl + v` (or `meta + v`) on a node with a direct edit tool now triggers the direct edit and initializes it with the content of the clipboard.
 
 == v2024.9.0
 

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/Label.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/Label.tsx
@@ -110,7 +110,7 @@ const labelOverflowStyle = (label: EdgeLabel | InsideLabel | OutsideLabel): Reac
 
 export const Label = memo(({ diagramElementId, label, faded }: LabelProps) => {
   const theme: Theme = useTheme();
-  const { currentlyEditedLabelId, editingKey, resetDirectEdit } = useDiagramDirectEdit();
+  const { currentlyEditedLabelId, editingInput, resetDirectEdit } = useDiagramDirectEdit();
   const { readOnly } = useContext<DiagramContextValue>(DiagramContext);
 
   const handleClose = () => {
@@ -123,7 +123,7 @@ export const Label = memo(({ diagramElementId, label, faded }: LabelProps) => {
 
   const content: JSX.Element =
     label.id === currentlyEditedLabelId && !readOnly ? (
-      <DiagramDirectEditInput editingKey={editingKey} onClose={handleClose} labelId={label.id} />
+      <DiagramDirectEditInput editingInput={editingInput} onClose={handleClose} labelId={label.id} />
     ) : (
       <div
         data-id={`${label.id}-content`}

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/DiagramDirectEditContext.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/DiagramDirectEditContext.tsx
@@ -21,7 +21,7 @@ import {
 const defaultValue: DiagramDirectEditContextValue = {
   currentlyEditedLabelId: null,
   directEditTrigger: null,
-  editingKey: null,
+  editingInput: null,
   setCurrentlyEditedLabelId: () => {},
   resetDirectEdit: () => {},
 };
@@ -32,12 +32,12 @@ export const DiagramDirectEditContextProvider = ({ children }: DiagramDirectEdit
   const [state, setState] = useState<DiagramDirectEditContextProviderState>({
     currentlyEditedLabelId: null,
     directEditTrigger: null,
-    editingKey: null,
+    editingInput: null,
   });
 
   const setCurrentlyEditedLabelId = useCallback(
-    (directEditTrigger: DirectEditTrigger, currentlyEditedLabelId: string, editingKey: string | null) => {
-      setState((prevState) => ({ ...prevState, currentlyEditedLabelId, directEditTrigger, editingKey }));
+    (directEditTrigger: DirectEditTrigger, currentlyEditedLabelId: string, editingInput: string | null) => {
+      setState((prevState) => ({ ...prevState, currentlyEditedLabelId, directEditTrigger, editingInput }));
     },
     []
   );
@@ -48,7 +48,7 @@ export const DiagramDirectEditContextProvider = ({ children }: DiagramDirectEdit
         ...prevState,
         currentlyEditedLabelId: null,
         directEditTrigger: null,
-        editingKey: null,
+        editingInput: null,
       })),
     []
   );
@@ -58,7 +58,7 @@ export const DiagramDirectEditContextProvider = ({ children }: DiagramDirectEdit
       value={{
         currentlyEditedLabelId: state.currentlyEditedLabelId,
         directEditTrigger: state.directEditTrigger,
-        editingKey: state.editingKey,
+        editingInput: state.editingInput,
         setCurrentlyEditedLabelId,
         resetDirectEdit,
       }}>

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/DiagramDirectEditContext.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/DiagramDirectEditContext.types.ts
@@ -13,17 +13,17 @@
 
 export interface DiagramDirectEditContextValue {
   currentlyEditedLabelId: string | null;
-  editingKey: string | null;
+  editingInput: string | null;
   directEditTrigger: DirectEditTrigger | null;
   setCurrentlyEditedLabelId: (
     directEditTrigger: DirectEditTrigger,
     currentlyEditedLabelId: string,
-    editingKey: string | null
+    editingInput: string | null
   ) => void;
   resetDirectEdit: () => void;
 }
 
-export type DirectEditTrigger = 'keyDown' | 'F2' | 'palette' | 'doubleClick';
+export type DirectEditTrigger = 'keyDown' | 'F2' | 'palette' | 'doubleClick' | 'paste';
 
 export interface DiagramDirectEditContextProviderProps {
   children?: React.ReactNode;
@@ -31,6 +31,6 @@ export interface DiagramDirectEditContextProviderProps {
 
 export interface DiagramDirectEditContextProviderState {
   currentlyEditedLabelId: string | null;
-  editingKey: string | null;
+  editingInput: string | null;
   directEditTrigger: DirectEditTrigger | null;
 }

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/DiagramDirectEditInput.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/DiagramDirectEditInput.tsx
@@ -73,8 +73,8 @@ const isErrorPayload = (payload: GQLRenameElementPayload): payload is GQLErrorPa
 const isSuccessPayload = (payload: GQLRenameElementPayload): payload is GQLSuccessPayload =>
   payload.__typename === 'EditLabelSuccessPayload';
 
-export const DiagramDirectEditInput = ({ labelId, editingKey, onClose }: DiagramDirectEditInputProps) => {
-  const initialLabel = editingKey === null || editingKey === '' ? '' : editingKey;
+export const DiagramDirectEditInput = ({ labelId, editingInput, onClose }: DiagramDirectEditInputProps) => {
+  const initialLabel = editingInput === null || editingInput === '' ? '' : editingInput;
   const [state, setState] = useState<DiagramDirectEditInputState>({
     newLabel: initialLabel,
   });
@@ -132,7 +132,7 @@ export const DiagramDirectEditInput = ({ labelId, editingKey, onClose }: Diagram
     if (initialLabelItemData?.viewer.editingContext.representation.description.initialDirectEditElementLabel) {
       const initialLabel =
         initialLabelItemData?.viewer.editingContext.representation.description.initialDirectEditElementLabel;
-      if (!editingKey) {
+      if (!editingInput) {
         setState((prevState) => {
           return { ...prevState, newLabel: initialLabel };
         });

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/DiagramDirectEditInput.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/DiagramDirectEditInput.types.ts
@@ -14,7 +14,7 @@ import { GQLMessage } from '../Tool.types';
 
 export interface DiagramDirectEditInputProps {
   labelId: string;
-  editingKey: string | null;
+  editingInput: string | null;
   onClose: () => void;
 }
 

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/useDiagramDirectEdit.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/useDiagramDirectEdit.tsx
@@ -22,7 +22,7 @@ import { UseDiagramDirectEditValue } from './useDiagramDirectEdit.types';
 const directEditActivationValidCharacters = /[\w&é§èàùçÔØÁÛÊË"«»<>’”„´$¥€£\\¿?!=+-,;:%/{}[\]–#@*.]/;
 
 export const useDiagramDirectEdit = (): UseDiagramDirectEditValue => {
-  const { currentlyEditedLabelId, editingKey, setCurrentlyEditedLabelId, resetDirectEdit } =
+  const { currentlyEditedLabelId, editingInput, setCurrentlyEditedLabelId, resetDirectEdit } =
     useContext<DiagramDirectEditContextValue>(DiagramDirectEditContext);
   const { getNodes, getEdges } = useReactFlow<NodeData, EdgeData>();
   const { readOnly } = useContext<DiagramContextValue>(DiagramContext);
@@ -39,6 +39,8 @@ export const useDiagramDirectEdit = (): UseDiagramDirectEditValue => {
       event.preventDefault();
       const validFirstInputChar =
         !event.metaKey && !event.ctrlKey && key.length === 1 && directEditActivationValidCharacters.test(key);
+
+      const isPasteFromClipboard = (event.ctrlKey || event.metaKey) && key === 'v';
 
       let currentlyEditedLabelId: string | undefined | null;
       let isLabelEditable: boolean = false;
@@ -60,6 +62,10 @@ export const useDiagramDirectEdit = (): UseDiagramDirectEditValue => {
           setCurrentlyEditedLabelId('keyDown', currentlyEditedLabelId, key);
         } else if (key === 'F2') {
           setCurrentlyEditedLabelId('F2', currentlyEditedLabelId, null);
+        } else if (isPasteFromClipboard) {
+          navigator.clipboard
+            .readText()
+            .then((text) => setCurrentlyEditedLabelId('paste', currentlyEditedLabelId, text));
         }
       }
     },
@@ -68,7 +74,7 @@ export const useDiagramDirectEdit = (): UseDiagramDirectEditValue => {
 
   return {
     currentlyEditedLabelId,
-    editingKey,
+    editingInput,
     setCurrentlyEditedLabelId,
     resetDirectEdit,
     onDirectEdit,

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/useDiagramDirectEdit.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/direct-edit/useDiagramDirectEdit.types.ts
@@ -16,11 +16,11 @@ import { DirectEditTrigger } from './DiagramDirectEditContext.types';
 export interface UseDiagramDirectEditValue {
   onDirectEdit: (event: React.KeyboardEvent<Element>) => void;
   currentlyEditedLabelId: string | null;
-  editingKey: string | null;
+  editingInput: string | null;
   setCurrentlyEditedLabelId: (
     directEditTrigger: DirectEditTrigger,
     currentlyEditedLabelId: string,
-    editingKey: string | null
+    editingInput: string | null
   ) => void;
   resetDirectEdit: () => void;
 }


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4069

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
- Open a flow diagram
- Copy some text in your clipboard
- Select an element on the flow diagram
- Hit `ctrl + v` (or `meta + v` on MacOS)
- The direct edit of the selected element should trigger and should be initialized with the content of the clipboard

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?