### PR TITLE
[1062] Allow expand/collapse of tree items without selecting them

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -50,6 +50,8 @@ This provider is in charge of getting the icon list of the representation.
 === Bug fixes
 
 - https://github.com/eclipse-sirius/sirius-web/issues/4195[#4195] [sirius-web] Prevent objects disappearing when dropped on themselves (or a descendant) in the _Explorer_.
+- https://github.com/eclipse-sirius/sirius-web/issues/1062[#1062] [explorer] It is now possible to expand or collapse items in the explorer without selecting them by clicking directly on the expand/collapse arrow icon.
+This was first fixed in 2022.3.0 but broken in 2024.3.0; it is now fixed again.
 
 
 === New Features

--- a/integration-tests/cypress/e2e/project/details/widget-reference.cy.ts
+++ b/integration-tests/cypress/e2e/project/details/widget-reference.cy.ts
@@ -31,9 +31,9 @@ describe('Details - Widget-reference', () => {
 
     it('then diagnostic messages are display on widget reference', () => {
       const explorer = new Explorer();
-      explorer.expand('Flow');
-      explorer.expand('NewSystem');
-      explorer.expand('DataSource1');
+      explorer.expandWithDoubleClick('Flow');
+      explorer.expandWithDoubleClick('NewSystem');
+      explorer.expandWithDoubleClick('DataSource1');
       explorer.select('standard');
       const details = new Details();
       details.getReferenceWidget('Target').find('p[class*="Mui-error"]').should('not.exist');
@@ -64,9 +64,9 @@ describe('Details - Widget-reference', () => {
     after(() => cy.deleteProject(studioProjectId));
     it('check widget reference click navigation to filter tree item', () => {
       const explorer = new Explorer();
-      explorer.expand(domainName);
-      explorer.expand('Entity1');
-      explorer.expand('Entity2');
+      explorer.expandWithDoubleClick(domainName);
+      explorer.expandWithDoubleClick('Entity1');
+      explorer.expandWithDoubleClick('Entity2');
       explorer.select('linkedTo');
       cy.getByTestId('reference-value-Entity2').should('exist');
 

--- a/integration-tests/cypress/e2e/project/diagrams/arrange-all.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/arrange-all.cy.ts
@@ -26,8 +26,8 @@ describe('Diagram - arrange all', () => {
         project.visit(projectId);
         project.disableDeletionConfirmationDialog();
         const explorer = new Explorer();
-        explorer.expand('Flow');
-        explorer.expand('NewSystem');
+        explorer.expandWithDoubleClick('Flow');
+        explorer.expandWithDoubleClick('NewSystem');
         explorer.selectRepresentation('Topography');
       });
     });
@@ -37,7 +37,7 @@ describe('Diagram - arrange all', () => {
     it('Check arrange all do not marked node as resizedByUser', () => {
       const diagram = new Diagram();
       const explorer = new Explorer();
-      explorer.expand('CompositeProcessor1');
+      explorer.expandWithDoubleClick('CompositeProcessor1');
       explorer.rename('Processor1', 'CPU');
       diagram.getNodes('Topography', 'CPU').should('exist');
       diagram.arrangeAll();

--- a/integration-tests/cypress/e2e/project/diagrams/collapse.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/collapse.cy.ts
@@ -36,23 +36,23 @@ describe('Diagram - collapsible node', () => {
 
           const explorer = new Explorer();
           const details = new Details();
-          explorer.expand('DomainNewModel');
+          explorer.expandWithDoubleClick('DomainNewModel');
           cy.get('[title="domain::Domain"]').then(($div) => {
             domainName = $div.data().testid;
-            explorer.expand(domainName);
+            explorer.expandWithDoubleClick(domainName);
             explorer.createObject('Entity1', 'relations-Relation');
             details.getCheckBox('Containment').check();
             details.openReferenceWidgetOptions('Target Type');
             details.selectReferenceWidgetOption('Entity2');
-            explorer.expand('ViewNewModel');
-            explorer.expand('View');
-            explorer.expand(`${domainName} Diagram Description`);
+            explorer.expandWithDoubleClick('ViewNewModel');
+            explorer.expandWithDoubleClick('View');
+            explorer.expandWithDoubleClick(`${domainName} Diagram Description`);
             explorer.select('Entity1 Node');
             details.getCheckBox('Collapsible').check();
             details.openReferenceWidgetOptions('Reused Child Node Descriptions');
             details.selectReferenceWidgetOption('Entity2 Node');
-            explorer.expand('Entity1 Node');
-            explorer.expand('aql:self.name');
+            explorer.expandWithDoubleClick('Entity1 Node');
+            explorer.expandWithDoubleClick('aql:self.name');
             explorer.select('InsideLabelStyle');
             details.getCheckBox('With Header').check();
             details.getCheckBox('Display Header Separator').check();

--- a/integration-tests/cypress/e2e/project/diagrams/direct-edit-label.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/direct-edit-label.cy.ts
@@ -38,11 +38,11 @@ describe('Diagram - Direct edit label', () => {
           explorer.getTreeItemByLabel('DomainNewModel').dblclick();
           cy.get('[title="domain::Domain"]').then(($div) => {
             domainName = $div.data().testid;
-            explorer.expand('ViewNewModel');
-            explorer.expand('View');
-            explorer.expand(`${domainName} Diagram Description`);
-            explorer.expand('Entity1 Node');
-            explorer.expand('NodePalette');
+            explorer.expandWithDoubleClick('ViewNewModel');
+            explorer.expandWithDoubleClick('View');
+            explorer.expandWithDoubleClick(`${domainName} Diagram Description`);
+            explorer.expandWithDoubleClick('Entity1 Node');
+            explorer.expandWithDoubleClick('NodePalette');
             explorer.delete('Edit Label');
             explorer.select('LinkedTo Edge');
             new Details().getTextField('Center Label Expression').type('Edge center{enter}');

--- a/integration-tests/cypress/e2e/project/diagrams/drop-on-diagram.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/drop-on-diagram.cy.ts
@@ -34,7 +34,7 @@ describe('/projects/:projectId/edit - Diagram', () => {
     // We should look again at this test with a more recent cypress version.
     it.skip('Then we can create views by Drag and Drop on an unsynchronized diagram', () => {
       const explorer = new Explorer();
-      explorer.expand('robot');
+      explorer.expandWithDoubleClick('robot');
       explorer.createRepresentation('System', 'Topography unsynchronized', 'diagram');
 
       const diagram = new Diagram();

--- a/integration-tests/cypress/e2e/project/diagrams/edges.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/edges.cy.ts
@@ -11,11 +11,11 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { Project } from '../../../pages/Project';
+import { Flow } from '../../../usecases/Flow';
 import { Studio } from '../../../usecases/Studio';
 import { Details } from '../../../workbench/Details';
 import { Diagram } from '../../../workbench/Diagram';
 import { Explorer } from '../../../workbench/Explorer';
-import { Flow } from '../../../usecases/Flow';
 
 describe('Diagram - edges', () => {
   context.skip('Given a studio template', () => {
@@ -27,20 +27,20 @@ describe('Diagram - edges', () => {
         studioProjectId = createdProjectData.projectId;
         new Project().visit(createdProjectData.projectId);
         const explorer = new Explorer();
-        explorer.expand('DomainNewModel');
+        explorer.expandWithDoubleClick('DomainNewModel');
         cy.get('[title="domain::Domain"]').then(($div) => {
           domainName = $div.data().testid;
-          explorer.expand(`${domainName}`);
+          explorer.expandWithDoubleClick(`${domainName}`);
           explorer.createObject('Entity1', 'relations-Relation');
           const details = new Details();
           details.getCheckBox('Containment').check();
           details.openReferenceWidgetOptions('Target Type');
           details.selectReferenceWidgetOption('Entity2');
 
-          explorer.expand('ViewNewModel');
-          explorer.expand('View');
-          explorer.expand(`${domainName} Diagram Description`);
-          explorer.expand('Entity1 Node');
+          explorer.expandWithDoubleClick('ViewNewModel');
+          explorer.expandWithDoubleClick('View');
+          explorer.expandWithDoubleClick(`${domainName} Diagram Description`);
+          explorer.expandWithDoubleClick('Entity1 Node');
           details.openReferenceWidgetOptions('Reused Child Node Descriptions');
           details.selectReferenceWidgetOption('Entity2 Node');
           details.getTextField('Default Width Expression').type('290{enter}');
@@ -102,14 +102,14 @@ describe('Diagram - edges', () => {
         project.disableDeletionConfirmationDialog();
         const explorer = new Explorer();
         const details = new Details();
-        explorer.expand('DomainNewModel');
+        explorer.expandWithDoubleClick('DomainNewModel');
         cy.get('[title="domain::Domain"]').then(($div) => {
           domainName = $div.data().testid;
 
-          explorer.expand('ViewNewModel');
-          explorer.expand('View');
-          explorer.expand(`${domainName} Diagram Description`);
-          explorer.expand('Entity1 Node');
+          explorer.expandWithDoubleClick('ViewNewModel');
+          explorer.expandWithDoubleClick('View');
+          explorer.expandWithDoubleClick(`${domainName} Diagram Description`);
+          explorer.expandWithDoubleClick('Entity1 Node');
           details.getTextField('Default Width Expression').type('300{enter}');
           details.getTextField('Default Height Expression').type('50{enter}');
           explorer.delete('RectangularNodeStyleDescription');
@@ -180,7 +180,7 @@ describe('Diagram - edges', () => {
         project.disableDeletionConfirmationDialog();
         const explorer = new Explorer();
         const details = new Details();
-        explorer.expand('DomainNewModel');
+        explorer.expandWithDoubleClick('DomainNewModel');
         cy.get('[title="domain::Domain"]').then(($div) => {
           domainName = $div.data().testid;
           explorer.createObject(domainName, 'Entity');
@@ -201,10 +201,10 @@ describe('Diagram - edges', () => {
           details.selectReferenceWidgetOption('Entity2');
           details.getTextField('Name').type('{selectAll}entity2{enter}');
 
-          explorer.expand('ViewNewModel');
-          explorer.expand('View');
-          explorer.expand(`${domainName} Diagram Description`);
-          explorer.expand('Entity1 Node');
+          explorer.expandWithDoubleClick('ViewNewModel');
+          explorer.expandWithDoubleClick('View');
+          explorer.expandWithDoubleClick(`${domainName} Diagram Description`);
+          explorer.expandWithDoubleClick('Entity1 Node');
           details.openReferenceWidgetOptions('Reused Child Node Descriptions');
           details.selectReferenceWidgetOption('Entity2 Node');
           details.getTextField('Default Width Expression').type('300{enter}');
@@ -295,8 +295,8 @@ describe('Diagram - edges', () => {
         const project = new Project();
         project.visit(projectId);
         const explorer = new Explorer();
-        explorer.expand('Flow');
-        explorer.expand('NewSystem');
+        explorer.expandWithDoubleClick('Flow');
+        explorer.expandWithDoubleClick('NewSystem');
         explorer.selectRepresentation('Topography');
       });
     });
@@ -306,7 +306,7 @@ describe('Diagram - edges', () => {
     it('Check bend points are available when selecting an edge', () => {
       const diagram = new Diagram();
       const explorer = new Explorer();
-      explorer.expand('DataSource1');
+      explorer.expandWithDoubleClick('DataSource1');
       diagram.getNodes('Topography', 'DataSource1').should('exist');
       explorer.select('standard');
       cy.getByTestId('bend-point-0');

--- a/integration-tests/cypress/e2e/project/diagrams/graphical-dnd.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/graphical-dnd.cy.ts
@@ -27,10 +27,10 @@ describe.skip('Diagram - Graphical-dnd', () => {
         studioProjectId = createdProjectData.projectId;
         new Project().visit(createdProjectData.projectId);
         const explorer = new Explorer();
-        explorer.expand('DomainNewModel');
+        explorer.expandWithDoubleClick('DomainNewModel');
         cy.get('[title="domain::Domain"]').then(($div) => {
           domainName = $div.data().testid;
-          explorer.expand(`${domainName}`);
+          explorer.expandWithDoubleClick(`${domainName}`);
         });
       })
     );
@@ -49,10 +49,10 @@ describe.skip('Diagram - Graphical-dnd', () => {
         details.openReferenceWidgetOptions('Target Type');
         details.selectReferenceWidgetOption('Entity1');
 
-        explorer.expand('ViewNewModel');
-        explorer.expand('View');
-        explorer.expand(`${domainName} Diagram Description`);
-        explorer.expand('Entity2 Node');
+        explorer.expandWithDoubleClick('ViewNewModel');
+        explorer.expandWithDoubleClick('View');
+        explorer.expandWithDoubleClick(`${domainName} Diagram Description`);
+        explorer.expandWithDoubleClick('Entity2 Node');
         details.openReferenceWidgetOptions('Reused Child Node Descriptions');
         details.selectReferenceWidgetOption('Entity1 Node');
         explorer.createObject('NodePalette', 'dropNodeTool-DropNodeTool');

--- a/integration-tests/cypress/e2e/project/diagrams/group-palette.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/group-palette.cy.ts
@@ -25,7 +25,7 @@ describe('Diagram - group palette', () => {
         new Project().visit(projectId);
       });
       const explorer = new Explorer();
-      explorer.expand('robot');
+      explorer.expandWithDoubleClick('robot');
       explorer.createRepresentation('System', 'Topography', 'diagram');
     });
 

--- a/integration-tests/cypress/e2e/project/diagrams/node-aspect-ratio.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/node-aspect-ratio.cy.ts
@@ -26,10 +26,10 @@ describe('Diagram - Node aspect ratio', () => {
         studioProjectId = createdProjectData.projectId;
         new Project().visit(createdProjectData.projectId);
         const explorer = new Explorer();
-        explorer.expand('DomainNewModel');
+        explorer.expandWithDoubleClick('DomainNewModel');
         cy.get('[title="domain::Domain"]').then(($div) => {
           domainName = $div.data().testid;
-          explorer.expand(`${domainName}`);
+          explorer.expandWithDoubleClick(`${domainName}`);
         });
       })
     );
@@ -42,9 +42,9 @@ describe('Diagram - Node aspect ratio', () => {
 
       it('Then node default size is used for node creation', () => {
         const explorer = new Explorer();
-        explorer.expand('ViewNewModel');
-        explorer.expand('View');
-        explorer.expand(`${domainName} Diagram Description`);
+        explorer.expandWithDoubleClick('ViewNewModel');
+        explorer.expandWithDoubleClick('View');
+        explorer.expandWithDoubleClick(`${domainName} Diagram Description`);
         explorer.select('Entity1 Node');
         const details = new Details();
         details.getTextField('Default Width Expression').type('200');
@@ -97,9 +97,9 @@ describe('Diagram - Node aspect ratio', () => {
           details.openReferenceWidgetOptions('Target Type');
           details.selectReferenceWidgetOption('SubNode');
 
-          explorer.expand('ViewNewModel');
-          explorer.expand('View');
-          explorer.expand(`${domainName} Diagram Description`);
+          explorer.expandWithDoubleClick('ViewNewModel');
+          explorer.expandWithDoubleClick('View');
+          explorer.expandWithDoubleClick(`${domainName} Diagram Description`);
 
           explorer.createObject(`${domainName} Diagram Description`, 'nodeDescriptions-NodeDescription');
 

--- a/integration-tests/cypress/e2e/project/explorer/explorer-dnd.cy.ts
+++ b/integration-tests/cypress/e2e/project/explorer/explorer-dnd.cy.ts
@@ -31,17 +31,17 @@ describe('Explorer', () => {
     context('When we drop tree item in the explorer', () => {
       it('Then the object are moved', () => {
         const explorer = new Explorer();
-        explorer.expand('robot');
-        explorer.expand('System');
-        explorer.expand('Central_Unit');
+        explorer.expandWithDoubleClick('robot');
+        explorer.expandWithDoubleClick('System');
+        explorer.expandWithDoubleClick('Central_Unit');
         explorer.getTreeItemByLabel('Radar').should('not.exist');
 
-        explorer.expand('CompositeProcessor');
+        explorer.expandWithDoubleClick('CompositeProcessor');
         const dataTransfer = new DataTransfer();
         explorer.dragTreeItem('Radar', dataTransfer);
         explorer.dopOnTreeItem('Central_Unit', dataTransfer);
-        explorer.collapse('CompositeProcessor');
-        
+        explorer.collapseWithDoubleClick('CompositeProcessor');
+
         explorer.getTreeItemByLabel('Radar').should('exist');
       });
     });

--- a/integration-tests/cypress/e2e/project/explorer/explorer-selection.cy.ts
+++ b/integration-tests/cypress/e2e/project/explorer/explorer-selection.cy.ts
@@ -26,7 +26,7 @@ describe('/projects/:projectId/edit - Tree toolbar', () => {
         new Project().visit(projectId);
       });
       const explorer = new Explorer();
-      explorer.expand('robot');
+      explorer.expandWithDoubleClick('robot');
       explorer.createRepresentation('System', 'Topography', 'diagram');
 
       new Diagram().getNodes('diagram', 'Wifi').should('exist');

--- a/integration-tests/cypress/e2e/project/explorer/explorer.cy.ts
+++ b/integration-tests/cypress/e2e/project/explorer/explorer.cy.ts
@@ -30,15 +30,79 @@ describe('Explorer', () => {
     afterEach(() => cy.deleteProject(projectId));
 
     context('When we interact with the explorer', () => {
-      it.skip('Then we can navigate through the explorer using keyboard arrows', () => {
+      it('Then we can expand and collapse an item with double click', () => {
         const explorer = new Explorer();
-        explorer.expand('robot');
+        explorer.expandWithDoubleClick('robot');
         explorer.getTreeItemByLabel('System').should('exist');
 
-        explorer.expand('Robot');
+        explorer.expandWithDoubleClick('System');
         explorer.getTreeItemByLabel('Central_Unit').should('exist');
-        explorer.getTreeItemByLabel('CaptureSubSystem').should('exist');
+        explorer.getTreeItemByLabel('CompositeProcessor').should('exist');
         explorer.getTreeItemByLabel('Wifi').should('exist');
+
+        explorer.collapseWithDoubleClick('System');
+        explorer.getTreeItemByLabel('Central_Unit').should('not.exist');
+        explorer.getTreeItemByLabel('CompositeProcessor').should('not.exist');
+        explorer.getTreeItemByLabel('Wifi').should('not.exist');
+      });
+
+      it('Then we can expand and collapse an item without selecting it by clicking on the toggle', () => {
+        const explorer = new Explorer();
+        explorer.expandWithDoubleClick('robot');
+        explorer.getTreeItemByLabel('System').should('exist');
+        explorer.select('robot');
+        explorer.getSelectedTreeItems().should('have.length', 1);
+        explorer.getSelectedTreeItems().contains('robot').should('exist');
+
+        // Expand 'System' using the toggle
+        explorer.toggle('System');
+        // Check that its children are visible (i.e. it is correcly expanded)
+        explorer.getTreeItemByLabel('Central_Unit').should('exist');
+        explorer.getTreeItemByLabel('CompositeProcessor').should('exist');
+        explorer.getTreeItemByLabel('Wifi').should('exist');
+        // Check that this has not changed the selection (still on 'robot')
+        explorer.getSelectedTreeItems().should('have.length', 1);
+        explorer.getSelectedTreeItems().contains('robot').should('exist');
+
+        // Collapse 'System' using the toggle
+        explorer.toggle('System');
+        // Check that its children are no longer visible (i.e. it is correcly collapsed)
+        explorer.getTreeItemByLabel('Central_Unit').should('not.exist');
+        explorer.getTreeItemByLabel('CompositeProcessor').should('not.exist');
+        explorer.getTreeItemByLabel('Wifi').should('not.exist');
+        // Check that this has not changed the selection (still on 'robot')
+        explorer.getSelectedTreeItems().should('have.length', 1);
+        explorer.getSelectedTreeItems().contains('robot').should('exist');
+      });
+
+      it('Then we can select a visible item by clicking on the right empty area', () => {
+        const explorer = new Explorer();
+        explorer.expandWithDoubleClick('robot');
+        explorer.getTreeItemByLabel('System').should('exist');
+
+        explorer.expandWithDoubleClick('System');
+        explorer.getTreeItemByLabel('Central_Unit').should('exist');
+        cy.getByTestId('Central_Unit-fullrow').should('exist');
+
+        // Click in the empty area after the label & menu: this should select the item
+        cy.getByTestId('Central_Unit-fullrow').click('right');
+        explorer.getSelectedTreeItems().should('have.length', 1);
+        explorer.getSelectedTreeItems().contains('Central_Unit').should('exist');
+      });
+
+      it('Then we can select a visible item by clicking on the left empty area', () => {
+        const explorer = new Explorer();
+        explorer.expandWithDoubleClick('robot');
+        explorer.getTreeItemByLabel('System').should('exist');
+
+        explorer.expandWithDoubleClick('System');
+        explorer.getTreeItemByLabel('Central_Unit').should('exist');
+        cy.getByTestId('Central_Unit-fullrow').should('exist');
+
+        // Click in the empty area before the toggle: this should also select the item
+        cy.getByTestId('Central_Unit-fullrow').click('left');
+        explorer.getSelectedTreeItems().should('have.length', 1);
+        explorer.getSelectedTreeItems().contains('Central_Unit').should('exist');
       });
     });
   });

--- a/integration-tests/cypress/e2e/project/forms/widget-reference.cy.ts
+++ b/integration-tests/cypress/e2e/project/forms/widget-reference.cy.ts
@@ -27,13 +27,13 @@ const createFormWithWidgetRef = (domainType: string, name: string, reference: st
   details.getTextField('Domain Type').type(domainType);
   details.getTextField('Name').type(`{selectall}${name}{enter}`);
   details.getTextField('Title Expression').type(`{selectall}${name}{enter}`);
-  explorer.expand(name);
-  explorer.expand('PageDescription');
+  explorer.expandWithDoubleClick(name);
+  explorer.expandWithDoubleClick('PageDescription');
   explorer.createObject('GroupDescription', 'children-ReferenceWidgetDescription');
   details.getTextField('Reference Name Expression').should('exist');
   details.getTextField('Label Expression').type('Test Widget Reference');
   details.getTextField('Reference Name Expression').type(`${reference}{enter}`);
-  explorer.collapse(name);
+  explorer.collapseWithDoubleClick(name);
 };
 describe('Forms Widget-reference', () => {
   context('Given a blank studio template', () => {
@@ -44,7 +44,7 @@ describe('Forms Widget-reference', () => {
       new Studio().createBlankStudioProjectWithView().then((createdProjectData) => {
         studioProjectId = createdProjectData.projectId;
         const explorer = new Explorer();
-        explorer.expand('ViewDocument');
+        explorer.expandWithDoubleClick('ViewDocument');
         createFormWithWidgetRef('flow::DataFlow', 'WidgetRefMonoValue', 'target');
         createFormWithWidgetRef('flow::CompositeProcessor', 'WidgetRefMultiValueNonContainment', 'incomingFlows');
         createFormWithWidgetRef('flow::System', 'WidgetRefContainment', 'powerOutputs');
@@ -64,9 +64,9 @@ describe('Forms Widget-reference', () => {
       it('Then widget reference mono-valued is available', () => {
         const explorer = new Explorer();
         const form = new Form();
-        explorer.expand('Flow');
-        explorer.expand('NewSystem');
-        explorer.expand('DataSource1');
+        explorer.expandWithDoubleClick('Flow');
+        explorer.expandWithDoubleClick('NewSystem');
+        explorer.expandWithDoubleClick('DataSource1');
         explorer.createRepresentation('standard', 'WidgetRefMonoValue', 'WidgetRefMonoValue');
         form.getForm().should('exist');
         form.getWidget('Test Widget Reference').should('exist');
@@ -103,8 +103,8 @@ describe('Forms Widget-reference', () => {
       it('Then widget reference multi-valued is available', () => {
         const explorer = new Explorer();
         const form = new Form();
-        explorer.expand('Flow');
-        explorer.expand('NewSystem');
+        explorer.expandWithDoubleClick('Flow');
+        explorer.expandWithDoubleClick('NewSystem');
         explorer.createRepresentation(
           'CompositeProcessor1',
           'WidgetRefMultiValueNonContainment',
@@ -142,7 +142,7 @@ describe('Forms Widget-reference', () => {
         form.getWidgetElement('Test Widget Reference', 'Test Widget Reference-clear').click();
         form.getWidgetElement('Test Widget Reference', 'reference-value-standard').should('not.exist');
 
-        explorer.expand('DataSource1');
+        explorer.expandWithDoubleClick('DataSource1');
         const dataTransferStandardExplorer = new DataTransfer();
         explorer.getTreeItemByLabel('standard').trigger('dragstart', { dataTransfer: dataTransferStandardExplorer });
         form.getWidget('Test Widget Reference').trigger('drop', { dataTransfer: dataTransferStandardExplorer });
@@ -162,7 +162,7 @@ describe('Forms Widget-reference', () => {
       it('Then widget reference containment is available', () => {
         const explorer = new Explorer();
         const form = new Form();
-        explorer.expand('Flow');
+        explorer.expandWithDoubleClick('Flow');
         explorer.createRepresentation('NewSystem', 'WidgetRefContainment', 'WidgetRefContainment');
         form.getForm().should('exist');
         form.getWidget('Test Widget Reference').should('exist');
@@ -243,8 +243,8 @@ describe('Forms Widget-reference', () => {
       it('Then widget reference non containment is available', () => {
         const explorer = new Explorer();
         const form = new Form();
-        explorer.expand('Flow');
-        explorer.expand('NewSystem');
+        explorer.expandWithDoubleClick('Flow');
+        explorer.expandWithDoubleClick('NewSystem');
         explorer.createRepresentation(
           'CompositeProcessor1',
           'WidgetRefMultiValueNonContainment',
@@ -280,7 +280,7 @@ describe('Forms Widget-reference', () => {
           .click();
         cy.getByTestId('create-modal').findByTestId('create-object').click();
         form.getWidgetElement('Test Widget Reference', 'reference-value-unused').should('exist');
-        explorer.expand('DataSource1');
+        explorer.expandWithDoubleClick('DataSource1');
         explorer.getTreeItemByLabel('unused').should('exist');
       });
     });
@@ -340,7 +340,7 @@ describe('Forms Widget-reference', () => {
       details.openReferenceWidgetOptions('Super Type');
       details.selectReferenceWidgetOption('SuperEntity1');
 
-      explorer.expand('ViewNewModel');
+      explorer.expandWithDoubleClick('ViewNewModel');
       createFormWithWidgetRef(`${domainName}::Entity1`, 'WidgetRefRepresentation', 'relation');
 
       new Studio().createProjectFromDomain('Cypress - Studio Instance', domainName, 'Root').then((res) => {
@@ -401,7 +401,7 @@ describe('Forms Widget-reference', () => {
       const details = new Details();
       const form = new Form();
 
-      explorer.expand(domainName);
+      explorer.expandWithDoubleClick(domainName);
       explorer.createObject('Entity1', 'relations-Relation');
       details.getCheckBox('Containment').check();
       details.openReferenceWidgetOptions('Target Type');
@@ -411,14 +411,14 @@ describe('Forms Widget-reference', () => {
       details.openReferenceWidgetOptions('Target Type');
       details.selectReferenceWidgetOption('Entity1');
 
-      explorer.expand('ViewNewModel');
+      explorer.expandWithDoubleClick('ViewNewModel');
       explorer.createObject('View', 'descriptions-FormDescription');
       explorer.select('New Form Description');
       details.getTextField('Domain Type').type(`${domainName}::Entity1`);
       details.getTextField('Name').type(`{selectall}WidgetRefRepresentation{enter}`);
       details.getTextField('Title Expression').type(`{selectall}WidgetRefRepresentation{enter}`);
-      explorer.expand('WidgetRefRepresentation');
-      explorer.expand('PageDescription');
+      explorer.expandWithDoubleClick('WidgetRefRepresentation');
+      explorer.expandWithDoubleClick('PageDescription');
       explorer.createObject('Group Description', 'children-ReferenceWidgetDescription');
       details.getTextField('Reference Name Expression').should('exist');
       details.getTextField('Label Expression').type('Test Widget Reference linkedTo');

--- a/integration-tests/cypress/e2e/project/tables/table.cy.ts
+++ b/integration-tests/cypress/e2e/project/tables/table.cy.ts
@@ -12,8 +12,8 @@
  *******************************************************************************/
 
 import { Project } from '../../../pages/Project';
-import { Explorer } from '../../../workbench/Explorer';
 import { Papaya } from '../../../usecases/Papaya';
+import { Explorer } from '../../../workbench/Explorer';
 
 describe('Tables', () => {
   context('Given a papaya project', () => {
@@ -25,9 +25,9 @@ describe('Tables', () => {
         project.visit(projectId);
         project.disableDeletionConfirmationDialog();
         const explorer = new Explorer();
-        explorer.expand('Papaya');
-        explorer.expand('Project Project');
-        explorer.expand('Component Component');
+        explorer.expandWithDoubleClick('Papaya');
+        explorer.expandWithDoubleClick('Project Project');
+        explorer.expandWithDoubleClick('Component Component');
       });
     });
 

--- a/integration-tests/cypress/workbench/Deck.ts
+++ b/integration-tests/cypress/workbench/Deck.ts
@@ -34,8 +34,8 @@ export class Deck {
   public createDailyDeckRepresentation(rootElementName: string, deckRepresentationName) {
     const explorer = new Explorer();
     explorer.getTreeItemByLabel('Task Model').should('exist');
-    explorer.expand('Task Model');
-    explorer.expand('Company');
+    explorer.expandWithDoubleClick('Task Model');
+    explorer.expandWithDoubleClick('Company');
     explorer.createRepresentation(rootElementName, 'Deck Daily Representation', deckRepresentationName);
   }
 
@@ -53,9 +53,9 @@ export class Deck {
     project.visit(taskProjectId);
     project.disableDeletionConfirmationDialog();
     const explorer = new Explorer();
-    explorer.expand('Task Model');
-    explorer.expand('Company');
-    explorer.expand(projectName);
+    explorer.expandWithDoubleClick('Task Model');
+    explorer.expandWithDoubleClick('Company');
+    explorer.expandWithDoubleClick(projectName);
     new Explorer().getTreeItemByLabel(representationName).click();
   }
 

--- a/integration-tests/cypress/workbench/Explorer.ts
+++ b/integration-tests/cypress/workbench/Explorer.ts
@@ -28,12 +28,12 @@ export class Explorer {
     return this.getExplorerView().find('[data-treeitemid][data-testid="selected"]');
   }
 
-  public expand(treeItemLabel: string): void {
+  public expandWithDoubleClick(treeItemLabel: string): void {
     this.getTreeItemByLabel(treeItemLabel).should('have.attr', 'data-expanded', 'false');
     this.getTreeItemByLabel(treeItemLabel).dblclick();
   }
 
-  public collapse(treeItemLabel: string): void {
+  public collapseWithDoubleClick(treeItemLabel: string): void {
     this.getTreeItemByLabel(treeItemLabel).should('have.attr', 'data-expanded', 'true');
     this.getTreeItemByLabel(treeItemLabel).dblclick();
   }
@@ -70,6 +70,11 @@ export class Explorer {
   public select(treeItemLabel: string, multiSelection: boolean = false): void {
     this.getTreeItemByLabel(treeItemLabel).should('exist');
     this.getTreeItemByLabel(treeItemLabel).click({ ctrlKey: multiSelection });
+  }
+
+  public toggle(treeItemLabel: string): void {
+    this.getTreeItemByLabel(treeItemLabel).should('exist');
+    this.getTreeItemByLabel(treeItemLabel).getByTestId(`${treeItemLabel}-toggle`).click();
   }
 
   public selectRepresentation(treeItemLabel: string): void {

--- a/integration-tests/cypress/workbench/Gantt.ts
+++ b/integration-tests/cypress/workbench/Gantt.ts
@@ -86,8 +86,8 @@ export class GanttTestHelper {
   public createGanttRepresentation(rootElementName: string, GanttRepresentationName) {
     const explorer = new Explorer();
     explorer.getTreeItemByLabel('Task Model').should('exist');
-    explorer.expand('Task Model');
-    explorer.expand('Company');
+    explorer.expandWithDoubleClick('Task Model');
+    explorer.expandWithDoubleClick('Company');
     explorer.createRepresentation(rootElementName, 'Gantt Representation', GanttRepresentationName);
   }
 
@@ -105,9 +105,9 @@ export class GanttTestHelper {
     project.visit(taskProjectId);
     project.disableDeletionConfirmationDialog();
     const explorer = new Explorer();
-    explorer.expand('Task Model');
-    explorer.expand('Company');
-    explorer.expand(projectName);
+    explorer.expandWithDoubleClick('Task Model');
+    explorer.expandWithDoubleClick('Company');
+    explorer.expandWithDoubleClick(projectName);
     new Explorer().getTreeItemByLabel(representationName).click();
   }
 


### PR DESCRIPTION
This was originally fixed in 2022.3.0 via commit 48913d175c88a80d0dc10fd16f51a149bcaeee58, but broken again in 2024.3.0.

This reverts "[3056] Expand the clickable/draggable zone for tree items" (commit 190b91909afd65e678f736257fe65d1f1ca641e8) which caused the regression.

I'll try and see if I can get both #1062 and #3056 working at the same time, but in the meantime if we decide #1062 is more important than the small UX improvement in #3056 we could merge this.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/1062
