### PR TITLE
[4204] Prevent the changeDescriptionSink from crashing because of the related representation refresh

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -130,6 +130,7 @@ Except for the specific case where `cause === 'refresh'` in `DiagramRenderer` (w
 - https://github.com/eclipse-sirius/sirius-web/issues/4679[#4679] [tree] Remove coupling between TreeView and useSelection
 - https://github.com/eclipse-sirius/sirius-web/issues/4657[#4657] [diagram] Resize a parent node using a list layout when one of its children has disappeared even when the node has been manually resized
 - https://github.com/eclipse-sirius/sirius-web/issues/4464[#4464] [diagram] [portal] Reduce usage of the selection kind
+- https://github.com/eclipse-sirius/sirius-web/issues/4204[#4204] [core] Prevent the changeDescriptionSink from crashing because of the related representation refresh
 
 
 == v2025.2.0

--- a/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessor.java
+++ b/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessor.java
@@ -159,9 +159,9 @@ public class EditingContextEventProcessor implements IEditingContextEventProcess
 
             var refreshRepresentationSample = Timer.start(this.meterRegistry);
 
-            RepresentationEventProcessorEntry representationEventProcessorEntry = this.representationEventProcessors.get(changeDescription.getSourceId());
-            if (representationEventProcessorEntry != null) {
-                try {
+            try {
+                RepresentationEventProcessorEntry representationEventProcessorEntry = this.representationEventProcessors.get(changeDescription.getSourceId());
+                if (representationEventProcessorEntry != null) {
                     IRepresentationEventProcessor representationEventProcessor = representationEventProcessorEntry.getRepresentationEventProcessor();
 
                     long start = System.currentTimeMillis();
@@ -178,11 +178,11 @@ public class EditingContextEventProcessor implements IEditingContextEventProcess
 
                     IRepresentation representation = representationEventProcessor.getRepresentation();
                     this.applicationEventPublisher.publishEvent(new RepresentationRefreshedEvent(this.editingContext.getId(), representation));
-                } catch (Exception exception) {
-                    this.logger.warn(exception.getMessage(), exception);
                 }
+                this.refreshOtherRepresentations(changeDescription);
+            } catch (Exception exception) {
+                this.logger.warn(exception.getMessage(), exception);
             }
-            this.refreshOtherRepresentations(changeDescription);
 
             var timer = this.meterRegistry.timer(Monitoring.TIMER_REFRESH_REPRESENTATION, "changeDescription", changeDescription.getSourceId());
             refreshRepresentationSample.stop(timer);

--- a/packages/emf/backend/sirius-components-interpreter/src/main/java/org/eclipse/sirius/components/interpreter/Result.java
+++ b/packages/emf/backend/sirius-components-interpreter/src/main/java/org/eclipse/sirius/components/interpreter/Result.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -147,6 +147,6 @@ public class Result {
 
     @Override
     public String toString() {
-        return MessageFormat.format("Result { status: {0}, rawValue: {1}}", this.status, this.rawValue);
+        return MessageFormat.format("Result '{' status: {0}, rawValue: {1} '}'", this.status, this.rawValue);
     }
 }


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4204

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?