### PR TITLE
[doc] Add an ADR on undo redo representation changes

### DIFF
--- a/doc/adrs/160_add_support_for_undo_redo_on_representation_changes.adoc
+++ b/doc/adrs/160_add_support_for_undo_redo_on_representation_changes.adoc
@@ -1,0 +1,114 @@
+= [ADR-160] Add support for undo redo on representation changes
+
+== Context
+
+We want to be able to undo or redo an action performed on a representation.
+Whereas [ADR-159] focuses on undo redo semantic changes performed on a resource, here we want to undo or redo changes persisted in the database.
+
+
+=== Current behavior
+
+This follow the undo redo of mutations that creates a semantic change on an EMF ressource.
+
+
+== Decision
+
+=== Frontend
+
+Draft, do we need to handle several mutations as one action (ex : addPortal + layout)
+
+=== Backend
+
+In order to `track changes` and `undo` or `redo` a representation changes, we will add a new API.
+`IRepresentationChangeEventRecorder` will be used to get a `list of IRepresentationChangeEvent` from a `mutation input`.
+[source,java]
+----
+public interface IRepresentationChangeEventRecorder {
+    List<IRepresentationChangeEvent> getChanges(IEditingContext editingContext, IInput input);
+    boolean canHandle(IEditingContext editingContext, IInput input);
+}
+----
+
+These changes will be `stored` in the `editingContext`.
+
+[source,java]
+----
+private final Map<String, List<IRepresentationChangeEvent>> representationChangesDescription = new HashMap<>();
+
+public Map<String, List<IRepresentationChangeEvent>> getRepresentationChangesDescription() {
+    return representationChangesDescription;
+}
+----
+
+The recorder will be called in an `IInputPreProcessor` implementation.
+
+[source,java]
+----
+    @Override
+    public IInput preProcess(IEditingContext editingContext, IInput input, Sinks.Many<ChangeDescription> changeDescriptionSink) {
+        if (editingContext instanceof EditingContext siriusEditingContext) {
+            if (canHandle(input)) {
+                siriusEditingContext.getChangeRecorder().beginRecording(siriusEditingContext.getDomain().getResourceSet().getResources());
+            }
+            this.representationChangeEventRecorders.stream()
+                    .filter(recorder -> recorder.canHandle(editingContext, input))
+                    .forEach(recorder -> {
+                        var changes = recorder.getChanges(editingContext, input);
+                        siriusEditingContext.getRepresentationChangesDescription().put(input.id().toString(), changes);
+                    });
+        }
+        return input;
+    }
+----
+
+All implementation will return some `IRepresentationChangeEvent` for a given input.
+
+[source,java]
+----
+@Service
+public class PortalChangeEventRecorder implements IRepresentationChangeEventRecorder {
+
+    private final IRepresentationSearchService representationSearchService;
+
+    public PortalChangeEventRecorder(IRepresentationSearchService representationSearchService) {
+        this.representationSearchService = representationSearchService;
+    }
+
+    @Override
+    public boolean canHandle(IEditingContext editingContext, IInput input) {
+        return input instanceof IPortalInput;
+    }
+
+    public List<IRepresentationChangeEvent> getChanges(IEditingContext editingContext, IInput input) {
+        var listChanges = new ArrayList<IRepresentationChangeEvent>();
+        if (input instanceof IPortalInput portalInput) {
+            var currentPortal = this.representationSearchService.findById(editingContext, portalInput.representationId(), Portal.class);
+            if (currentPortal.isPresent()) {
+                if (portalInput instanceof LayoutPortalInput layoutPortalInput) {
+                    listChanges.addAll(handleLayoutPortalInput(currentPortal.get(), layoutPortalInput));
+                }
+                if (portalInput instanceof AddPortalViewInput addPortalViewInput) {
+                    listChanges.addAll(handleAddPortalViewInput(currentPortal.get(), addPortalViewInput));
+                }
+                if (portalInput instanceof RemovePortalViewInput removePortalViewInput) {
+                    listChanges.addAll(handleRemovePortalViewInput(currentPortal.get(), removePortalViewInput));
+                }
+            }
+        }
+        return listChanges;
+    }
+}
+----
+
+=== Things to improve
+
+DRAFT, Do we want a service for each representation used by UndoEventHandler
+
+== Status
+
+Work in progress
+
+
+== Consequences
+
+All representations that want to support undo / redo feature will need to implement an `IRepresentationChangeEventRecorder`


### PR DESCRIPTION
# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?