### PR TITLE
[doc] Add ADR on undo redo semantic changes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,7 +16,8 @@
 
 - [ADR-158] Support delegating representation event handling
 - [ADR-159] Create event processor only using the representation id
-- [ADR-XXX] Persist label position in diagram
+- [ADR-160] Persist label position in diagram
+- [ADR-161] Add support for undo redo on semantic changes
 
 === Deprecation warning
 

--- a/doc/adrs/160_persist_label_position_in_diagram.adoc
+++ b/doc/adrs/160_persist_label_position_in_diagram.adoc
@@ -1,4 +1,4 @@
-= [ADR-XXX] Persist label position in diagram
+= [ADR-160] Persist label position in diagram
 
 == Context
 

--- a/doc/adrs/161_add_support_for_undo_redo_on_semantic_changes_in_representations.adoc
+++ b/doc/adrs/161_add_support_for_undo_redo_on_semantic_changes_in_representations.adoc
@@ -1,0 +1,158 @@
+= [ADR-161] Add support for undo redo on semantic changes
+
+== Context
+
+We want to be able to undo or redo an action performed.
+
+
+=== Current behavior
+
+None.
+
+
+== Decision
+
+=== Frontend
+
+We will store the `ids` of each `mutation` performed by the front-end using `ApolloLink API` in two arrays to track available undo or redo.
+
+[source,typescript]
+----
+export class OperationCountLink extends ApolloLink {
+  constructor() {
+    super();
+  }
+  override request(operation: Operation, forward) {
+    if (
+      operation.query.definitions[0].kind === Kind.OPERATION_DEFINITION &&
+      operation.query.definitions[0].operation === OperationTypeNode.MUTATION &&
+      operation.variables.input.id &&
+      !(
+        operation.operationName === 'undo' ||
+        operation.operationName === 'redo'
+      )
+    ) {
+      var storedUndoStack = sessionStorage.getItem('undoStack');
+      var undoStack = JSON.parse(storedUndoStack);
+
+      sessionStorage.setItem('undoStack', JSON.stringify([operation.variables.input.id, ...undoStack]));
+      sessionStorage.setItem('redoStack', JSON.stringify([]));
+    }
+
+    return forward(operation);
+  }
+}
+----
+
+We will add two `event handlers` to handle `ctrl + z` and `ctrl + y` to respectively `undo` or `redo` a mutation.
+Theses event handler will send an undo or redo mutation to the back-end with the `id of the mutation` previously responsible for a `semantic change`.
+
+[source,typescript]
+----
+const undoLastAction = () => {
+var storedArray = sessionStorage.getItem('undoStack');
+if (storedArray) {
+    var arr = JSON.parse(storedArray);
+    if (arr[0]) {
+    const input: GQLUndoInput = {
+        id: crypto.randomUUID(),
+        editingContextId: projectId,
+        mutationInputId: arr[0],
+    };
+    undo({ variables: { input } });
+    }
+}
+};
+----
+
+* When performing a undo or redo, the arrays are updated to reflect the available undo or redo actions.
+* When performing a new mutation, the redo mutation array will be cleared.
+
+=== Backend
+
+* In order to track changes and `undo` or `redo` a semantic change on elements of a resource, we will use the `org.eclipse.emf.ecore.change` API.
+* We will leverage `IInputPreProcessor` and `IInputPostProcessor` API to trigger the tracking of semantic changes caused by a mutation.
+
+[source,java]
+----
+@Service
+public class UndoRedoRecorder implements IInputPreProcessor, IInputPostProcessor {
+
+    @Override
+    public IInput preProcess(IEditingContext editingContext, IInput input, Sinks.Many<ChangeDescription> changeDescriptionSink) {
+        if (editingContext instanceof IEMFEditingContext emfEditingContext && input instanceof UndoableInput) {
+            // ...
+            changeRecorder.beginRecording(emfEditingContext.getDomain().getResourceSet().getResources());
+        }
+
+        return input;
+    }
+
+    @Override
+    public void postProcess(IEditingContext editingContext, IInput input, Sinks.Many<ChangeDescription> changeDescriptionSink) {
+        if (editingContext instanceof IEMFEditingContext emfEditingContext && input instanceof UndoableInput) {
+            // ...
+            var change = changeRecorder.summarize();
+            inputId2change.put(input.id().toString(), changeDescription);
+            changeRecorder.endRecording();
+        }
+    }
+}
+----
+
+We can apply either undo or redo with the `applyAndReverse` method.
+
+[source,java]
+----
+@Service
+public class UndoEventHandler implements IEditingContextEventHandler {
+
+    @Override
+    public boolean canHandle(IEditingContext editingContext, IInput input) {
+        return input instanceof UndoInput;
+    }
+
+    @Override
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, IInput input) {
+        IPayload payload = new ErrorPayload(input.id(), "Error ");
+        ChangeDescription changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, editingContext.getId(), input);
+        if (editingContext instanceof EditingContext siriusEditingContext && input instanceof UndoInput undoInput) {
+            // ...
+            change.applyAndReverse();
+            payload = new SuccessPayload(input.id());
+        }
+        payloadSink.tryEmitValue(payload);
+        changeDescriptionSink.tryEmitNext(changeDescription);
+    }
+
+}
+----
+
+We don't have a clear way to identify the input that we need to consider.
+We need to make the distinction to avoid storing too much informations, as such we will introduce a new interface:
+
+[source,java]
+----
+public interface IUndoableInput extends IInput {
+}
+----
+
+=== Things to improve
+
+The `org.eclipse.emf.ecore.change` API does not handle the `deletion` and `restoration` of a `resource` by default but only the changes on the `EObjects` contained in the resource.
+
+== Status
+
+Work in progress
+
+
+== Consequences
+
+All existing mutation `Input` that we want to consider will need to implement `IUndoableInput`.
+
+
+
+
+
+
+


### PR DESCRIPTION
# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [x] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?