### PR TITLE
[4302] Fix edges label flashing

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -57,8 +57,8 @@ This provider is in charge of getting the icon list of the representation.
 - https://github.com/eclipse-sirius/sirius-web/issues/4195[#4195] [sirius-web] Prevent objects disappearing when dropped on themselves (or a descendant) in the _Explorer_.
 - https://github.com/eclipse-sirius/sirius-web/issues/1062[#1062] [explorer] It is now possible to expand or collapse items in the explorer without selecting them by clicking directly on the expand/collapse arrow icon.
 This was first fixed in 2022.3.0 but broken in 2024.3.0; it is now fixed again.
-- https://github.com/eclipse-sirius/sirius-web/issues/4280[#4280] Fix direct edit with F2 when the palette is opened
-
+- https://github.com/eclipse-sirius/sirius-web/issues/4280[#4280] [diagram] Fix direct edit with F2 when the palette is opened
+- https://github.com/eclipse-sirius/sirius-web/issues/4302[#4302] [diagram] Fix edges label flashing
 
 === New Features
 


### PR DESCRIPTION
The changes:
* extract the code to compute the middle points in a function;
* when computing `edgeCenter`, if we need to use the middlepoints, compute them (using that function) if they are not available inside the state at this point in time. This is the main part of the fix, which ensures we do not end up looking into an empty array of middle points and returning 0;
* compute `edgeCenter` once as a `XYPoint` instead of doing the work twice in two similar functions for x and y;
* be more precise in the memo dependencies, as `point.x + point.y` can technically return the same value for different `x` & `y`.
