### PR TITLE
[4376] Add support for URLs to specify a selection of elements in the workbench

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -137,6 +137,7 @@ The implementation of the library update mechanism is generic and works on any p
 - https://github.com/eclipse-sirius/sirius-web/issues/4483 [#4483] Add row level filters in table
 
 
+
 === Improvements
 
 - https://github.com/eclipse-sirius/sirius-web/issues/4495[#4495] [form] Add an user indicator when executing form actions
@@ -166,7 +167,7 @@ Except for the specific case where `cause === 'refresh'` in `DiagramRenderer` (w
 - https://github.com/eclipse-sirius/sirius-web/issues/4208[#4208] [form] Improve performance of details view rendering on selection change
 - https://github.com/eclipse-sirius/sirius-web/issues/4704[#4704] [diagram] Stop zooming in when selecting an element
 - [table] Remove the old "Fork Table View Model" from the settings of the table since this menu existed even on non view based tables and a more generic menu is now available in the explorer
-
+- https://github.com/eclipse-sirius/sirius-web/issues/4376[#4376] [sirius-web] Keep URL search params while using the project workbench
 
 
 == v2025.2.0

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -168,6 +168,7 @@ Except for the specific case where `cause === 'refresh'` in `DiagramRenderer` (w
 - https://github.com/eclipse-sirius/sirius-web/issues/4704[#4704] [diagram] Stop zooming in when selecting an element
 - [table] Remove the old "Fork Table View Model" from the settings of the table since this menu existed even on non view based tables and a more generic menu is now available in the explorer
 - https://github.com/eclipse-sirius/sirius-web/issues/4376[#4376] [sirius-web] Keep URL search params while using the project workbench
+- https://github.com/eclipse-sirius/sirius-web/issues/4376[#4376] [sirius-web] Synchronize the selection with the URL
 
 
 == v2025.2.0

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/EditProjectView.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/EditProjectView.tsx
@@ -10,6 +10,7 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
+
 import {
   RepresentationMetadata,
   Selection,
@@ -25,7 +26,7 @@ import {
 } from '@eclipse-sirius/sirius-components-trees';
 import { useMachine } from '@xstate/react';
 import { useEffect } from 'react';
-import { generatePath, Navigate, useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 import { makeStyles } from 'tss-react/mui';
 import { StateMachine } from 'xstate';
 import { NavigationBar } from '../../navigationBar/NavigationBar';
@@ -45,6 +46,7 @@ import { NewDocumentModalContribution } from './TreeToolBarContributions/NewDocu
 import { UploadDocumentModalContribution } from './TreeToolBarContributions/UploadDocumentModalContribution';
 import { UndoRedo } from './UndoRedo';
 import { useProjectAndRepresentationMetadata } from './useProjectAndRepresentationMetadata';
+import { useSynchronizeSelectionAndURL } from './useSynchronizeSelectionAndURL';
 
 const PROJECT_ID_SEPARATOR = '@';
 
@@ -59,7 +61,6 @@ const useEditProjectViewStyles = makeStyles()((_) => ({
 }));
 
 export const EditProjectView = () => {
-  const navigate = useNavigate();
   const { projectId: rawProjectId, representationId } = useParams<EditProjectViewParams>();
   const { classes } = useEditProjectViewStyles();
 
@@ -89,22 +90,16 @@ export const EditProjectView = () => {
     dispatch(selectRepresentationEvent);
   };
 
-  useEffect(() => {
-    const projectIdToRedirect = name ? projectId + PROJECT_ID_SEPARATOR + name : projectId;
-    if (context.representation && context.representation.id !== representationId && context.project.id === projectId) {
-      const pathname = generatePath('/projects/:projectId/edit/:representationId', {
-        projectId: projectIdToRedirect,
-        representationId: context.representation.id,
-      });
-      navigate(pathname);
-    } else if (value === 'loaded' && context.representation === null && representationId) {
-      const pathname = generatePath('/projects/:projectId/edit/', { projectId: projectIdToRedirect });
-      navigate(pathname);
-    }
-  }, [value, projectId, context.representation, representationId]);
+  useSynchronizeSelectionAndURL(
+    projectId,
+    name,
+    representationId,
+    context.project?.id ?? null,
+    context.representation?.id ?? null,
+    value !== 'loaded'
+  );
 
   let content: React.ReactNode = null;
-
   if (value === 'loading') {
     content = <NavigationBar />;
   }

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/SelectionSynchronizer.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/SelectionSynchronizer.tsx
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { useSelection } from '@eclipse-sirius/sirius-components-core';
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { SelectionSynchronizerProps } from './SelectionSynchronizer.types';
+
+export const SelectionSynchronizer = ({ children }: SelectionSynchronizerProps) => {
+  const { selection } = useSelection();
+  const [_urlSearchParams, setUrlSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    setUrlSearchParams((urlSearchParams: URLSearchParams) => {
+      if (selection.entries.length > 0) {
+        const selectionValue: string = selection.entries.map((entry) => entry.id).join(',');
+        urlSearchParams.set('selection', selectionValue);
+      } else {
+        if (urlSearchParams.has('selection')) {
+          urlSearchParams.delete('selection');
+        }
+      }
+      return urlSearchParams;
+    });
+  }, [selection]);
+
+  return children;
+};

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/SelectionSynchronizer.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/SelectionSynchronizer.types.ts
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+export interface SelectionSynchronizerProps {
+  children: React.ReactNode;
+}

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/useSynchronizeSelectionAndURL.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/useSynchronizeSelectionAndURL.ts
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { useEffect } from 'react';
+import { generatePath, useNavigate } from 'react-router-dom';
+
+const PROJECT_ID_SEPARATOR = '@';
+
+export const useSynchronizeSelectionAndURL = (
+  projectId: string,
+  name: string,
+  representationId: string,
+  selectedProjectId: string | null,
+  selectedRepresentationId: string | null,
+  skip: boolean
+): void => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const projectIdToRedirect = name ? projectId + PROJECT_ID_SEPARATOR + name : projectId;
+    let pathname: string | null = null;
+    if (selectedRepresentationId && selectedRepresentationId !== representationId && selectedProjectId === projectId) {
+      pathname = generatePath('/projects/:projectId/edit/:representationId', {
+        projectId: projectIdToRedirect,
+        representationId: selectedRepresentationId,
+      });
+    } else if (selectedRepresentationId === null && representationId) {
+      pathname = generatePath('/projects/:projectId/edit/', { projectId: projectIdToRedirect });
+    }
+
+    if (!skip && pathname) {
+      navigate(pathname);
+    }
+  }, [projectId, selectedRepresentationId, representationId, skip]);
+};

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/useSynchronizeSelectionAndURL.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/useSynchronizeSelectionAndURL.ts
@@ -12,7 +12,7 @@
  *******************************************************************************/
 
 import { useEffect } from 'react';
-import { generatePath, useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate, useSearchParams } from 'react-router-dom';
 
 const PROJECT_ID_SEPARATOR = '@';
 
@@ -25,6 +25,7 @@ export const useSynchronizeSelectionAndURL = (
   skip: boolean
 ): void => {
   const navigate = useNavigate();
+  const [urlSearchParams] = useSearchParams();
 
   useEffect(() => {
     const projectIdToRedirect = name ? projectId + PROJECT_ID_SEPARATOR + name : projectId;
@@ -39,7 +40,14 @@ export const useSynchronizeSelectionAndURL = (
     }
 
     if (!skip && pathname) {
-      navigate(pathname);
+      if (urlSearchParams !== null && urlSearchParams.size > 0) {
+        navigate({
+          pathname: pathname,
+          search: `?${urlSearchParams}`,
+        });
+      } else {
+        navigate(pathname);
+      }
     }
-  }, [projectId, selectedRepresentationId, representationId, skip]);
+  }, [projectId, selectedRepresentationId, representationId, skip, urlSearchParams]);
 };

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/ExplorerView.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/ExplorerView.tsx
@@ -155,7 +155,7 @@ export const ExplorerView = ({ editingContextId, readOnly }: WorkbenchViewCompon
     .sort()
     .join(':');
   useEffect(() => {
-    if (state.synchronizedWithSelection && state.tree?.id) {
+    if (state.synchronizedWithSelection && state.tree) {
       const variables: GQLGetTreePathVariables = {
         editingContextId,
         treeId: state.tree.id,
@@ -163,7 +163,7 @@ export const ExplorerView = ({ editingContextId, readOnly }: WorkbenchViewCompon
       };
       getTreePath({ variables });
     }
-  }, [editingContextId, selectionKey, state.synchronizedWithSelection, getTreePath]);
+  }, [editingContextId, selectionKey, state.synchronizedWithSelection, state.tree, getTreePath]);
 
   useEffect(() => {
     if (treePathData && treePathData.viewer?.editingContext?.treePath) {


### PR DESCRIPTION
Can you please review this PR and let me know:
* If the implementation looks OK
* What kind of tests do you expect for this feature?

Note: there are 2 small remaining issues I found while testing:

1. Selecting a representation leads to an empty selection
This is an existing issue which impacts us a bit. I believe it's out of the scope of this PR as it already existed and is not blocking, but it could be good to have a dedicated issue to track this.
To reproduce:
    * Start from a diagram with a selection of elements which are displayed
in the diagram (they can be selected either in the diagram or through
the 'Explorer' tree)
    * Then select either the diagram representation in the 'Explorer' view, or the diagram background.
    * => The selection gets set to the diagram representation (briefly), but quickly evolves into an empty selection => KO
    * Notice how this does not occur when starting from a selection of elements that are _not_ shown in the diagram, or from an empty selection.
    * I believe the issue is that currently selecting a representation when it is opened 'resets' the selection to an empty one. I think the correct behavior would be to keep the representation in the selection.

3. Graphical selection in diagram is not performed when resolving a URL with a selection.
This one is a bit more annoying.
To reproduce:
    * Open a diagram representation, select an element (from the 'Explorer' view or the diagram) that is represented in the diagram.
    * Observe that the corresponding graphical element (e.g. node) is selected graphically because its border is in purple.
    * Reload the URL
    * Observe that the workbench selection gets set appropriately (the selected element in the 'Explorer' has the pink background)
    * But the graphical selection is not performed. => KO.
    * Expectation: the graphical node must be selected as well.
    * I think the issue stems from the effect in `useDiagramSelection` that depends on `selection`. When it is executed for the first time, the diagram does not yet have its nodes and edges so nothing gets selected. Adding a dependency from this effect to the getNodes and getEdges leads to flickering between the current and previous selections.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [X] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [X] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [X] Variables have a proper type
- [X] Functions’ arguments have a proper type
- [X] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [X] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
* Open a project
* Select element(s) like documents, semantic elements or representations from the workbench (e.g. in 'Explorer' view or in a representation).
* Observe that the URL changes as the workbench selection evolves.
* Observe that loading such a URL does set the workbench selection as specified.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?