### PR TITLE
[4254] Make explorer services reusable

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -94,6 +94,7 @@ Specifiers are also encouraged to implement their own `IRestDataVersionPayloadSe
 - https://github.com/eclipse-sirius/sirius-web/issues/3823[#3823] [table] Remove cell type to use `ICellDescription`
 - https://github.com/eclipse-sirius/sirius-web/issues/4231[#4231] [table] Make table's column resizable
 - https://github.com/eclipse-sirius/sirius-web/issues/4234[#4234] [table] Make table's row resizable
+- https://github.com/eclipse-sirius/sirius-web/issues/4254[#4254] [sirius-web] Make explorer services reusable
 
 == v2024.11.0
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/representations/DomainExplorerServices.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/representations/DomainExplorerServices.java
@@ -17,28 +17,19 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
-import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature.Setting;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationImageProvider;
-import org.eclipse.sirius.components.core.CoreImageConstants;
-import org.eclipse.sirius.components.core.RepresentationMetadata;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.core.api.IURLParser;
-import org.eclipse.sirius.components.core.api.SemanticKindConstants;
 import org.eclipse.sirius.components.domain.Domain;
 import org.eclipse.sirius.components.domain.Entity;
-import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
-import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
-import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
 import org.eclipse.sirius.web.application.UUIDParser;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerServices;
 import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.services.api.IRepresentationMetadataSearchService;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.stereotype.Service;
@@ -61,54 +52,35 @@ public class DomainExplorerServices {
 
     private final IRepresentationMetadataSearchService representationMetadataSearchService;
 
-    private final IURLParser urlParser;
+    private final IExplorerServices explorerServices;
 
-    private final List<IRepresentationImageProvider> representationImageProviders;
-
-    public DomainExplorerServices(IObjectService objectService, IRepresentationMetadataSearchService representationMetadataSearchService, IURLParser urlParser, List<IRepresentationImageProvider> representationImageProviders) {
+    public DomainExplorerServices(IObjectService objectService, IRepresentationMetadataSearchService representationMetadataSearchService, IURLParser urlParser, List<IRepresentationImageProvider> representationImageProviders, IExplorerServices explorerServices) {
         this.objectService = Objects.requireNonNull(objectService);
         this.representationMetadataSearchService = Objects.requireNonNull(representationMetadataSearchService);
-        this.urlParser = Objects.requireNonNull(urlParser);
-        this.representationImageProviders = Objects.requireNonNull(representationImageProviders);
+        this.explorerServices = Objects.requireNonNull(explorerServices);
     }
 
     public String getKind(Object self) {
         String kind = "";
-        if (self instanceof RepresentationMetadata representationMetadata) {
-            kind = representationMetadata.kind();
-        } else if (self instanceof Resource) {
-            kind = DOCUMENT_KIND;
-        } else if (self instanceof SettingWrapper) {
+        if (self instanceof SettingWrapper) {
             kind = "setting";
         } else {
-            kind = this.objectService.getKind(self);
+            kind = this.explorerServices.getKind(self);
         }
         return kind;
     }
 
     public boolean hasChildren(IEditingContext editingContext, Object self) {
         boolean hasChildren = false;
-        if (self instanceof Resource resource) {
-            hasChildren = !resource.getContents().isEmpty();
-        } else if (self instanceof EObject eObject) {
-            hasChildren = !eObject.eContents().isEmpty();
-
-            if (!hasChildren) {
-                var optionalEditingContextId = new UUIDParser().parse(editingContext.getId());
-                if (optionalEditingContextId.isPresent()) {
-                    var projectId = optionalEditingContextId.get();
-                    String id = this.objectService.getId(eObject);
-                    hasChildren = this.representationMetadataSearchService.existAnyRepresentationForProjectAndTargetObjectId(AggregateReference.to(projectId), id);
-                }
-            }
-
-            if (!hasChildren && self instanceof Entity) {
-                hasChildren = true;
-            }
-        } else if (self instanceof SettingWrapper wrapper) {
+        if (self instanceof SettingWrapper wrapper) {
             var value = wrapper.setting.get(true);
             if (value instanceof Collection<?> collection) {
                 hasChildren = !collection.isEmpty();
+            }
+        } else {
+            hasChildren = this.explorerServices.hasChildren(self, editingContext);
+            if (!hasChildren && self instanceof Entity) {
+                hasChildren = true;
             }
         }
         return hasChildren;
@@ -116,19 +88,9 @@ public class DomainExplorerServices {
 
     public List<Object> getElements(IEditingContext editingContext) {
         List<Object> elements = new ArrayList<>();
-
-        var optionalResourceSet = Optional.of(editingContext).filter(IEditingContext.class::isInstance)
-                .filter(IEMFEditingContext.class::isInstance)
-                .map(IEMFEditingContext.class::cast)
-                .map(IEMFEditingContext::getDomain)
-                .map(EditingDomain::getResourceSet);
-
-        var resources = optionalResourceSet.map(resourceSet -> resourceSet.getResources().stream()
+        this.explorerServices.getDefaultElements(editingContext).stream()
                 .filter(resource -> resource.getContents().stream().anyMatch(Domain.class::isInstance))
-                .sorted(Comparator.nullsLast(Comparator.comparing(this::getResourceLabel, String.CASE_INSENSITIVE_ORDER)))
-                .toList()
-        ).orElseGet(ArrayList::new);
-        elements.addAll(resources);
+                .forEach(elements::add);
         return elements;
     }
 
@@ -166,53 +128,31 @@ public class DomainExplorerServices {
 
     public Object getParent(Object self, IEditingContext editingContext, String treeItemId) {
         Object result = null;
-
-        if (self instanceof RepresentationMetadata) {
-            var optionalRepresentationMetadata = new UUIDParser().parse(treeItemId).flatMap(this.representationMetadataSearchService::findMetadataById);
-            var repId = optionalRepresentationMetadata.map(org.eclipse.sirius.web.domain.boundedcontexts.representationdata.RepresentationMetadata::getTargetObjectId).orElse(null);
-            result = this.objectService.getObject(editingContext, repId);
-        } else if (self instanceof EObject eObject) {
-            Object semanticContainer = eObject.eContainer();
-            if (semanticContainer == null) {
-                semanticContainer = eObject.eResource();
-            }
-            result = semanticContainer;
-        } else if (self instanceof SettingWrapper wrapper) {
-            // the parent of the superTypes node is the object associated to this Setting
+        if (self instanceof SettingWrapper wrapper) {
+         // the parent of the superTypes node is the object associated to this Setting
             result = wrapper.setting.getEObject();
+        } else {
+            result = this.explorerServices.getParent(self, treeItemId, editingContext);
         }
         return result;
     }
 
     public String getTreeItemLabel(Object self) {
         String label = "";
-
-        if (self instanceof RepresentationMetadata representationMetadata) {
-            label = representationMetadata.label();
-        } else if (self instanceof Resource resource) {
-            label = this.getResourceLabel(resource);
-        } else if (self instanceof EObject) {
-            label = this.objectService.getLabel(self);
-            if (label.isBlank()) {
-                var kind = this.objectService.getKind(self);
-                label = this.urlParser.getParameterValues(kind).get(SemanticKindConstants.ENTITY_ARGUMENT).get(0);
-            }
-        } else if (self instanceof SettingWrapper wrapper) {
+        if (self instanceof SettingWrapper wrapper) {
             label = wrapper.setting.getEStructuralFeature().getName();
+        } else {
+            label = this.explorerServices.getLabel(self);
         }
         return label;
     }
 
     public String getTreeItemId(Object self) {
         String id = null;
-        if (self instanceof RepresentationMetadata representationMetadata) {
-            id = representationMetadata.id();
-        } else if (self instanceof Resource resource) {
-            id = resource.getURI().path().substring(1);
-        } else if (self instanceof EObject) {
-            id = this.objectService.getId(self);
-        } else if (self instanceof SettingWrapper wrapper) {
+        if (self instanceof SettingWrapper wrapper) {
             id = SETTING + this.objectService.getId(wrapper.setting.getEObject()) + SETTING_ID_SEPARATOR + wrapper.setting.getEStructuralFeature().getName();
+        } else {
+            id = this.explorerServices.getTreeItemId(self);
         }
         return id;
     }
@@ -230,47 +170,14 @@ public class DomainExplorerServices {
                 result = new SettingWrapper(internalObject.eSetting(internalObject.eClass().getEStructuralFeature(featureName)));
             }
         } else {
-            var optionalObject = this.objectService.getObject(editingContext, treeItemId);
-            if (optionalObject.isPresent()) {
-                result = optionalObject.get();
-            } else {
-                var optionalEditingDomain = Optional.of(editingContext)
-                        .filter(IEMFEditingContext.class::isInstance)
-                        .map(IEMFEditingContext.class::cast)
-                        .map(IEMFEditingContext::getDomain);
-
-                if (optionalEditingDomain.isPresent()) {
-                    var editingDomain = optionalEditingDomain.get();
-                    ResourceSet resourceSet = editingDomain.getResourceSet();
-                    URI uri = new JSONResourceFactory().createResourceURI(treeItemId);
-
-                    result = resourceSet.getResources().stream()
-                            .filter(resource -> resource.getURI().equals(uri))
-                            .findFirst()
-                            .orElse(null);
-                }
-            }
+            result = this.explorerServices.getTreeItemObject(treeItemId, editingContext);
         }
 
         return result;
     }
 
     public List<String> getIconURL(Object self) {
-        List<String> result = List.of(CoreImageConstants.DEFAULT_SVG);
-        if (self instanceof EObject) {
-            result = this.objectService.getImagePath(self);
-        } else if (self instanceof RepresentationMetadata representationMetadata) {
-            if (!representationMetadata.iconURLs().isEmpty()) {
-                result = representationMetadata.iconURLs();
-            } else {
-                result = this.representationImageProviders.stream()
-                        .flatMap(provider -> provider.getImageURL(representationMetadata.kind()).stream())
-                        .toList();
-            }
-        } else if (self instanceof Resource) {
-            result = List.of("/explorer/Resource.svg");
-        }
-        return result;
+        return this.explorerServices.getImageURL(self);
     }
 
     public boolean isDeletable(Object self) {
@@ -283,15 +190,6 @@ public class DomainExplorerServices {
 
     public boolean isSelectable(Object self) {
         return !(self instanceof SettingWrapper);
-    }
-
-    private String getResourceLabel(Resource resource) {
-        return resource.eAdapters().stream()
-                .filter(ResourceMetadataAdapter.class::isInstance)
-                .map(ResourceMetadataAdapter.class::cast)
-                .findFirst()
-                .map(ResourceMetadataAdapter::getName)
-                .orElse(resource.getURI().lastSegment());
     }
 
     public Object toggleAbstractEntity(Object self) {

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerServices.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerServices.java
@@ -1,0 +1,260 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationImageProvider;
+import org.eclipse.sirius.components.core.CoreImageConstants;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IObjectService;
+import org.eclipse.sirius.components.core.api.IURLParser;
+import org.eclipse.sirius.components.core.api.SemanticKindConstants;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
+import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
+import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
+import org.eclipse.sirius.web.application.UUIDParser;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerServices;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.RepresentationIconURL;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.RepresentationMetadata;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.services.api.IRepresentationMetadataSearchService;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.stereotype.Service;
+
+/**
+ * Services used to perform operations in the explorer.
+ *
+ * @author gdaniel
+ */
+@Service
+public class ExplorerServices implements IExplorerServices {
+
+    private final IObjectService objectService;
+
+    private final IURLParser urlParser;
+
+    private final List<IRepresentationImageProvider> representationImageProviders;
+
+    private final IRepresentationMetadataSearchService representationMetadataSearchService;
+
+    public ExplorerServices(IObjectService objectService, IURLParser urlParser, List<IRepresentationImageProvider> representationImageProviders,
+            IRepresentationMetadataSearchService representationMetadataSearchService) {
+        this.objectService = objectService;
+        this.urlParser = urlParser;
+        this.representationImageProviders = representationImageProviders;
+        this.representationMetadataSearchService = representationMetadataSearchService;
+    }
+
+    @Override
+    public String getTreeItemId(Object self) {
+        String id = null;
+        if (self instanceof RepresentationMetadata representationMetadata) {
+            id = representationMetadata.getId().toString();
+        } else if (self instanceof Resource resource) {
+            id = resource.getURI().path().substring(1);
+        } else if (self instanceof EObject) {
+            id = this.objectService.getId(self);
+        }
+        return id;
+    }
+
+    @Override
+    public String getKind(Object self) {
+        String kind = "";
+        if (self instanceof RepresentationMetadata representationMetadata) {
+            kind = representationMetadata.getKind();
+        } else if (self instanceof Resource) {
+            kind = ExplorerDescriptionProvider.DOCUMENT_KIND;
+        } else {
+            kind = this.objectService.getKind(self);
+        }
+        return kind;
+    }
+
+    @Override
+    public String getLabel(Object self) {
+        String label = "";
+        if (self instanceof RepresentationMetadata representationMetadata) {
+            label = representationMetadata.getLabel();
+        } else if (self instanceof Resource resource) {
+            label = this.getResourceLabel(resource);
+        } else if (self instanceof EObject) {
+            label = this.objectService.getLabel(self);
+            if (label.isBlank()) {
+                var kind = this.objectService.getKind(self);
+                label = this.urlParser.getParameterValues(kind).get(SemanticKindConstants.ENTITY_ARGUMENT).get(0);
+            }
+        }
+        return label;
+    }
+
+    private String getResourceLabel(Resource resource) {
+        return resource.eAdapters().stream().filter(ResourceMetadataAdapter.class::isInstance).map(ResourceMetadataAdapter.class::cast).findFirst().map(ResourceMetadataAdapter::getName)
+                .orElse(resource.getURI().lastSegment());
+    }
+
+    @Override
+    public boolean isEditable(Object self) {
+        boolean editable = false;
+        if (self instanceof RepresentationMetadata) {
+            editable = true;
+        } else if (self instanceof Resource) {
+            editable = true;
+        } else if (self instanceof EObject) {
+            editable = this.objectService.isLabelEditable(self);
+        }
+        return editable;
+    }
+
+    @Override
+    public boolean isDeletable(Object self) {
+        return true;
+    }
+
+    @Override
+    public boolean isSelectable(Object self) {
+        return true;
+    }
+
+    @Override
+    public List<String> getImageURL(Object self) {
+        List<String> imageURL = List.of(CoreImageConstants.DEFAULT_SVG);
+        if (self instanceof EObject) {
+            imageURL = this.objectService.getImagePath(self);
+        } else if (self instanceof RepresentationMetadata representationMetadata) {
+            if (!representationMetadata.getIconURLs().isEmpty()) {
+                imageURL = representationMetadata.getIconURLs().stream()
+                        .map(RepresentationIconURL::url)
+                        .toList();
+            } else {
+                imageURL = this.representationImageProviders.stream()
+                        .flatMap(provider -> provider.getImageURL(representationMetadata.getKind()).stream())
+                        .toList();
+            }
+        } else if (self instanceof Resource) {
+            imageURL = List.of("/explorer/Resource.svg");
+        }
+        return imageURL;
+    }
+
+    @Override
+    public Object getTreeItemObject(String treeItemId, IEditingContext editingContext) {
+        Object result = null;
+        if (editingContext != null && treeItemId != null) {
+            var optionalObject = this.objectService.getObject(editingContext, treeItemId);
+            if (optionalObject.isPresent()) {
+                result = optionalObject.get();
+            } else {
+                var optionalEditingDomain = Optional.of(editingContext)
+                        .filter(IEMFEditingContext.class::isInstance)
+                        .map(IEMFEditingContext.class::cast)
+                        .map(IEMFEditingContext::getDomain);
+
+                if (optionalEditingDomain.isPresent()) {
+                    var editingDomain = optionalEditingDomain.get();
+                    ResourceSet resourceSet = editingDomain.getResourceSet();
+                    URI uri = new JSONResourceFactory().createResourceURI(treeItemId);
+
+                    result = resourceSet.getResources().stream()
+                            .filter(resource -> resource.getURI().equals(uri))
+                            .findFirst()
+                            .orElse(null);
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Object getParent(Object self, String treeItemId, IEditingContext editingContext) {
+        Object result = null;
+
+        if (self instanceof RepresentationMetadata && treeItemId != null && editingContext != null) {
+            var optionalRepresentationMetadata = new UUIDParser().parse(treeItemId).flatMap(this.representationMetadataSearchService::findMetadataById);
+            var targetObjectId = optionalRepresentationMetadata.map(RepresentationMetadata::getTargetObjectId).orElse(null);
+            result = this.objectService.getObject(editingContext, targetObjectId).orElse(null);
+        } else if (self instanceof EObject eObject) {
+            Object semanticContainer = eObject.eContainer();
+            if (semanticContainer == null) {
+                semanticContainer = eObject.eResource();
+            }
+            result = semanticContainer;
+        }
+        return result;
+    }
+
+    @Override
+    public boolean hasChildren(Object self, IEditingContext editingContext) {
+        boolean hasChildren = false;
+        if (self instanceof Resource resource) {
+            hasChildren = !resource.getContents().isEmpty();
+        } else if (self instanceof EObject eObject) {
+            hasChildren = !eObject.eContents().isEmpty();
+            var optionalProjectId = Optional.ofNullable(editingContext).map(IEditingContext::getId).flatMap(new UUIDParser()::parse);
+
+            if (!hasChildren && optionalProjectId.isPresent()) {
+                var projectId = optionalProjectId.get();
+                String id = this.objectService.getId(eObject);
+                hasChildren = this.representationMetadataSearchService.existAnyRepresentationForProjectAndTargetObjectId(AggregateReference.to(projectId), id);
+            }
+        }
+        return hasChildren;
+    }
+
+    @Override
+    public List<Object> getDefaultChildren(Object self, IEditingContext editingContext, List<String> expandedIds) {
+        List<Object> result = new ArrayList<>();
+        if (editingContext != null) {
+            String id = this.getTreeItemId(self);
+            if (expandedIds.contains(id)) {
+                if (self instanceof Resource resource) {
+                    result.addAll(resource.getContents());
+                } else if (self instanceof EObject) {
+                    new UUIDParser().parse(editingContext.getId()).ifPresent(projectId -> {
+                        var representationMetadata = new ArrayList<>(this.representationMetadataSearchService.findAllMetadataByProjectAndTargetObjectId(AggregateReference.to(projectId), id));
+                        representationMetadata.sort(Comparator.comparing(RepresentationMetadata::getLabel));
+                        result.addAll(representationMetadata);
+                        List<Object> contents = this.objectService.getContents(self);
+                        result.addAll(contents);
+                    });
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public List<Resource> getDefaultElements(IEditingContext editingContext) {
+        var optionalResourceSet = Optional.ofNullable(editingContext)
+                .filter(IEditingContext.class::isInstance)
+                .filter(IEMFEditingContext.class::isInstance)
+                .map(IEMFEditingContext.class::cast)
+                .map(IEMFEditingContext::getDomain)
+                .map(EditingDomain::getResourceSet);
+
+        return optionalResourceSet
+                .map(resourceSet -> resourceSet.getResources().stream()
+                        .sorted(Comparator.nullsLast(Comparator.comparing(this::getResourceLabel, String.CASE_INSENSITIVE_ORDER)))
+                        .toList())
+                .orElseGet(ArrayList::new);
+    }
+
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerServices.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerServices.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services.api;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+
+/**
+ * Services used to perform operations in the explorer.
+ *
+ * @author gdaniel
+ */
+public interface IExplorerServices {
+
+    String getTreeItemId(Object self);
+
+    String getKind(Object self);
+
+    String getLabel(Object self);
+
+    boolean isEditable(Object self);
+
+    boolean isDeletable(Object self);
+
+    boolean isSelectable(Object self);
+
+    List<String> getImageURL(Object self);
+
+    Object getTreeItemObject(String treeItemId, IEditingContext editingContext);
+
+    Object getParent(Object self, String treeItemId, IEditingContext editingContext);
+
+    boolean hasChildren(Object self, IEditingContext editingContext);
+
+    /**
+     * Returns the un-filtered list of children for {@code self}.
+     *
+     * @param self
+     *            the object to retrieve the children from
+     * @param editingContext
+     *            the editing context
+     * @param expandedIds
+     *            the list of expanded tree items
+     * @return the list of children
+     */
+    List<Object> getDefaultChildren(Object self, IEditingContext editingContext, List<String> expandedIds);
+
+    /**
+     * Returns the un-filtered list of root elements.
+     *
+     * @param editingContext
+     *            the editing context
+     * @return the list of root elements
+     */
+    List<Resource> getDefaultElements(IEditingContext editingContext);
+}


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4254

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
- Existing default explorer should have the same behavior as before.
- The "Domain Explorer by DSL" explorer should have the same behavior as before.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?