### PR TITLE
[fix] Remove unused parameters

### DIFF
--- a/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/services/DefaultLabelService.java
+++ b/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/services/DefaultLabelService.java
@@ -29,9 +29,7 @@ import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.emf.edit.provider.ComposedImage;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.ReflectiveItemProvider;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationImageProvider;
 import org.eclipse.sirius.components.core.api.IDefaultLabelService;
-import org.eclipse.sirius.components.core.api.IRepresentationMetadataProvider;
 import org.eclipse.sirius.components.core.api.labels.StyledString;
 import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.slf4j.Logger;
@@ -50,22 +48,15 @@ public class DefaultLabelService implements IDefaultLabelService {
 
     private static final String DEFAULT_LABEL_FEATURE = "name";
 
-    private final List<IRepresentationMetadataProvider> representationMetadataProviders;
-
     private final LabelFeatureProviderRegistry labelFeatureProviderRegistry;
 
     private final ComposedAdapterFactory composedAdapterFactory;
 
-    private final List<IRepresentationImageProvider> representationImageProviders;
+    private final Logger logger = LoggerFactory.getLogger(DefaultLabelService.class);
 
-    private final Logger logger = LoggerFactory.getLogger(LabelFeatureProviderRegistry.class);
-
-    public DefaultLabelService(List<IRepresentationMetadataProvider> representationMetadataProviders, LabelFeatureProviderRegistry labelFeatureProviderRegistry, ComposedAdapterFactory composedAdapterFactory,
-            List<IRepresentationImageProvider> representationImageProviders) {
-        this.representationMetadataProviders = Objects.requireNonNull(representationMetadataProviders);
+    public DefaultLabelService(LabelFeatureProviderRegistry labelFeatureProviderRegistry, ComposedAdapterFactory composedAdapterFactory) {
         this.labelFeatureProviderRegistry = Objects.requireNonNull(labelFeatureProviderRegistry);
         this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
-        this.representationImageProviders = Objects.requireNonNull(representationImageProviders);
     }
 
     @Override

--- a/packages/emf/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/services/DefaultLabelServiceTests.java
+++ b/packages/emf/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/services/DefaultLabelServiceTests.java
@@ -29,7 +29,6 @@ import org.eclipse.emf.edit.provider.IItemStyledLabelProvider;
 import org.eclipse.emf.edit.provider.ItemProviderAdapter;
 import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
 import org.eclipse.emf.edit.provider.StyledString;
-import org.eclipse.sirius.components.core.api.IRepresentationMetadataProvider;
 import org.eclipse.sirius.components.core.api.labels.BorderStyle;
 import org.eclipse.sirius.components.core.api.labels.UnderLineStyle;
 import org.junit.jupiter.api.Test;
@@ -45,7 +44,7 @@ public class DefaultLabelServiceTests {
         ComposedAdapterFactory composedAdapterFactory = new ComposedAdapterFactory(List.of(new EcoreItemProviderAdapterFactory()));
         composedAdapterFactory.addAdapterFactory(new EcoreAdapterFactory());
         composedAdapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
-        DefaultLabelService labelService = new DefaultLabelService(List.of(new IRepresentationMetadataProvider.NoOp()), new LabelFeatureProviderRegistry(), composedAdapterFactory, List.of());
+        DefaultLabelService labelService = new DefaultLabelService(new LabelFeatureProviderRegistry(), composedAdapterFactory);
         EAttribute attr = EcoreFactory.eINSTANCE.createEAttribute();
         List<String> imagePath = labelService.getImagePath(attr);
         assertThat(imagePath).hasSize(1);
@@ -111,7 +110,7 @@ public class DefaultLabelServiceTests {
 
         @Override
         public String getText(Object object) {
-            return getStyledText(object).toString();
+            return this.getStyledText(object).toString();
         }
     }
 }

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/PapayaLabelProvider.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/PapayaLabelProvider.java
@@ -12,16 +12,13 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.papaya.services;
 
-import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemStyledLabelProvider;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationImageProvider;
 import org.eclipse.sirius.components.core.api.ILabelServiceDelegate;
-import org.eclipse.sirius.components.core.api.IRepresentationMetadataProvider;
 import org.eclipse.sirius.components.core.api.labels.StyledString;
 import org.eclipse.sirius.components.emf.services.DefaultLabelService;
 import org.eclipse.sirius.components.emf.services.LabelFeatureProviderRegistry;
@@ -40,8 +37,8 @@ public class PapayaLabelProvider extends DefaultLabelService implements ILabelSe
 
     private final IStyledStringConverter styledStringConverter;
 
-    public PapayaLabelProvider(List<IRepresentationMetadataProvider> representationMetadataProviders, LabelFeatureProviderRegistry labelFeatureProviderRegistry, ComposedAdapterFactory composedAdapterFactory, List<IRepresentationImageProvider> representationImageProviders, IStyledStringConverter styledStringConverter) {
-        super(representationMetadataProviders, labelFeatureProviderRegistry, composedAdapterFactory, representationImageProviders);
+    public PapayaLabelProvider(LabelFeatureProviderRegistry labelFeatureProviderRegistry, ComposedAdapterFactory composedAdapterFactory, IStyledStringConverter styledStringConverter) {
+        super(labelFeatureProviderRegistry, composedAdapterFactory);
         this.styledStringConverter = Objects.requireNonNull(styledStringConverter);
     }
 

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/tree/EcoreSampleStyledLabelService.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/tree/EcoreSampleStyledLabelService.java
@@ -16,10 +16,7 @@ import java.util.List;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationImageProvider;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationMetadataPersistenceService;
 import org.eclipse.sirius.components.core.api.ILabelServiceDelegate;
-import org.eclipse.sirius.components.core.api.IRepresentationMetadataProvider;
 import org.eclipse.sirius.components.core.api.labels.StyledString;
 import org.eclipse.sirius.components.core.api.labels.StyledStringFragment;
 import org.eclipse.sirius.components.core.api.labels.StyledStringFragmentStyle;
@@ -37,8 +34,8 @@ public class EcoreSampleStyledLabelService extends DefaultLabelService implement
 
     private static final String NAME = "name";
 
-    public EcoreSampleStyledLabelService(List<IRepresentationMetadataProvider> representationMetadataProviders, IRepresentationMetadataPersistenceService representationMetadataPersistenceService, LabelFeatureProviderRegistry labelFeatureProviderRegistry, ComposedAdapterFactory composedAdapterFactory, List<IRepresentationImageProvider> representationImageProviders) {
-        super(representationMetadataProviders, labelFeatureProviderRegistry, composedAdapterFactory, representationImageProviders);
+    public EcoreSampleStyledLabelService(LabelFeatureProviderRegistry labelFeatureProviderRegistry, ComposedAdapterFactory composedAdapterFactory) {
+        super(labelFeatureProviderRegistry, composedAdapterFactory);
     }
 
     @Override

--- a/packages/starters/backend/sirius-components-task-starter/src/main/java/org/eclipse/sirius/components/task/starter/services/TaskLabelServiceDelegate.java
+++ b/packages/starters/backend/sirius-components-task-starter/src/main/java/org/eclipse/sirius/components/task/starter/services/TaskLabelServiceDelegate.java
@@ -12,14 +12,12 @@
  *******************************************************************************/
 package org.eclipse.sirius.components.task.starter.services;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.core.api.ILabelServiceDelegate;
 import org.eclipse.sirius.components.core.api.IObjectSearchService;
-import org.eclipse.sirius.components.core.api.IRepresentationMetadataProvider;
 import org.eclipse.sirius.components.core.api.labels.StyledString;
 import org.eclipse.sirius.components.emf.services.DefaultLabelService;
 import org.eclipse.sirius.components.emf.services.LabelFeatureProviderRegistry;
@@ -37,8 +35,8 @@ public class TaskLabelServiceDelegate extends DefaultLabelService implements ILa
 
     private final EditingDomainServices editingDomainServices = new EditingDomainServices();
 
-    public TaskLabelServiceDelegate(List<IRepresentationMetadataProvider> representationMetadataProviders, ComposedAdapterFactory composedAdapterFactory, LabelFeatureProviderRegistry labelFeatureProviderRegistry) {
-        super(representationMetadataProviders, labelFeatureProviderRegistry, composedAdapterFactory, List.of());
+    public TaskLabelServiceDelegate(ComposedAdapterFactory composedAdapterFactory, LabelFeatureProviderRegistry labelFeatureProviderRegistry) {
+        super(labelFeatureProviderRegistry, composedAdapterFactory);
     }
 
     @Override


### PR DESCRIPTION
## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?