### PR TITLE
[3980] Disable the ability to select newly created nodes

### DIFF
--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sirius-web-integration-tests",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sirius-web-integration-tests",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "dependencies": {
         "prettier": "2.7.1"

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sirius-web-integration-tests",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "license": "EPL-2.0",
   "private": true,
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components-parent",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components-parent",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "workspaces": [
         "./packages/*/frontend/*"
@@ -7906,7 +7906,7 @@
     },
     "packages/charts/frontend/sirius-components-charts": {
       "name": "@eclipse-sirius/sirius-components-charts",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@eclipse-sirius/sirius-components-tsconfig": "*",
@@ -7926,7 +7926,7 @@
     },
     "packages/core/frontend/sirius-components-core": {
       "name": "@eclipse-sirius/sirius-components-core",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -7963,7 +7963,7 @@
     },
     "packages/core/frontend/sirius-components-omnibox": {
       "name": "@eclipse-sirius/sirius-components-omnibox",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@eclipse-sirius/sirius-components-core": "*",
@@ -7997,7 +7997,7 @@
     },
     "packages/deck/frontend/sirius-components-deck": {
       "name": "@eclipse-sirius/sirius-components-deck",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8036,7 +8036,7 @@
     },
     "packages/diagrams/frontend/sirius-components-diagrams": {
       "name": "@eclipse-sirius/sirius-components-diagrams",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8148,7 +8148,7 @@
     },
     "packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors": {
       "name": "@eclipse-sirius/sirius-components-formdescriptioneditors",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8200,7 +8200,7 @@
     },
     "packages/forms/frontend/sirius-components-forms": {
       "name": "@eclipse-sirius/sirius-components-forms",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8255,7 +8255,7 @@
     },
     "packages/forms/frontend/sirius-components-widget-reference": {
       "name": "@eclipse-sirius/sirius-components-widget-reference",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8312,7 +8312,7 @@
     },
     "packages/gantt/frontend/sirius-components-gantt": {
       "name": "@eclipse-sirius/sirius-components-gantt",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8351,7 +8351,7 @@
     },
     "packages/portals/frontend/sirius-components-portals": {
       "name": "@eclipse-sirius/sirius-components-portals",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8391,12 +8391,12 @@
     },
     "packages/releng/frontend/sirius-components-tsconfig": {
       "name": "@eclipse-sirius/sirius-components-tsconfig",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0"
     },
     "packages/selection/frontend/sirius-components-selection": {
       "name": "@eclipse-sirius/sirius-components-selection",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8436,7 +8436,7 @@
     },
     "packages/sirius-web/frontend/sirius-web": {
       "name": "@eclipse-sirius/sirius-web",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "dependencies": {
         "@apollo/client": "3.10.4",
@@ -8501,7 +8501,7 @@
     },
     "packages/sirius-web/frontend/sirius-web-application": {
       "name": "@eclipse-sirius/sirius-web-application",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8567,7 +8567,7 @@
     },
     "packages/sirius-web/frontend/sirius-web-papaya": {
       "name": "@eclipse-sirius/sirius-web-papaya",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8633,7 +8633,7 @@
     },
     "packages/tables/frontend/sirius-components-tables": {
       "name": "@eclipse-sirius/sirius-components-tables",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8675,7 +8675,7 @@
     },
     "packages/tools/frontend/sirius-components-specification-layout": {
       "name": "@eclipse-sirius/sirius-components-specification-layout",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@mui/icons-material": "5.15.19",
@@ -8697,7 +8697,7 @@
     },
     "packages/trees/frontend/sirius-components-trees": {
       "name": "@eclipse-sirius/sirius-components-trees",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",
@@ -8736,7 +8736,7 @@
     },
     "packages/validation/frontend/sirius-components-validation": {
       "name": "@eclipse-sirius/sirius-components-validation",
-      "version": "2024.9.9",
+      "version": "2024.9.10",
       "license": "EPL-2.0",
       "devDependencies": {
         "@apollo/client": "3.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-parent",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/charts/backend/pom.xml
+++ b/packages/charts/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-charts-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-charts-parent</name>
 	<description>Sirius Components Charts Parent</description>

--- a/packages/charts/backend/sirius-components-charts-graphql/pom.xml
+++ b/packages/charts/backend/sirius-components-charts-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-charts-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-charts-graphql</name>
 	<description>Sirius Components Charts GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-charts</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/charts/backend/sirius-components-charts/pom.xml
+++ b/packages/charts/backend/sirius-components-charts/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-charts</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-charts</name>
 	<description>Sirius Components Charts</description>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/charts/backend/sirius-components-collaborative-charts/pom.xml
+++ b/packages/charts/backend/sirius-components-collaborative-charts/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-charts</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-charts</name>
 	<description>Sirius Components Collaborative Charts</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/charts/frontend/sirius-components-charts/package.json
+++ b/packages/charts/frontend/sirius-components-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-charts",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/compatibility/backend/pom.xml
+++ b/packages/compatibility/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-compatibility-parent</name>
 	<description>Sirius Components Compatibility Parent</description>

--- a/packages/compatibility/backend/sirius-components-compatibility-emf/pom.xml
+++ b/packages/compatibility/backend/sirius-components-compatibility-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility-emf</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-compatibility-emf</name>
 	<description>Sirius Components Compatibility EMF</description>
 
@@ -58,32 +58,32 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -93,19 +93,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/compatibility/backend/sirius-components-compatibility/pom.xml
+++ b/packages/compatibility/backend/sirius-components-compatibility/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-compatibility</name>
 	<description>Sirius Components Compatibility</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -74,43 +74,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/packages/core/backend/pom.xml
+++ b/packages/core/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-core-parent</name>
 	<description>Sirius Components Core Parent</description>

--- a/packages/core/backend/sirius-components-annotations-spring/pom.xml
+++ b/packages/core/backend/sirius-components-annotations-spring/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations-spring</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-annotations-spring</name>
 	<description>Sirius Components Annotations Spring</description>
 

--- a/packages/core/backend/sirius-components-annotations/pom.xml
+++ b/packages/core/backend/sirius-components-annotations/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-annotations</name>
 	<description>Sirius Components Annotations</description>
 

--- a/packages/core/backend/sirius-components-collaborative/pom.xml
+++ b/packages/core/backend/sirius-components-collaborative/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative</name>
 	<description>Sirius Components Collaborative</description>
 
@@ -67,23 +67,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/core/backend/sirius-components-core-graphql/pom.xml
+++ b/packages/core/backend/sirius-components-core-graphql/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <groupId>org.eclipse.sirius</groupId>
     <artifactId>sirius-components-core-graphql</artifactId>
-    <version>2024.9.9</version>
+    <version>2024.9.10</version>
     <name>sirius-components-core-graphql</name>
     <description>Sirius Components Core Graphql</description>
 
@@ -47,23 +47,23 @@
         <dependency>
             <groupId>org.eclipse.sirius</groupId>
             <artifactId>sirius-components-graphql-api</artifactId>
-            <version>2024.9.9</version>
+            <version>2024.9.10</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.sirius</groupId>
             <artifactId>sirius-components-collaborative</artifactId>
-            <version>2024.9.9</version>
+            <version>2024.9.10</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.sirius</groupId>
             <artifactId>sirius-components-tests</artifactId>
-            <version>2024.9.9</version>
+            <version>2024.9.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.sirius</groupId>
             <artifactId>sirius-components-spring-tests</artifactId>
-            <version>2024.9.9</version>
+            <version>2024.9.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/packages/core/backend/sirius-components-core/pom.xml
+++ b/packages/core/backend/sirius-components-core/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-core</name>
 	<description>Sirius Components Core</description>
 
@@ -52,17 +52,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-events</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/core/backend/sirius-components-events/pom.xml
+++ b/packages/core/backend/sirius-components-events/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-events</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-events</name>
 	<description>Sirius Components Events</description>
 

--- a/packages/core/backend/sirius-components-graphql-api/pom.xml
+++ b/packages/core/backend/sirius-components-graphql-api/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-api</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-graphql-api</name>
 	<description>Sirius Components GraphQL API</description>
 
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/core/backend/sirius-components-representations/pom.xml
+++ b/packages/core/backend/sirius-components-representations/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-representations</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-representations</name>
 	<description>Sirius Components Representations</description>
 
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/core/frontend/sirius-components-core/package.json
+++ b/packages/core/frontend/sirius-components-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-core",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/core/frontend/sirius-components-omnibox/package.json
+++ b/packages/core/frontend/sirius-components-omnibox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eclipse-sirius/sirius-components-omnibox",
   "author": "Eclipse Sirius",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "license": "EPL-2.0",
   "repository": {
     "type": "git",

--- a/packages/deck/backend/pom.xml
+++ b/packages/deck/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-deck-parent</artifactId>
-    <version>2024.9.9</version>
+    <version>2024.9.10</version>
 
 	<name>sirius-components-deck-parent</name>
 	<description>Sirius Components Deck Parent</description>

--- a/packages/deck/backend/sirius-components-collaborative-deck/pom.xml
+++ b/packages/deck/backend/sirius-components-collaborative-deck/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-deck</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-deck</name>
 	<description>Sirius Components Collaborative deck</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-deck</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/deck/backend/sirius-components-deck-graphql/pom.xml
+++ b/packages/deck/backend/sirius-components-deck-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-deck-graphql</artifactId>
-    <version>2024.9.9</version>
+    <version>2024.9.10</version>
 	<name>sirius-components-deck-graphql</name>
 	<description>Sirius Components Deck GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-deck</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/deck/backend/sirius-components-deck/pom.xml
+++ b/packages/deck/backend/sirius-components-deck/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-deck</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-deck</name>
 	<description>Sirius Components Deck</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/deck/frontend/sirius-components-deck/package.json
+++ b/packages/deck/frontend/sirius-components-deck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-deck",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/diagrams/backend/pom.xml
+++ b/packages/diagrams/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-diagrams-parent</name>
 	<description>Sirius Components Diagrams Parent</description>

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/pom.xml
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-diagrams</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-diagrams</name>
 	<description>Sirius Components Collaborative Diagrams</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-diagrams-graphql</name>
 	<description>Sirius Components Diagrams GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/diagrams/backend/sirius-components-diagrams-tests/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-tests</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-diagrams-tests</name>
 	<description>Sirius Components Diagrams Tests</description>
 
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -56,12 +56,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/diagrams/backend/sirius-components-diagrams/pom.xml
+++ b/packages/diagrams/backend/sirius-components-diagrams/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-diagrams</name>
 	<description>Sirius Components Diagrams</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/diagrams/frontend/sirius-components-diagrams/package.json
+++ b/packages/diagrams/frontend/sirius-components-diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-diagrams",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/DiagramRenderer.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/DiagramRenderer.tsx
@@ -27,7 +27,6 @@ import {
   ReactFlow,
   ReactFlowProps,
   applyNodeChanges,
-  useStoreApi,
 } from '@xyflow/react';
 import React, { MouseEvent as ReactMouseEvent, memo, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { DiagramContext } from '../contexts/DiagramContext';
@@ -122,41 +121,24 @@ export const DiagramRenderer = memo(({ diagramRefreshedEventPayload }: DiagramRe
 
   const { nodeConverters } = useContext<NodeTypeContextValue>(NodeTypeContext);
 
-  const { selection, setSelection } = useSelection();
+  const { setSelection } = useSelection();
   const { edgeType, setEdgeType } = useEdgeType();
 
   useInitialFitToScreen();
 
-  const store = useStoreApi<Node<NodeData>, Edge<EdgeData>>();
   useEffect(() => {
     const { diagram, cause } = diagramRefreshedEventPayload;
     const convertedDiagram: Diagram = convertDiagram(diagram, nodeConverters, diagramDescription, edgeType);
 
+    const selectedNodeIds = nodes.filter((node) => node.selected).map((node) => node.id);
+    const selectedEdgeIds = edges.filter((edge) => edge.selected).map((edge) => edge.id);
     if (cause === 'layout') {
-      const diagramElementIds: string[] = [
-        ...getNodes().map((node) => node.data.targetObjectId),
-        ...getEdges().map((edge) => edge.data?.targetObjectId ?? ''),
-      ];
-
-      const selectionDiagramEntryIds = selection.entries
-        .map((entry) => entry.id)
-        .filter((id) => diagramElementIds.includes(id))
-        .sort((id1: string, id2: string) => id1.localeCompare(id2));
-      const selectedDiagramElementIds = [
-        ...new Set(
-          [...getNodes(), ...getEdges()]
-            .filter((element) => element.selected)
-            .map((element) => element.data?.targetObjectId ?? '')
-        ),
-      ];
-      selectedDiagramElementIds.sort((id1: string, id2: string) => id1.localeCompare(id2));
-
-      convertedDiagram.nodes = convertedDiagram.nodes.map((node) => {
-        return { ...node, selected: selectionDiagramEntryIds.includes(node.data ? node.data.targetObjectId : '') };
-      });
-      convertedDiagram.edges = convertedDiagram.edges.map((edge) => {
-        return { ...edge, selected: selectionDiagramEntryIds.includes(edge.data ? edge.data.targetObjectId : '') };
-      });
+      convertedDiagram.nodes
+        .filter((node) => selectedNodeIds.includes(node.id))
+        .forEach((node) => (node.selected = true));
+      convertedDiagram.edges
+        .filter((edge) => selectedEdgeIds.includes(edge.id))
+        .forEach((edge) => (edge.selected = true));
 
       setEdges(convertedDiagram.edges);
       setNodes(convertedDiagram.nodes);
@@ -166,27 +148,12 @@ export const DiagramRenderer = memo(({ diagramRefreshedEventPayload }: DiagramRe
         edges,
       };
       layout(previousDiagram, convertedDiagram, diagramRefreshedEventPayload.referencePosition, (laidOutDiagram) => {
-        const { nodeLookup, edgeLookup } = store.getState();
-
-        laidOutDiagram.nodes = laidOutDiagram.nodes.map((node) => {
-          if (nodeLookup.get(node.id)) {
-            return {
-              ...node,
-              selected: !!nodeLookup.get(node.id)?.selected,
-            };
-          }
-          return node;
-        });
-
-        laidOutDiagram.edges = laidOutDiagram.edges.map((edge) => {
-          if (edgeLookup.get(edge.id)) {
-            return {
-              ...edge,
-              selected: !!edgeLookup.get(edge.id)?.selected,
-            };
-          }
-          return edge;
-        });
+        laidOutDiagram.nodes
+          .filter((node) => selectedNodeIds.includes(node.id))
+          .forEach((node) => (node.selected = true));
+        laidOutDiagram.edges
+          .filter((edge) => selectedEdgeIds.includes(edge.id))
+          .forEach((edge) => (edge.selected = true));
 
         setEdges(laidOutDiagram.edges);
         setNodes(laidOutDiagram.nodes);

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/selection/useDiagramSelection.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/selection/useDiagramSelection.ts
@@ -17,13 +17,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { useStore } from '../../representation/useStore';
 import { EdgeData, NodeData } from '../DiagramRenderer.types';
 
-// Compute a deterministic key from a selection
-const selectionKey = (entries: SelectionEntry[]) => {
-  return JSON.stringify(
-    entries.map((selectionEntry) => selectionEntry.id).sort((id1: string, id2: string) => id1.localeCompare(id2))
-  );
-};
-
 export const useDiagramSelection = (onShiftSelection: boolean): void => {
   const { selection, setSelection } = useSelection();
   const [shiftSelection, setShiftSelection] = useState<SelectionEntry[]>([]);
@@ -31,107 +24,82 @@ export const useDiagramSelection = (onShiftSelection: boolean): void => {
   const { fitView } = useReactFlow<Node<NodeData>, Edge<EdgeData>>();
   const { getNodes, setNodes, getEdges, setEdges } = useStore();
 
-  // Called when the worbench-level selection is changed.
-  // Apply it on our diagram by selecting exactly the diagram elements
-  // present which correspond to the workbench-selected semantic elements.
   useEffect(() => {
-    const allDiagramElements = [...getNodes(), ...getEdges()];
-    const displayedSemanticElements: Set<string> = new Set([
+    const diagramElementIds: string[] = [
       ...getNodes().map((node) => node.data.targetObjectId),
       ...getEdges().map((edge) => edge.data?.targetObjectId ?? ''),
-    ]);
-    const displayedSemanticElementsToSelect = selection.entries
+    ];
+
+    const selectionDiagramEntryIds = selection.entries
       .map((entry) => entry.id)
-      .filter((id) => displayedSemanticElements.has(id))
+      .filter((id) => diagramElementIds.includes(id))
       .sort((id1: string, id2: string) => id1.localeCompare(id2));
-
-    const semanticElementsAlreadySelectedOnDiagram = allDiagramElements
-      .filter((element) => element.selected)
-      .map((element) => element.data?.targetObjectId ?? '')
-      .sort((id1: string, id2: string) => id1.localeCompare(id2));
-
-    if (
-      JSON.stringify(displayedSemanticElementsToSelect) !== JSON.stringify(semanticElementsAlreadySelectedOnDiagram)
-    ) {
-      const nodesToReveal: Set<string> = new Set();
-      const newNodes = getNodes().map((node) => {
-        const selected = displayedSemanticElementsToSelect.includes(node.data.targetObjectId);
-        const newNode = { ...node, selected };
-        if (selected) {
-          nodesToReveal.add(newNode.id);
-        }
-        return newNode;
+    const selectedDiagramElementIds = [
+      ...new Set(
+        [...getNodes(), ...getEdges()]
+          .filter((element) => element.selected)
+          .map((element) => element.data?.targetObjectId ?? '')
+      ),
+    ];
+    selectedDiagramElementIds.sort((id1: string, id2: string) => id1.localeCompare(id2));
+    if (JSON.stringify(selectionDiagramEntryIds) !== JSON.stringify(selectedDiagramElementIds)) {
+      const newNodeSelection = getNodes().map((node) => {
+        return { ...node, selected: selectionDiagramEntryIds.includes(node.data.targetObjectId) };
       });
-      const newEdges = getEdges().map((edge) => {
-        const selected = displayedSemanticElementsToSelect.includes(edge.data ? edge.data.targetObjectId : '');
-        const newEdge = { ...edge, selected };
-        if (selected) {
-          // React Flow does not support "fit on edge", so include its source & target nodes
-          // to ensure the edge is visible and in context
-          nodesToReveal.add(newEdge.source);
-          nodesToReveal.add(newEdge.target);
-        }
-        return newEdge;
+      const newEdgeSelection = getEdges().map((edge) => {
+        return { ...edge, selected: selectionDiagramEntryIds.includes(edge.data ? edge.data.targetObjectId : '') };
       });
 
-      setEdges(newEdges);
-      setNodes(newNodes);
+      setEdges(newEdgeSelection);
+      setNodes(newNodeSelection);
 
-      fitView({ nodes: getNodes().filter((node) => nodesToReveal.has(node.id)), maxZoom: 1.5, duration: 1000 });
+      const fitViewNodes = newNodeSelection.filter((node) => {
+        // React Flow does not support "fit on edge", so fit on its source & target nodes to ensure it is visible and in context
+        return (
+          node.selected ||
+          newEdgeSelection
+            .filter((edge) => edge.selected)
+            .flatMap((edge) => [edge.source, edge.target])
+            .includes(node.id)
+        );
+      });
+      fitView({ nodes: fitViewNodes, maxZoom: 1.5, duration: 1000 });
     }
   }, [selection]);
 
   const onChange = useCallback(
     ({ nodes, edges }) => {
-      const semanticElementsDisplayedOnDiagram: Set<string> = new Set([
+      const diagramElementIds: string[] = [
         ...getNodes().map((node) => node.data.targetObjectId),
         ...getEdges().map((edge) => edge.data?.targetObjectId ?? ''),
-      ]);
-
-      const semanticElementsSelectedOnDiagram: Set<string> = new Set([
-        ...nodes.map((node) => node.data.targetObjectId),
-        ...edges.map((edge) => edge.data?.targetObjectId ?? ''),
-      ]);
-
-      const semanticElementsUnselectedOnDiagram: Set<string> = new Set(
-        [...semanticElementsDisplayedOnDiagram].filter((id) => !semanticElementsSelectedOnDiagram.has(id))
-      );
-
-      const semanticElementsSelectedInWorkbench: Set<string> = new Set(
-        selection.entries
-          .filter((entry) => entry.kind.startsWith('siriusComponents://semantic?'))
-          .map((entry) => entry.id)
-      );
-
-      const nextSemanticElementsToSelect: Set<string> = new Set(
-        [...semanticElementsSelectedOnDiagram, ...semanticElementsSelectedInWorkbench].filter(
-          (id) => !semanticElementsUnselectedOnDiagram.has(id)
-        )
-      );
-
-      const selectionEntriesFromDiagram: SelectionEntry[] = [...nodes, ...edges].map((node) => {
-        const { targetObjectId, targetObjectKind } = node.data;
-        return {
-          id: targetObjectId,
-          kind: targetObjectKind,
-        };
-      });
-      const selectionEntriesFromWorkbench: SelectionEntry[] = selection.entries.filter(
-        (entry) => entry.kind.startsWith('siriusComponents://semantic?') && nextSemanticElementsToSelect.has(entry.id)
-      );
-
-      const nextSelectionEntries = [...selectionEntriesFromDiagram];
-      selectionEntriesFromWorkbench.forEach((candidate) => {
-        if (!nextSelectionEntries.find((entry) => entry.id === candidate.id)) {
-          nextSelectionEntries.push(candidate);
+      ];
+      const selectionEntries: SelectionEntry[] = [...nodes, ...edges].reduce((uniqueIds, node) => {
+        const { targetObjectId, targetObjectKind, targetObjectLabel } = node.data;
+        const existingEntry = uniqueIds.find((entry: SelectionEntry) => entry.id === targetObjectId);
+        if (!existingEntry) {
+          uniqueIds.push({
+            id: targetObjectId,
+            kind: targetObjectKind,
+            label: targetObjectLabel,
+          });
         }
-      });
+        return uniqueIds;
+      }, []);
 
-      if (selectionKey(nextSelectionEntries) !== selectionKey(selection.entries)) {
+      const selectionDiagramEntryIds = selection.entries
+        .map((selectionEntry) => selectionEntry.id)
+        .filter((id) => diagramElementIds.includes(id))
+        .sort((id1: string, id2: string) => id1.localeCompare(id2));
+
+      const selectedDiagramElementIds = selectionEntries
+        .map((entry) => entry.id)
+        .sort((id1: string, id2: string) => id1.localeCompare(id2));
+
+      if (JSON.stringify(selectedDiagramElementIds) !== JSON.stringify(selectionDiagramEntryIds)) {
         if (onShiftSelection) {
-          setShiftSelection(nextSelectionEntries);
+          setShiftSelection(selectionEntries);
         } else {
-          setSelection({ entries: nextSelectionEntries });
+          setSelection({ entries: selectionEntries });
         }
       }
     },

--- a/packages/domain/backend/pom.xml
+++ b/packages/domain/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-domain-parent</name>
 	<description>Sirius Components Domain Parent</description>

--- a/packages/domain/backend/sirius-components-domain-edit/pom.xml
+++ b/packages/domain/backend/sirius-components-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-domain-edit</name>
 	<description>Sirius Components Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/domain/backend/sirius-components-domain-emf/pom.xml
+++ b/packages/domain/backend/sirius-components-domain-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-emf</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-domain-emf</name>
 	<description>Sirius Components Domain EMF</description>
 
@@ -54,12 +54,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -69,13 +69,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/domain/backend/sirius-components-domain/pom.xml
+++ b/packages/domain/backend/sirius-components-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-domain</name>
 	<description>Sirius Components Domain Definition DSL</description>
 

--- a/packages/emf/backend/pom.xml
+++ b/packages/emf/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-emf-parent</name>
 	<description>Sirius Components EMF Parent</description>

--- a/packages/emf/backend/sirius-components-emf-forms/pom.xml
+++ b/packages/emf/backend/sirius-components-emf-forms/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf-forms</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-emf-forms</name>
 	<description>Sirius Components EMF Forms</description>
 
@@ -54,17 +54,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -74,13 +74,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/emf/backend/sirius-components-emf/pom.xml
+++ b/packages/emf/backend/sirius-components-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-emf</name>
 	<description>Sirius Components EMF</description>
 
@@ -58,12 +58,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -112,19 +112,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/emf/backend/sirius-components-interpreter/pom.xml
+++ b/packages/emf/backend/sirius-components-interpreter/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-interpreter</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-interpreter</name>
 	<description>Sirius Components Intepreter</description>
 
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/packages/formdescriptioneditors/backend/pom.xml
+++ b/packages/formdescriptioneditors/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-formdescriptioneditors-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-formdescriptioneditors-parent</name>
 	<description>Sirius Components FormDescription Editors Parent</description>

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors-widget-reference/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors-widget-reference/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-formdescriptioneditors-widget-reference</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-formdescriptioneditors-widget-reference</name>
 	<description>Sirius Components Collaborative FormDescriptionEditors Widget Reference</description>
 
@@ -43,22 +43,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-formdescriptioneditors</name>
 	<description>Sirius Components Collaborative FormDescriptionEditors</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors-graphql/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-formdescriptioneditors-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-formdescriptioneditors-graphql</name>
 	<description>Sirius Components FormDescription Editors GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors/pom.xml
+++ b/packages/formdescriptioneditors/backend/sirius-components-formdescriptioneditors/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-formdescriptioneditors</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-formdescriptioneditors</name>
 	<description>Sirius Components FormDescriptionEditors</description>
 
@@ -47,22 +47,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/package.json
+++ b/packages/formdescriptioneditors/frontend/sirius-components-formdescriptioneditors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-formdescriptioneditors",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/forms/backend/pom.xml
+++ b/packages/forms/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-forms-parent</name>
 	<description>Sirius Components Forms Parent</description>

--- a/packages/forms/backend/sirius-components-collaborative-forms/pom.xml
+++ b/packages/forms/backend/sirius-components-collaborative-forms/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-forms</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-forms</name>
 	<description>Sirius Components Collaborative Forms</description>
 
@@ -51,33 +51,33 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-charts</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-tables</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/backend/sirius-components-collaborative-widget-reference/pom.xml
+++ b/packages/forms/backend/sirius-components-collaborative-widget-reference/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-widget-reference</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-widget-reference</name>
 	<description>Sirius Components Collaborative Forms :: Reference Widget</description>
 
@@ -51,33 +51,33 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/backend/sirius-components-forms-graphql/pom.xml
+++ b/packages/forms/backend/sirius-components-forms-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-forms-graphql</name>
 	<description>Sirius Components Forms GraphQL</description>
 
@@ -47,22 +47,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/backend/sirius-components-forms-tests/pom.xml
+++ b/packages/forms/backend/sirius-components-forms-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-tests</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-forms-tests</name>
 	<description>Sirius Components Forms Tests</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -61,12 +61,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/forms/backend/sirius-components-forms/pom.xml
+++ b/packages/forms/backend/sirius-components-forms/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-forms</name>
 	<description>Sirius Components Forms</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tables</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/backend/sirius-components-widget-reference-graphql/pom.xml
+++ b/packages/forms/backend/sirius-components-widget-reference-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-widget-reference-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-widget-reference-graphql</name>
 	<description>Sirius Components Reference Widget GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/forms/backend/sirius-components-widget-reference/pom.xml
+++ b/packages/forms/backend/sirius-components-widget-reference/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-widget-reference</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-widget-reference</name>
 	<description>Sirius Components Forms :: Reference Widget</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/forms/frontend/sirius-components-forms/package.json
+++ b/packages/forms/frontend/sirius-components-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-forms",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/forms/frontend/sirius-components-widget-reference/package.json
+++ b/packages/forms/frontend/sirius-components-widget-reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-widget-reference",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/gantt/backend/pom.xml
+++ b/packages/gantt/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-gantt-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-gantt-parent</name>
 	<description>Sirius Components Gantt Parent</description>

--- a/packages/gantt/backend/sirius-components-collaborative-gantt/pom.xml
+++ b/packages/gantt/backend/sirius-components-collaborative-gantt/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-gantt</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-gantt</name>
 	<description>Sirius Components Collaborative gantt</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/gantt/backend/sirius-components-gantt-graphql/pom.xml
+++ b/packages/gantt/backend/sirius-components-gantt-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-gantt-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-gantt-graphql</name>
 	<description>Sirius Components Gantt GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/gantt/backend/sirius-components-gantt-tests/pom.xml
+++ b/packages/gantt/backend/sirius-components-gantt-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-gantt-tests</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-gantt-tests</name>
 	<description>Sirius Components Gantt Tests</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -56,12 +56,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/gantt/backend/sirius-components-gantt/pom.xml
+++ b/packages/gantt/backend/sirius-components-gantt/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-gantt</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-gantt</name>
 	<description>Sirius Components Gantt</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/gantt/frontend/sirius-components-gantt/package.json
+++ b/packages/gantt/frontend/sirius-components-gantt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-gantt",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/papaya/backend/pom.xml
+++ b/packages/papaya/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-papaya-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-view-parent</name>
 	<description>Sirius Components Papaya Parent</description>

--- a/packages/papaya/backend/sirius-components-papaya-edit/pom.xml
+++ b/packages/papaya/backend/sirius-components-papaya-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-papaya-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-papaya-edit</name>
 	<description>Sirius Components Papaya Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-papaya</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/papaya/backend/sirius-components-papaya/pom.xml
+++ b/packages/papaya/backend/sirius-components-papaya/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-papaya</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-papaya</name>
 	<description>Sirius Components Papaya Definition DSL</description>
 

--- a/packages/pom.xml
+++ b/packages/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/packages/portals/backend/pom.xml
+++ b/packages/portals/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-portals-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-portals-parent</name>
 	<description>Sirius Components Portals Parent</description>

--- a/packages/portals/backend/sirius-components-collaborative-portals/pom.xml
+++ b/packages/portals/backend/sirius-components-collaborative-portals/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-portals</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-portals</name>
 	<description>Sirius Components Collaborative Portals</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-portals</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -65,13 +65,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/portals/backend/sirius-components-portals-graphql/pom.xml
+++ b/packages/portals/backend/sirius-components-portals-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-portals-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-portals-graphql</name>
 	<description>Sirius Components Portals GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-portals</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/portals/backend/sirius-components-portals-tests/pom.xml
+++ b/packages/portals/backend/sirius-components-portals-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-portals-tests</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-portals-tests</name>
 	<description>Sirius Components Portals Tests</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-portals</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/portals/backend/sirius-components-portals/pom.xml
+++ b/packages/portals/backend/sirius-components-portals/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-portals</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-portals</name>
 	<description>Sirius Components Portals</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/portals/frontend/sirius-components-portals/package.json
+++ b/packages/portals/frontend/sirius-components-portals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-portals",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/releng/backend/pom.xml
+++ b/packages/releng/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-releng-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-releng-parent</name>
 	<description>Sirius Components Releng Parent</description>

--- a/packages/releng/backend/sirius-components-test-coverage/pom.xml
+++ b/packages/releng/backend/sirius-components-test-coverage/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-test-coverage</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-test-coverage-aggregation</name>
 	<description>Sirius Components Test Coverage Aggregation</description>
 
@@ -43,412 +43,412 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-events</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-deck</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-portals</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tables</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-web</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-charts</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-deck</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-portals</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-tables</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-gantt-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-deck-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-portals-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tables-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-gantt-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-deck</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-deck-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-tree</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-tree-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-builder</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-task</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-task-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-customnodes</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-customnodes-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-papaya</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-application</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-infrastructure</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-starter</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/releng/frontend/sirius-components-tsconfig/package.json
+++ b/packages/releng/frontend/sirius-components-tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-tsconfig",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/selection/backend/pom.xml
+++ b/packages/selection/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-selection-parent</name>
 	<description>Sirius Components Selection Parent</description>

--- a/packages/selection/backend/sirius-components-collaborative-selection/pom.xml
+++ b/packages/selection/backend/sirius-components-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-selection</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-selection</name>
 	<description>Sirius Components Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,18 +56,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/selection/backend/sirius-components-selection-graphql/pom.xml
+++ b/packages/selection/backend/sirius-components-selection-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-selection-graphql</name>
 	<description>Sirius Components Selection GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/selection/backend/sirius-components-selection/pom.xml
+++ b/packages/selection/backend/sirius-components-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-selection</name>
 	<description>Sirius Components Selection</description>
 
@@ -43,18 +43,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/selection/frontend/sirius-components-selection/package.json
+++ b/packages/selection/frontend/sirius-components-selection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-selection",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/sirius-web/backend/pom.xml
+++ b/packages/sirius-web/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-web-parent</name>
 	<description>Sirius Web Parent</description>

--- a/packages/sirius-web/backend/sirius-web-application/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-application/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-application</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-web-application</name>
 	<description>Sirius Web Application</description>
 
@@ -47,162 +47,162 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-portals</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-customnodes</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-customnodes-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-builder</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-deck</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-deck-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-gantt-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-tree</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-tree-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/packages/sirius-web/backend/sirius-web-domain/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-domain</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-web-domain</name>
 	<description>Sirius Web Domain</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-events</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/packages/sirius-web/backend/sirius-web-e2e-tests/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-e2e-tests/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <groupId>org.eclipse.sirius</groupId>
     <artifactId>sirius-web-e2e-tests</artifactId>
-    <version>2024.9.9</version>
+    <version>2024.9.10</version>
     <name>sirius-web-e2e-tests</name>
     <description>Sirius Web End-to-end Tests</description>
 
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.eclipse.sirius</groupId>
             <artifactId>sirius-web-application</artifactId>
-            <version>2024.9.9</version>
+            <version>2024.9.10</version>
         </dependency>
     </dependencies>
 

--- a/packages/sirius-web/backend/sirius-web-frontend/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-frontend/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-frontend</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-web-frontend</name>
 	<description>Sirius Web Frontend</description>
 

--- a/packages/sirius-web/backend/sirius-web-infrastructure/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-infrastructure/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-infrastructure</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-web-infrastructure</name>
 	<description>Sirius Web Infrastructure</description>
 
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-application</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/sirius-web/backend/sirius-web-papaya/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-papaya/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-papaya</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-web-papaya</name>
 	<description>Sirius Web Papaya</description>
 
@@ -43,17 +43,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-application</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-papaya</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-papaya-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.reflections</groupId>

--- a/packages/sirius-web/backend/sirius-web-starter/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-starter/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-starter</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-web-starter</name>
 	<description>Sirius Web Starter</description>
 
@@ -47,172 +47,172 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-infrastructure</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-deck-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-gantt-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-portals-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tables-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-web</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-builder</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-deck</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-deck-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-gantt-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-tree</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-tree-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/sirius-web/backend/sirius-web-tests/pom.xml
+++ b/packages/sirius-web/backend/sirius-web-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web-tests</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-web-tests</name>
 	<description>Sirius Web Tests</description>
 
@@ -43,52 +43,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-application</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-deck</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tables-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-widget-reference</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-portals-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/sirius-web/backend/sirius-web/pom.xml
+++ b/packages/sirius-web/backend/sirius-web/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-web</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-web</name>
 	<description>Sirius Web</description>
 
@@ -43,29 +43,29 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-starter</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-frontend</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 
 		<!-- Sirius Web Specific Dependencies -->
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-papaya</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-flow-starter</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-task-starter</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-e2e-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 
 		<!-- Test Dependencies -->
@@ -112,43 +112,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-gantt-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-portals-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tables-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/sirius-web/frontend/sirius-web-application/package.json
+++ b/packages/sirius-web/frontend/sirius-web-application/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eclipse-sirius/sirius-web-application",
   "author": "Eclipse Sirius",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "license": "EPL-2.0",
   "repository": {
     "type": "git",

--- a/packages/sirius-web/frontend/sirius-web-papaya/package.json
+++ b/packages/sirius-web/frontend/sirius-web-papaya/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-web-papaya",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/sirius-web/frontend/sirius-web/package.json
+++ b/packages/sirius-web/frontend/sirius-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eclipse-sirius/sirius-web",
   "author": "Eclipse Sirius",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "license": "EPL-2.0",
   "repository": {
     "type": "git",

--- a/packages/starters/backend/pom.xml
+++ b/packages/starters/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-starter-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-starter-parent</name>
 	<description>Sirius Components Starter Parent</description>

--- a/packages/starters/backend/sirius-components-flow-starter/pom.xml
+++ b/packages/starters/backend/sirius-components-flow-starter/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-flow-starter</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-flow-starter</name>
 	<description>Sirius Components Flow Starter</description>
 
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-application</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 
 		<dependency>
@@ -71,13 +71,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/starters/backend/sirius-components-task-starter/pom.xml
+++ b/packages/starters/backend/sirius-components-task-starter/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-task-starter</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-task-starter</name>
 	<description>Sirius Components Task Starter</description>
 
@@ -59,18 +59,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-web-application</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-task</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-task-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/tables/backend/pom.xml
+++ b/packages/tables/backend/pom.xml
@@ -18,7 +18,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tables-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-tables-parent</name>
 	<description>Sirius Components Tables Parent</description>

--- a/packages/tables/backend/sirius-components-collaborative-tables/pom.xml
+++ b/packages/tables/backend/sirius-components-collaborative-tables/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-tables</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-tables</name>
 	<description>Sirius Components Collaborative Tables</description>
 
@@ -51,23 +51,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tables</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/tables/backend/sirius-components-tables-graphql/pom.xml
+++ b/packages/tables/backend/sirius-components-tables-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tables-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-tables-graphql</name>
 	<description>Sirius Components Tables GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-tables</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/tables/backend/sirius-components-tables-tests/pom.xml
+++ b/packages/tables/backend/sirius-components-tables-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tables-tests</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-tables-tests</name>
 	<description>Sirius Components Tables Tests</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tables</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -56,12 +56,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-tables</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/tables/backend/sirius-components-tables/pom.xml
+++ b/packages/tables/backend/sirius-components-tables/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tables</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-tables</name>
 	<description>Sirius Components Tables</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/tables/frontend/sirius-components-tables/package.json
+++ b/packages/tables/frontend/sirius-components-tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-tables",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/task/backend/pom.xml
+++ b/packages/task/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-task-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-task-parent</name>
 	<description>Sirius Components Task Parent</description>

--- a/packages/task/backend/sirius-components-task-edit/pom.xml
+++ b/packages/task/backend/sirius-components-task-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-task-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-task-edit</name>
 	<description>Sirius Components Task - Edit Support</description>
 
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-task</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/task/backend/sirius-components-task/pom.xml
+++ b/packages/task/backend/sirius-components-task/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-task</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-task</name>
 	<description>Sirius Components Task Meta-model</description>
 

--- a/packages/tests/backend/pom.xml
+++ b/packages/tests/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-tests-parent</name>
 	<description>Sirius Components Tests Parent</description>

--- a/packages/tests/backend/sirius-components-graphql-tests/pom.xml
+++ b/packages/tests/backend/sirius-components-graphql-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-tests</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-graphql-tests</name>
 	<description>Sirius Components GraphQL Tests</description>
 
@@ -64,17 +64,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/tests/backend/sirius-components-spring-tests/pom.xml
+++ b/packages/tests/backend/sirius-components-spring-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-spring-tests</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-spring-tests</name>
 	<description>Sirius Components Spring Tests</description>
 
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/packages/tests/backend/sirius-components-tests/pom.xml
+++ b/packages/tests/backend/sirius-components-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-tests</name>
 	<description>Sirius Components Tests</description>
 
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/tools/backend/pom.xml
+++ b/packages/tools/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tools-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-tools-parent</name>
 	<description>Sirius Components Tools Parent</description>

--- a/packages/tools/backend/sirius-components-graphiql/pom.xml
+++ b/packages/tools/backend/sirius-components-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphiql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-graphiql</name>
 	<description>Sirius Components Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/packages/tools/backend/sirius-components-graphql-voyager/pom.xml
+++ b/packages/tools/backend/sirius-components-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-voyager</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-graphql-voyager</name>
 	<description>Sirius Components Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/packages/tools/frontend/sirius-components-specification-layout/package.json
+++ b/packages/tools/frontend/sirius-components-specification-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-specification-layout",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/trees/backend/pom.xml
+++ b/packages/trees/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-trees-parent</name>
 	<description>Sirius Components Trees Parent</description>

--- a/packages/trees/backend/sirius-components-collaborative-trees/pom.xml
+++ b/packages/trees/backend/sirius-components-collaborative-trees/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-trees</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-trees</name>
 	<description>Sirius Components Collaborative Trees</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -65,13 +65,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/trees/backend/sirius-components-trees-graphql/pom.xml
+++ b/packages/trees/backend/sirius-components-trees-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-trees-graphql</name>
 	<description>Sirius Components Trees GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/trees/backend/sirius-components-trees-tests/pom.xml
+++ b/packages/trees/backend/sirius-components-trees-tests/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees-tests</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-trees-tests</name>
 	<description>Sirius Components Trees Tests</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/trees/backend/sirius-components-trees/pom.xml
+++ b/packages/trees/backend/sirius-components-trees/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-trees</name>
 	<description>Sirius Components Trees</description>
 
@@ -43,12 +43,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/trees/frontend/sirius-components-trees/package.json
+++ b/packages/trees/frontend/sirius-components-trees/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-trees",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/validation/backend/pom.xml
+++ b/packages/validation/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-validation-parent</name>
 	<description>Sirius Components Validation Parent</description>

--- a/packages/validation/backend/sirius-components-collaborative-validation/pom.xml
+++ b/packages/validation/backend/sirius-components-collaborative-validation/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-validation</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-collaborative-validation</name>
 	<description>Sirius Components Collaborative Validation</description>
 
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -62,13 +62,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/validation/backend/sirius-components-validation-graphql/pom.xml
+++ b/packages/validation/backend/sirius-components-validation-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-validation-graphql</name>
 	<description>Sirius Components Validation GraphQL</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/validation/backend/sirius-components-validation/pom.xml
+++ b/packages/validation/backend/sirius-components-validation/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-validation</name>
 	<description>Sirius Components Validation</description>
 
@@ -48,12 +48,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/validation/frontend/sirius-components-validation/package.json
+++ b/packages/validation/frontend/sirius-components-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components-validation",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "repository": {

--- a/packages/view/backend/pom.xml
+++ b/packages/view/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-view-parent</name>
 	<description>Sirius Components View Parent</description>

--- a/packages/view/backend/sirius-components-view-builder/pom.xml
+++ b/packages/view/backend/sirius-components-view-builder/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-builder</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-builder</name>
 	<description>Sirius View Builder</description>
 
@@ -68,42 +68,42 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-customnodes</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-deck</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-tree</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/view/backend/sirius-components-view-deck-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-deck-edit/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-deck-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-deck-edit</name>
 	<description>Sirius Components Deck View Definition DSL - Edit Support</description>
 
@@ -35,17 +35,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-deck</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-deck/pom.xml
+++ b/packages/view/backend/sirius-components-view-deck/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-deck</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-deck</name>
 	<description>Sirius Components Deck View Definition DSL</description>
 
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-diagram-customnodes-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-diagram-customnodes-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-diagram-customnodes-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-diagram-customnodes-edit</name>
 	<description>Support for additional custom nodes - edit support</description>
 
@@ -69,12 +69,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-customnodes</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-diagram-customnodes/pom.xml
+++ b/packages/view/backend/sirius-components-view-diagram-customnodes/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-diagram-customnodes</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-diagram-customnodes</name>
 	<description>Support for additional custom nodes</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-diagram-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-diagram-edit/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-diagram-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-diagram-edit</name>
 	<description>Sirius Components Diagram View Definition DSL - Edit Support</description>
 	<properties>
@@ -49,12 +49,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-diagram/pom.xml
+++ b/packages/view/backend/sirius-components-view-diagram/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-diagram</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-diagram</name>
 	<description>Sirius Components Diagram View Definition DSL</description>
 	<properties>
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-edit</name>
 	<description>Sirius Components View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-emf-widget-reference/pom.xml
+++ b/packages/view/backend/sirius-components-view-emf-widget-reference/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-emf-widget-reference</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-emf-widget-reference</name>
 	<description>Sirius Components View EMF Widget Reference</description>
 
@@ -43,17 +43,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -63,13 +63,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/view/backend/sirius-components-view-emf/pom.xml
+++ b/packages/view/backend/sirius-components-view-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-emf</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-emf</name>
 	<description>Sirius Components View EMF</description>
 
@@ -63,27 +63,27 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
@@ -93,47 +93,47 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-diagram</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		 <dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-deck</artifactId>
-             <version>2024.9.9</version>
+             <version>2024.9.10</version>
 		</dependency>
 		 <dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-tree</artifactId>
-             <version>2024.9.9</version>
+             <version>2024.9.10</version>
 		</dependency>
 		 <dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-             <version>2024.9.9</version>
+             <version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf-forms</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-deck</artifactId>
-            <version>2024.9.9</version>
+            <version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -143,19 +143,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/packages/view/backend/sirius-components-view-form-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-form-edit/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-form-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-form-edit</name>
 	<description>Sirius Components Form View Definition DSL - Edit Support</description>
 	<properties>
@@ -49,12 +49,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-form/pom.xml
+++ b/packages/view/backend/sirius-components-view-form/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-form</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-form</name>
 	<description>Sirius Components Form View Definition DSL</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-gantt-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-gantt-edit/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-gantt-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-gantt-edit</name>
 	<description>Sirius Components Gantt View Definition DSL - Edit Support</description>
 	<properties>
@@ -49,12 +49,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-gantt/pom.xml
+++ b/packages/view/backend/sirius-components-view-gantt/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-gantt</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-gantt</name>
 	<description>Sirius Components Gantt View Definition DSL</description>
 	<properties>
@@ -49,12 +49,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-gantt</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-tree-edit/pom.xml
+++ b/packages/view/backend/sirius-components-view-tree-edit/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-tree-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-tree-edit</name>
 	<description>Sirius Components Tree View Definition DSL - Edit Support</description>
 	<properties>
@@ -49,12 +49,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-tree</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view-tree/pom.xml
+++ b/packages/view/backend/sirius-components-view-tree/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-tree</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view-tree</name>
 	<description>Sirius Components Tree View Definition DSL</description>
 
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-view/pom.xml
+++ b/packages/view/backend/sirius-components-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-view</name>
 	<description>Sirius Components View Definition DSL</description>
 

--- a/packages/view/backend/sirius-components-widget-reference-view-edit/pom.xml
+++ b/packages/view/backend/sirius-components-widget-reference-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-widget-reference-view-edit</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-widget-reference-view-edit</name>
 	<description>View support for the reference custom widget :: edit support</description>
 
@@ -69,17 +69,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form-edit</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-widget-reference-view</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/view/backend/sirius-components-widget-reference-view/pom.xml
+++ b/packages/view/backend/sirius-components-widget-reference-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-widget-reference-view</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-widget-reference-view</name>
 	<description>View support for the reference custom widget</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-form</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 	</dependencies>
 

--- a/packages/web/backend/pom.xml
+++ b/packages/web/backend/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-web-parent</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 
 	<name>sirius-components-web-parent</name>
 	<description>Sirius Components Web Parent</description>

--- a/packages/web/backend/sirius-components-graphql/pom.xml
+++ b/packages/web/backend/sirius-components-graphql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-graphql</name>
 	<description>Sirius Components GraphQL</description>
 
@@ -59,18 +59,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/packages/web/backend/sirius-components-web/pom.xml
+++ b/packages/web/backend/sirius-components-web/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-web</artifactId>
-	<version>2024.9.9</version>
+	<version>2024.9.10</version>
 	<name>sirius-components-web</name>
 	<description>Sirius Components Web</description>
 
@@ -60,18 +60,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2024.9.9</version>
+			<version>2024.9.10</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -4,7 +4,7 @@
   "description": "Sirius Web extension for VSCode",
   "publisher": "eclipse-sirius",
   "license": "EPL-2.0",
-  "version": "2024.9.9",
+  "version": "2024.9.10",
   "homepage": "https://www.eclipse.dev/sirius/sirius-web.html",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This reverts commit 99513c34c49ebbb3b8ba0d972ff097fb70352bb8.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/3980
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?