### PR TITLE
[4462] Add support for library visualization

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -136,6 +136,8 @@ See `PapayaExtensionRegistry.tsx` for how the same result as before can be achie
 - https://github.com/eclipse-sirius/sirius-web/issues/4458[#4458] [sirius-web] Export direct edit functionalities.
 - https://github.com/eclipse-sirius/sirius-web/issues/4481[#4481] [table] Add support for cell custom target object in View DSL
 - https://github.com/eclipse-sirius/sirius-web/issues/4377[#4377] [sirius-web] Add the ability to update dynamically the description of any representation
+- https://github.com/eclipse-sirius/sirius-web/issues/4462[#4462] [sirius-web] Add support for visualization of the libraries available on a server.
+For that, a new page `/libraries` showing all the libraries has been contributed.
 
 
 === Improvements

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/controllers/ViewerLibrariesDataFetcher.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/controllers/ViewerLibrariesDataFetcher.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.library.controllers;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
+import org.eclipse.sirius.components.core.graphql.dto.PageInfoWithCount;
+import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.web.application.library.dto.LibraryDTO;
+import org.eclipse.sirius.web.application.library.services.api.ILibraryApplicationService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import graphql.relay.Connection;
+import graphql.relay.ConnectionCursor;
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.Edge;
+import graphql.relay.Relay;
+import graphql.schema.DataFetchingEnvironment;
+
+/**
+ * Data fetcher for the field Viewer#libraries.
+ *
+ * @author gdaniel
+ */
+@QueryDataFetcher(type = "Viewer", field = "libraries")
+public class ViewerLibrariesDataFetcher implements IDataFetcherWithFieldCoordinates<Connection<LibraryDTO>> {
+
+    private static final String PAGE_ARGUMENT = "page";
+
+    private static final String LIMIT_ARGUMENT = "limit";
+
+    private final ILibraryApplicationService libraryApplicationService;
+
+    public ViewerLibrariesDataFetcher(ILibraryApplicationService libraryApplicationService) {
+        this.libraryApplicationService = Objects.requireNonNull(libraryApplicationService);
+    }
+
+    @Override
+    public Connection<LibraryDTO> get(DataFetchingEnvironment environment) throws Exception {
+        int page = Optional.<Integer> ofNullable(environment.getArgument(PAGE_ARGUMENT))
+                .filter(pageArgument -> pageArgument > 0)
+                .orElse(0);
+        int limit = Optional.<Integer> ofNullable(environment.getArgument(LIMIT_ARGUMENT))
+                .filter(limitArgument -> limitArgument > 0)
+                .orElse(20);
+
+        var pageable = PageRequest.of(page, limit);
+        var libraryPage = this.libraryApplicationService.findAll(pageable);
+        return this.toConnection(libraryPage);
+    }
+
+    private Connection<LibraryDTO> toConnection(Page<LibraryDTO> libraryPage) {
+        var edges = libraryPage.stream().map(libraryDTO -> {
+            var globalId = new Relay().toGlobalId("Library", libraryDTO.id().toString());
+            var cursor = new DefaultConnectionCursor(globalId);
+            return (Edge<LibraryDTO>) new DefaultEdge<>(libraryDTO, cursor);
+        }).toList();
+
+        ConnectionCursor startCursor = edges.stream().findFirst()
+                .map(Edge::getCursor)
+                .orElse(null);
+        ConnectionCursor endCursor = null;
+        if (!edges.isEmpty()) {
+            endCursor = edges.get(edges.size() - 1).getCursor();
+        }
+        var pageInfo = new PageInfoWithCount(startCursor, endCursor, libraryPage.hasPrevious(), libraryPage.hasNext(), libraryPage.getTotalElements());
+        return new DefaultConnection<>(edges, pageInfo);
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/dto/LibraryDTO.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/dto/LibraryDTO.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.library.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * The DTO for libraries.
+ *
+ * @author gdaniel
+ */
+public record LibraryDTO(
+        @NotNull UUID id,
+        @NotNull String namespace,
+        @NotNull String name,
+        @NotNull String version,
+        @NotNull String description,
+        @NotNull Instant createdOn) {
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/LibraryApplicationService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/LibraryApplicationService.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.library.services;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.web.application.library.dto.LibraryDTO;
+import org.eclipse.sirius.web.application.library.services.api.ILibraryApplicationService;
+import org.eclipse.sirius.web.application.library.services.api.ILibraryMapper;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.services.api.ILibrarySearchService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Application services used to manipulate libraries.
+ *
+ * @author gdaniel
+ */
+@Service
+public class LibraryApplicationService implements ILibraryApplicationService {
+
+    private final ILibrarySearchService librarySearchService;
+
+    private final ILibraryMapper libraryMapper;
+
+    public LibraryApplicationService(ILibrarySearchService librarySearchService, ILibraryMapper libraryMapper) {
+        this.librarySearchService = Objects.requireNonNull(librarySearchService);
+        this.libraryMapper = Objects.requireNonNull(libraryMapper);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<LibraryDTO> findAll(Pageable pageable) {
+        return this.librarySearchService.findAll(pageable).map(this.libraryMapper::toDTO);
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/LibraryMapper.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/LibraryMapper.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.library.services;
+
+import org.eclipse.sirius.web.application.library.dto.LibraryDTO;
+import org.eclipse.sirius.web.application.library.services.api.ILibraryMapper;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.Library;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to convert a library to a DTO.
+ *
+ * @author gdaniel
+ */
+@Service
+public class LibraryMapper implements ILibraryMapper {
+
+    @Override
+    public LibraryDTO toDTO(Library library) {
+        return new LibraryDTO(
+                library.getId(),
+                library.getNamespace(),
+                library.getName(),
+                library.getVersion(),
+                library.getDescription(),
+                library.getCreatedOn()
+        );
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/api/ILibraryApplicationService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/api/ILibraryApplicationService.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.library.services.api;
+
+import org.eclipse.sirius.web.application.library.dto.LibraryDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Application services used to manipulate libraries.
+ *
+ * @author gdaniel
+ */
+public interface ILibraryApplicationService {
+
+    Page<LibraryDTO> findAll(Pageable pageable);
+
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/api/ILibraryMapper.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/api/ILibraryMapper.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.library.services.api;
+
+import org.eclipse.sirius.web.application.library.dto.LibraryDTO;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.Library;
+
+/**
+ * Used to convert a library to a DTO.
+ *
+ * @author gdaniel
+ */
+public interface ILibraryMapper {
+
+    LibraryDTO toDTO(Library library);
+
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/semanticdata/listeners/SemanticDataInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/semanticdata/listeners/SemanticDataInitializer.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.application.semanticdata.listeners;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.sirius.web.domain.boundedcontexts.project.events.ProjectCreatedEvent;
@@ -38,6 +39,6 @@ public class SemanticDataInitializer {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener
     public void onProjectCreatedEvent(ProjectCreatedEvent event) {
-        this.semanticDataCreationService.create(event);
+        this.semanticDataCreationService.create(event, List.of(), List.of());
     }
 }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/resources/schema/libraries.graphqls
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/resources/schema/libraries.graphqls
@@ -1,0 +1,21 @@
+extend type Viewer {
+  libraries(page: Int!, limit: Int!): ViewerLibrariesConnection!
+}
+
+type ViewerLibrariesConnection {
+  edges: [ViewerLibrariesEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ViewerLibrariesEdge {
+  node: Library!
+}
+
+type Library {
+  id: ID!
+  namespace: String!
+  name: String!
+  version: String!
+  description: String!
+  createdOn: Instant!
+}

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/Library.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/Library.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.domain.boundedcontexts.library;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.eclipse.sirius.components.events.ICause;
+import org.eclipse.sirius.web.domain.boundedcontexts.AbstractValidatingAggregateRoot;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.events.LibraryCreatedEvent;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.SemanticData;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.MappedCollection;
+import org.springframework.data.relational.core.mapping.Table;
+
+/**
+ * The aggregate root of the library bounded context.
+ *
+ * @author gdaniel
+ */
+@Table("library")
+public class Library extends AbstractValidatingAggregateRoot<Library> implements Persistable<UUID> {
+
+    @Transient
+    private boolean isNew;
+
+    @Id
+    private UUID id;
+
+    private String namespace;
+
+    private String name;
+
+    private String version;
+
+    @Column("semantic_data_id")
+    private AggregateReference<SemanticData, UUID> semanticData;
+
+    @MappedCollection(idColumn = "library_id", keyColumn = "index")
+    private Set<LibraryDependency> dependencies = new LinkedHashSet<>();
+
+    private String description;
+
+    private Instant createdOn;
+
+    private Instant lastModifiedOn;
+
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+
+    public String getNamespace() {
+        return this.namespace;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public AggregateReference<SemanticData, UUID> getSemanticData() {
+        return this.semanticData;
+    }
+
+    public Set<LibraryDependency> getDependencies() {
+        return Collections.unmodifiableSet(this.dependencies);
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public Instant getCreatedOn() {
+        return this.createdOn;
+    }
+
+    public Instant getLastModifiedOn() {
+        return this.lastModifiedOn;
+    }
+
+    @Override
+    public boolean isNew() {
+        return this.isNew;
+    }
+
+    public static Builder newLibrary() {
+        return new Builder();
+    }
+
+    /**
+     * Used to create new libraries.
+     *
+     * @author gdaniel
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+
+        private String namespace;
+
+        private String name;
+
+        private String version;
+
+        private AggregateReference<SemanticData, UUID> semanticData;
+
+        private Set<LibraryDependency> dependencies = new LinkedHashSet<>();
+
+        private String description;
+
+        public Builder namespace(String namespace) {
+            this.namespace = Objects.requireNonNull(namespace);
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = Objects.requireNonNull(name);
+            return this;
+        }
+
+        public Builder version(String version) {
+            this.version = Objects.requireNonNull(version);
+            return this;
+        }
+
+        public Builder semanticData(AggregateReference<SemanticData, UUID> semanticData) {
+            this.semanticData = Objects.requireNonNull(semanticData);
+            return this;
+        }
+
+        public Builder dependencies(List<AggregateReference<Library, UUID>> dependencies) {
+            this.dependencies = dependencies.stream()
+                .map(LibraryDependency::new)
+                .collect(Collectors.toSet());
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = Objects.requireNonNull(description);
+            return this;
+        }
+
+        public Library build(ICause cause) {
+            var library = new Library();
+            library.isNew = true;
+            library.id = UUID.randomUUID();
+            library.namespace = Objects.requireNonNull(this.namespace);
+            library.name = Objects.requireNonNull(this.name);
+            library.version = Objects.requireNonNull(this.version);
+            library.semanticData = Objects.requireNonNull(this.semanticData);
+            library.dependencies = Objects.requireNonNull(this.dependencies);
+            library.description = Objects.requireNonNull(this.description);
+
+            var now = Instant.now();
+            library.createdOn = now;
+            library.lastModifiedOn = now;
+
+            library.registerEvent(new LibraryCreatedEvent(UUID.randomUUID(), now, cause, library));
+            return library;
+        }
+    }
+
+}

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/LibraryDependency.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/LibraryDependency.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.domain.boundedcontexts.library;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.data.relational.core.mapping.Table;
+
+/**
+ * A dependency of a library.
+ *
+ * @author gdaniel
+ */
+@Table("library_dependency")
+public record LibraryDependency(AggregateReference<Library, UUID> dependencyLibraryId) {
+
+    public LibraryDependency {
+        Objects.requireNonNull(dependencyLibraryId);
+    }
+
+}

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/events/ILibraryEvent.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/events/ILibraryEvent.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.domain.boundedcontexts.library.events;
+
+import org.eclipse.sirius.web.domain.events.IDomainEvent;
+
+/**
+ * Interface implemented by all the domain events of the library bounded context.
+ *
+ * @author gdaniel
+ */
+public interface ILibraryEvent extends IDomainEvent {
+
+}

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/events/LibraryCreatedEvent.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/events/LibraryCreatedEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,20 +10,25 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api;
+package org.eclipse.sirius.web.domain.boundedcontexts.library.events;
 
-import java.util.List;
+import java.time.Instant;
+import java.util.UUID;
 
 import org.eclipse.sirius.components.events.ICause;
-import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.Document;
-import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.SemanticData;
-import org.eclipse.sirius.web.domain.services.IResult;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.Library;
+
+import jakarta.validation.constraints.NotNull;
 
 /**
- * Used to create the semantic data.
+ * Event fired when a library is created.
  *
- * @author sbegaudeau
+ * @author gdaniel
  */
-public interface ISemanticDataCreationService {
-    IResult<SemanticData> create(ICause cause, List<Document> documents, List<String> domains);
+public record LibraryCreatedEvent(
+        @NotNull UUID id,
+        @NotNull Instant createdOn,
+        @NotNull ICause causedBy,
+        @NotNull Library library) implements ILibraryEvent {
+
 }

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/repositories/ILibraryRepository.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/repositories/ILibraryRepository.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.domain.boundedcontexts.library.repositories;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.domain.boundedcontexts.library.Library;
+import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.ListPagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository used to persist the library aggregate.
+ *
+ * @author gdaniel
+ */
+@Repository
+public interface ILibraryRepository extends ListPagingAndSortingRepository<Library, UUID>, ListCrudRepository<Library, UUID> {
+
+    @Query("""
+        SELECT CASE WHEN COUNT(*) > 0 THEN true ELSE false END
+        FROM library
+        WHERE library.namespace = :namespace AND library.name = :name AND library.version = :version
+        """)
+    boolean existsByNamespaceAndNameAndVersion(String namespace, String name, String version);
+
+    @Query("""
+        SELECT * FROM library
+        WHERE library.namespace = :namespace AND library.name = :name AND library.version = :version
+        """)
+    Optional<Library> findByNamespaceAndNameAndVersion(String namespace, String name, String version);
+}

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/services/LibraryCreationService.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/services/LibraryCreationService.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.domain.boundedcontexts.library.services;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.web.domain.boundedcontexts.library.Library;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.repositories.ILibraryRepository;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.services.api.ILibraryCreationService;
+import org.eclipse.sirius.web.domain.services.IResult;
+import org.eclipse.sirius.web.domain.services.Success;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to create libraries.
+ *
+ * @author sbegaudeau
+ */
+@Service
+public class LibraryCreationService implements ILibraryCreationService {
+
+    private final ILibraryRepository libraryRepository;
+
+    public LibraryCreationService(ILibraryRepository libraryRepository) {
+        this.libraryRepository = Objects.requireNonNull(libraryRepository);
+    }
+
+    @Override
+    public IResult<Library> createLibrary(Library library) {
+        this.libraryRepository.save(library);
+        return new Success<>(library);
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/services/LibrarySearchService.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/services/LibrarySearchService.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.domain.boundedcontexts.library.services;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.sirius.web.domain.boundedcontexts.library.Library;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.repositories.ILibraryRepository;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.services.api.ILibrarySearchService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to retrieve libraries.
+ *
+ * @author gdaniel
+ */
+@Service
+public class LibrarySearchService implements ILibrarySearchService {
+
+    private final ILibraryRepository libraryRepository;
+
+    public LibrarySearchService(ILibraryRepository libraryRepository) {
+        this.libraryRepository = Objects.requireNonNull(libraryRepository);
+    }
+
+    @Override
+    public Page<Library> findAll(Pageable pageable) {
+        return this.libraryRepository.findAll(pageable);
+    }
+
+    @Override
+    public boolean existsByNamespaceAndNameAndVersion(String namespace, String name, String version) {
+        return this.libraryRepository.existsByNamespaceAndNameAndVersion(namespace, name, version);
+    }
+
+    @Override
+    public Optional<Library> findByNamespaceAndNameAndVersion(String namespace, String name, String version) {
+        return this.libraryRepository.findByNamespaceAndNameAndVersion(namespace, name, version);
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/services/api/ILibraryCreationService.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/services/api/ILibraryCreationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,20 +10,16 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api;
+package org.eclipse.sirius.web.domain.boundedcontexts.library.services.api;
 
-import java.util.List;
-
-import org.eclipse.sirius.components.events.ICause;
-import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.Document;
-import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.SemanticData;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.Library;
 import org.eclipse.sirius.web.domain.services.IResult;
 
 /**
- * Used to create the semantic data.
+ * Used to create a library.
  *
  * @author sbegaudeau
  */
-public interface ISemanticDataCreationService {
-    IResult<SemanticData> create(ICause cause, List<Document> documents, List<String> domains);
+public interface ILibraryCreationService {
+    IResult<Library> createLibrary(Library library);
 }

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/services/api/ILibrarySearchService.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/library/services/api/ILibrarySearchService.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.domain.boundedcontexts.library.services.api;
+
+import java.util.Optional;
+
+import org.eclipse.sirius.web.domain.boundedcontexts.library.Library;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Used to retrieve libraries.
+ *
+ * @author gdaniel
+ */
+public interface ILibrarySearchService {
+
+    Page<Library> findAll(Pageable pageable);
+
+    boolean existsByNamespaceAndNameAndVersion(String namespace, String name, String version);
+
+    Optional<Library> findByNamespaceAndNameAndVersion(String namespace, String name, String version);
+}

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/semanticdata/SemanticData.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/semanticdata/SemanticData.java
@@ -13,9 +13,9 @@
 package org.eclipse.sirius.web.domain.boundedcontexts.semanticdata;
 
 import java.time.Instant;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -153,12 +153,13 @@ public class SemanticData extends AbstractValidatingAggregateRoot<SemanticData> 
 
         private Set<SemanticDataDomain> domains = new LinkedHashSet<>();
 
-        public Builder documents(Set<Document> documents) {
-            this.documents = Objects.requireNonNull(documents);
+        public Builder documents(List<Document> documents) {
+            this.documents = documents.stream()
+                    .collect(Collectors.toSet());
             return this;
         }
 
-        public Builder domains(Collection<String> domains) {
+        public Builder domains(List<String> domains) {
             this.domains = domains.stream()
                     .map(SemanticDataDomain::new)
                     .collect(Collectors.toSet());

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/semanticdata/services/SemanticDataCreationService.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/semanticdata/services/SemanticDataCreationService.java
@@ -12,10 +12,11 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services;
 
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import org.eclipse.sirius.components.events.ICause;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.Document;
 import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.SemanticData;
 import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.repositories.ISemanticDataRepository;
 import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api.ISemanticDataCreationService;
@@ -38,9 +39,10 @@ public class SemanticDataCreationService implements ISemanticDataCreationService
     }
 
     @Override
-    public IResult<SemanticData> create(ICause cause) {
+    public IResult<SemanticData> create(ICause cause, List<Document> documents, List<String> domains) {
         var semanticData = SemanticData.newSemanticData()
-                .documents(Set.of())
+                .documents(documents)
+                .domains(domains)
                 .build(cause);
         this.semanticDataRepository.save(semanticData);
 

--- a/packages/sirius-web/backend/sirius-web-infrastructure/src/main/resources/db/changelog/2025.2/03-add-library-table.xml
+++ b/packages/sirius-web/backend/sirius-web-infrastructure/src/main/resources/db/changelog/2025.2/03-add-library-table.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025 Obeo.
+  ~ This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  ~
+  ~ Contributors:
+  ~     Obeo - initial API and implementation
+  -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="03-add-library-table" author="gdaniel">
+
+        <createTable tableName="library">
+            <column name="id" type="UUID" defaultValueComputed="gen_random_uuid()">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="namespace" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+			<column name="name" type="TEXT">
+                <constraints nullable="false" />
+            </column>
+            <column name="version" type="TEXT">
+                <constraints nullable="false" />
+            </column>
+            <column name="semantic_data_id" type="UUID">
+                <constraints nullable="false" />
+            </column>
+            <column name="description" type="TEXT">
+                <constraints nullable="false" />
+            </column>
+            <column name="created_on" type="TIMESTAMPTZ">
+                <constraints nullable="false" />
+            </column>
+            <column name="last_modified_on" type="TIMESTAMPTZ">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+        <addUniqueConstraint tableName="library" columnNames="namespace,name,version" />
+        <addForeignKeyConstraint baseTableName="library" baseColumnNames="semantic_data_id" constraintName="fk_library_semantic_data_id" referencedTableName="semantic_data" referencedColumnNames="id" />
+
+        <createTable tableName="library_dependency">
+            <column name="library_id" type="UUID">
+                <constraints nullable="false" />
+            </column>
+			<column name="dependency_library_id" type="UUID">
+                <constraints nullable="false" />
+            </column>
+            <column name="index" type="INTEGER">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="library_dependency" columnNames="library_id,dependency_library_id" />
+		<addForeignKeyConstraint baseTableName="library_dependency" baseColumnNames="library_id" constraintName="fk_library_id" referencedTableName="library" referencedColumnNames="id" />
+		<addForeignKeyConstraint baseTableName="library_dependency" baseColumnNames="dependency_library_id" constraintName="fk_dependency_library_id" referencedTableName="library" referencedColumnNames="id" />
+
+    </changeSet>
+</databaseChangeLog>

--- a/packages/sirius-web/backend/sirius-web-infrastructure/src/main/resources/db/changelog/2025.2/2025.2.0.xml
+++ b/packages/sirius-web/backend/sirius-web-infrastructure/src/main/resources/db/changelog/2025.2/2025.2.0.xml
@@ -17,4 +17,5 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
     <include file="db/changelog/2025.2/01-alter_project_id_type.xml" />
     <include file="db/changelog/2025.2/02-drop-fk-semantic-data-project-id-add-project-semantic-data.xml" />
+    <include file="db/changelog/2025.2/03-add-library-table.xml" />
 </databaseChangeLog>

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/factories/JavaLangFactory.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/factories/JavaLangFactory.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.papaya.factories;
+
+import java.util.List;
+
+import org.eclipse.sirius.components.papaya.Package;
+import org.eclipse.sirius.components.papaya.PapayaFactory;
+import org.eclipse.sirius.components.papaya.Type;
+
+/**
+ * Used to create the java.lang package.
+ *
+ * @author sbegaudeau
+ */
+public class JavaLangFactory {
+
+    public Package javaLang() {
+        var javaLang = PapayaFactory.eINSTANCE.createPackage();
+        javaLang.setName("java.lang");
+        javaLang.getTypes().addAll(this.javaLangPrimitiveTypes());
+        javaLang.getTypes().addAll(this.javaLangObjectTypes());
+
+        return javaLang;
+    }
+
+    private List<Type> javaLangPrimitiveTypes() {
+        var voidDataType = PapayaFactory.eINSTANCE.createDataType();
+        voidDataType.setName("void");
+
+        var byteDataType = PapayaFactory.eINSTANCE.createDataType();
+        byteDataType.setName("byte");
+
+        var shortDataType = PapayaFactory.eINSTANCE.createDataType();
+        shortDataType.setName("short");
+
+        var intDataType = PapayaFactory.eINSTANCE.createDataType();
+        intDataType.setName("int");
+
+        var longDataType = PapayaFactory.eINSTANCE.createDataType();
+        longDataType.setName("long");
+
+        var floatDataType = PapayaFactory.eINSTANCE.createDataType();
+        floatDataType.setName("float");
+
+        var doubleDataType = PapayaFactory.eINSTANCE.createDataType();
+        doubleDataType.setName("double");
+
+        var booleanDataType = PapayaFactory.eINSTANCE.createDataType();
+        booleanDataType.setName("boolean");
+
+        var charDataType = PapayaFactory.eINSTANCE.createDataType();
+        charDataType.setName("char");
+
+        return List.of(voidDataType, byteDataType, shortDataType, intDataType, longDataType, floatDataType, doubleDataType, booleanDataType, charDataType);
+    }
+
+    private List<Type> javaLangObjectTypes() {
+        var objectClass = PapayaFactory.eINSTANCE.createClass();
+        objectClass.setName("Object");
+
+        var stringClass = PapayaFactory.eINSTANCE.createClass();
+        stringClass.setName("String");
+
+        var voidClass = PapayaFactory.eINSTANCE.createClass();
+        voidClass.setName("Void");
+
+        var byteClass = PapayaFactory.eINSTANCE.createClass();
+        byteClass.setName("Byte");
+
+        var shortClass = PapayaFactory.eINSTANCE.createClass();
+        shortClass.setName("Short");
+
+        var integerClass = PapayaFactory.eINSTANCE.createClass();
+        integerClass.setName("Integer");
+
+        var longClass = PapayaFactory.eINSTANCE.createClass();
+        longClass.setName("Long");
+
+        var floatClass = PapayaFactory.eINSTANCE.createClass();
+        floatClass.setName("Float");
+
+        var doubleClass = PapayaFactory.eINSTANCE.createClass();
+        doubleClass.setName("Double");
+
+        var booleanClass = PapayaFactory.eINSTANCE.createClass();
+        booleanClass.setName("Boolean");
+
+        var characterClass = PapayaFactory.eINSTANCE.createClass();
+        characterClass.setName("Character");
+
+        var autoCloseableInterface = PapayaFactory.eINSTANCE.createInterface();
+        autoCloseableInterface.setName("AutoCloseable");
+
+        var cloneableInterface = PapayaFactory.eINSTANCE.createInterface();
+        cloneableInterface.setName("Cloneable");
+
+        var comparableTTypeParameter = PapayaFactory.eINSTANCE.createTypeParameter();
+        comparableTTypeParameter.setName("T");
+        var comparableInterface = PapayaFactory.eINSTANCE.createInterface();
+        comparableInterface.setName("Comparable");
+        comparableInterface.getTypeParameters().add(comparableTTypeParameter);
+
+        var iterableTTypeParameter = PapayaFactory.eINSTANCE.createTypeParameter();
+        iterableTTypeParameter.setName("T");
+        var iterableInterface = PapayaFactory.eINSTANCE.createInterface();
+        iterableInterface.setName("Iterable");
+        iterableInterface.getTypeParameters().add(iterableTTypeParameter);
+
+        return List.of(
+                objectClass,
+                stringClass,
+                voidClass,
+                byteClass,
+                shortClass,
+                integerClass,
+                longClass,
+                floatClass,
+                doubleClass,
+                booleanClass,
+                characterClass,
+                autoCloseableInterface,
+                cloneableInterface,
+                comparableInterface,
+                iterableInterface
+        );
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/factories/JavaProjectFactory.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/factories/JavaProjectFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,6 @@ import org.eclipse.sirius.components.papaya.Component;
 import org.eclipse.sirius.components.papaya.Package;
 import org.eclipse.sirius.components.papaya.PapayaFactory;
 import org.eclipse.sirius.components.papaya.Project;
-import org.eclipse.sirius.components.papaya.Type;
 import org.eclipse.sirius.web.papaya.factories.services.api.IEObjectIndexer;
 import org.eclipse.sirius.web.papaya.factories.services.api.IObjectFactory;
 
@@ -57,7 +56,7 @@ public class JavaProjectFactory implements IObjectFactory {
         var javaBase = PapayaFactory.eINSTANCE.createComponent();
         javaBase.setName("java.base");
         javaBase.getPackages().addAll(List.of(
-                this.javaLang(),
+                new JavaLangFactory().javaLang(),
                 this.javaIo(),
                 this.javaText(),
                 this.javaTime(),
@@ -65,117 +64,6 @@ public class JavaProjectFactory implements IObjectFactory {
         ));
 
         return javaBase;
-    }
-
-    private Package javaLang() {
-        var javaLang = PapayaFactory.eINSTANCE.createPackage();
-        javaLang.setName("java.lang");
-        javaLang.getTypes().addAll(this.javaLangPrimitiveTypes());
-        javaLang.getTypes().addAll(this.javaLangObjectTypes());
-
-        return javaLang;
-    }
-
-    private List<Type> javaLangPrimitiveTypes() {
-        var voidDataType = PapayaFactory.eINSTANCE.createDataType();
-        voidDataType.setName("void");
-
-        var byteDataType = PapayaFactory.eINSTANCE.createDataType();
-        byteDataType.setName("byte");
-
-        var shortDataType = PapayaFactory.eINSTANCE.createDataType();
-        shortDataType.setName("short");
-
-        var intDataType = PapayaFactory.eINSTANCE.createDataType();
-        intDataType.setName("int");
-
-        var longDataType = PapayaFactory.eINSTANCE.createDataType();
-        longDataType.setName("long");
-
-        var floatDataType = PapayaFactory.eINSTANCE.createDataType();
-        floatDataType.setName("float");
-
-        var doubleDataType = PapayaFactory.eINSTANCE.createDataType();
-        doubleDataType.setName("double");
-
-        var booleanDataType = PapayaFactory.eINSTANCE.createDataType();
-        booleanDataType.setName("boolean");
-
-        var charDataType = PapayaFactory.eINSTANCE.createDataType();
-        charDataType.setName("char");
-
-        return List.of(voidDataType, byteDataType, shortDataType, intDataType, longDataType, floatDataType, doubleDataType, booleanDataType, charDataType);
-    }
-
-    private List<Type> javaLangObjectTypes() {
-        var objectClass = PapayaFactory.eINSTANCE.createClass();
-        objectClass.setName("Object");
-
-        var stringClass = PapayaFactory.eINSTANCE.createClass();
-        stringClass.setName("String");
-
-        var voidClass = PapayaFactory.eINSTANCE.createClass();
-        voidClass.setName("Void");
-
-        var byteClass = PapayaFactory.eINSTANCE.createClass();
-        byteClass.setName("Byte");
-
-        var shortClass = PapayaFactory.eINSTANCE.createClass();
-        shortClass.setName("Short");
-
-        var integerClass = PapayaFactory.eINSTANCE.createClass();
-        integerClass.setName("Integer");
-
-        var longClass = PapayaFactory.eINSTANCE.createClass();
-        longClass.setName("Long");
-
-        var floatClass = PapayaFactory.eINSTANCE.createClass();
-        floatClass.setName("Float");
-
-        var doubleClass = PapayaFactory.eINSTANCE.createClass();
-        doubleClass.setName("Double");
-
-        var booleanClass = PapayaFactory.eINSTANCE.createClass();
-        booleanClass.setName("Boolean");
-
-        var characterClass = PapayaFactory.eINSTANCE.createClass();
-        characterClass.setName("Character");
-
-        var autoCloseableInterface = PapayaFactory.eINSTANCE.createInterface();
-        autoCloseableInterface.setName("AutoCloseable");
-
-        var cloneableInterface = PapayaFactory.eINSTANCE.createInterface();
-        cloneableInterface.setName("Cloneable");
-
-        var comparableTTypeParameter = PapayaFactory.eINSTANCE.createTypeParameter();
-        comparableTTypeParameter.setName("T");
-        var comparableInterface = PapayaFactory.eINSTANCE.createInterface();
-        comparableInterface.setName("Comparable");
-        comparableInterface.getTypeParameters().add(comparableTTypeParameter);
-
-        var iterableTTypeParameter = PapayaFactory.eINSTANCE.createTypeParameter();
-        iterableTTypeParameter.setName("T");
-        var iterableInterface = PapayaFactory.eINSTANCE.createInterface();
-        iterableInterface.setName("Iterable");
-        iterableInterface.getTypeParameters().add(iterableTTypeParameter);
-
-        return List.of(
-                objectClass,
-                stringClass,
-                voidClass,
-                byteClass,
-                shortClass,
-                integerClass,
-                longClass,
-                floatClass,
-                doubleClass,
-                booleanClass,
-                characterClass,
-                autoCloseableInterface,
-                cloneableInterface,
-                comparableInterface,
-                iterableInterface
-        );
     }
 
     private Package javaIo() {

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/InitializeStandardLibraryEvent.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/InitializeStandardLibraryEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2025, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,20 +10,23 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api;
+package org.eclipse.sirius.web.papaya.services.library;
 
-import java.util.List;
+import java.util.UUID;
 
 import org.eclipse.sirius.components.events.ICause;
-import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.Document;
-import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.SemanticData;
-import org.eclipse.sirius.web.domain.services.IResult;
+
+import jakarta.validation.constraints.NotNull;
 
 /**
- * Used to create the semantic data.
+ * Input used to track the initialization of the standard library.
  *
  * @author sbegaudeau
  */
-public interface ISemanticDataCreationService {
-    IResult<SemanticData> create(ICause cause, List<Document> documents, List<String> domains);
+public record InitializeStandardLibraryEvent(
+        @NotNull UUID id,
+        @NotNull String namespace,
+        @NotNull String name,
+        @NotNull String version,
+        @NotNull String description) implements ICause {
 }

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/PapayaJavaStandardLibraryPublisher.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/PapayaJavaStandardLibraryPublisher.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2025, 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.papaya.services.library;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.papaya.services.library.api.IStandardLibrarySemanticDataInitializer;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to ensure that the Papaya - Java Standard Library is always published in a Sirius Web application.
+ *
+ * @author sbegaudeau
+ */
+@Service
+public class PapayaJavaStandardLibraryPublisher implements CommandLineRunner {
+
+    private final IStandardLibrarySemanticDataInitializer standardLibrarySemanticDataInitializer;
+
+    public PapayaJavaStandardLibraryPublisher(IStandardLibrarySemanticDataInitializer standardLibrarySemanticDataInitializer) {
+        this.standardLibrarySemanticDataInitializer = Objects.requireNonNull(standardLibrarySemanticDataInitializer);
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        var initializeJavaStandardLibraryEvent = new InitializeStandardLibraryEvent(UUID.randomUUID(), "java", "Java Standard Library", "17.0.0", "The standard library of the Java programming language");
+        this.standardLibrarySemanticDataInitializer.initializeStandardLibrary(initializeJavaStandardLibraryEvent);
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/StandardLibraryInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/StandardLibraryInitializer.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.papaya.services.library;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.web.domain.boundedcontexts.library.Library;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.services.api.ILibraryCreationService;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.events.SemanticDataCreatedEvent;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Used to register the standard libraries once their semantic data have been created.
+ *
+ * @author sbegaudeau
+ */
+@Service
+public class StandardLibraryInitializer {
+
+    private final ILibraryCreationService libraryCreationService;
+
+    public StandardLibraryInitializer(ILibraryCreationService libraryCreationService) {
+        this.libraryCreationService = Objects.requireNonNull(libraryCreationService);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener
+    public void onSemanticDataCreatedEvent(SemanticDataCreatedEvent event) {
+        if (event.causedBy() instanceof InitializeStandardLibraryEvent initializeStandardLibraryEvent) {
+            var library = Library.newLibrary()
+                    .namespace(initializeStandardLibraryEvent.namespace())
+                    .name(initializeStandardLibraryEvent.name())
+                    .version(initializeStandardLibraryEvent.version())
+                    .semanticData(AggregateReference.to(event.semanticData().getId()))
+                    .dependencies(List.of())
+                    .description(initializeStandardLibraryEvent.description())
+                    .build(event);
+            this.libraryCreationService.createLibrary(library);
+        }
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/StandardLibrarySemanticDataInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/StandardLibrarySemanticDataInitializer.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.papaya.services.library;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
+import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
+import org.eclipse.sirius.components.papaya.PapayaPackage;
+import org.eclipse.sirius.web.application.editingcontext.services.EPackageEntry;
+import org.eclipse.sirius.web.application.editingcontext.services.api.IEditingDomainFactory;
+import org.eclipse.sirius.web.application.editingcontext.services.api.IResourceToDocumentService;
+import org.eclipse.sirius.web.domain.boundedcontexts.library.services.api.ILibrarySearchService;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api.ISemanticDataCreationService;
+import org.eclipse.sirius.web.papaya.factories.JavaLangFactory;
+import org.eclipse.sirius.web.papaya.services.library.api.IStandardLibrarySemanticDataInitializer;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Used to initialize the semantic data of a Papaya standard library.
+ *
+ * @author sbegaudeau
+ */
+@Service
+public class StandardLibrarySemanticDataInitializer implements IStandardLibrarySemanticDataInitializer {
+
+    private final ILibrarySearchService librarySearchService;
+
+    private final IEditingDomainFactory editingDomainFactory;
+
+    private final IResourceToDocumentService resourceToDocumentService;
+
+    private final ISemanticDataCreationService semanticDataCreationService;
+
+    public StandardLibrarySemanticDataInitializer(ILibrarySearchService librarySearchService, IEditingDomainFactory editingDomainFactory, IResourceToDocumentService resourceToDocumentService, ISemanticDataCreationService semanticDataCreationService) {
+        this.librarySearchService = Objects.requireNonNull(librarySearchService);
+        this.editingDomainFactory = Objects.requireNonNull(editingDomainFactory);
+        this.resourceToDocumentService = Objects.requireNonNull(resourceToDocumentService);
+        this.semanticDataCreationService = Objects.requireNonNull(semanticDataCreationService);
+    }
+
+    @Transactional
+    @Override
+    public void initializeStandardLibrary(InitializeStandardLibraryEvent event) {
+        if (this.librarySearchService.existsByNamespaceAndNameAndVersion(event.namespace(), event.name(), event.version())) {
+            return;
+        }
+
+        AdapterFactoryEditingDomain editingDomain = this.editingDomainFactory.createEditingDomain();
+        var packageRegistry = editingDomain.getResourceSet().getPackageRegistry();
+        packageRegistry.put(PapayaPackage.eNS_URI, PapayaPackage.eINSTANCE);
+
+        var documentId = UUID.nameUUIDFromBytes((event.namespace() + ":" + event.name() + ":" + event.version()).getBytes(StandardCharsets.UTF_8)).toString();
+        var resource = new JSONResourceFactory().createResourceFromPath(documentId);
+        var resourceMetadataAdapter = new ResourceMetadataAdapter(event.name());
+        resource.eAdapters().add(resourceMetadataAdapter);
+        editingDomain.getResourceSet().getResources().add(resource);
+
+        if (event.namespace().equals("java") && event.name().equals("Java Standard Library")) {
+            var javaLangPackage = new JavaLangFactory().javaLang();
+            resource.getContents().add(javaLangPackage);
+        }
+
+        this.resourceToDocumentService.toDocument(resource, false).ifPresent(documentData -> {
+            this.semanticDataCreationService.create(event, List.of(documentData.document()), documentData.ePackageEntries().stream().map(EPackageEntry::nsURI).toList());
+        });
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/api/IStandardLibrarySemanticDataInitializer.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/api/IStandardLibrarySemanticDataInitializer.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.papaya.services.library.api;
+
+import org.eclipse.sirius.web.papaya.services.library.InitializeStandardLibraryEvent;
+
+/**
+ * Used to initialize the semantic data of a Papaya standard library.
+ *
+ * @author sbegaudeau
+ */
+public interface IStandardLibrarySemanticDataInitializer {
+    void initializeStandardLibrary(InitializeStandardLibraryEvent event);
+}

--- a/packages/sirius-web/backend/sirius-web-tests-data/src/main/resources/sirius-web-scripts/cleanup.sql
+++ b/packages/sirius-web/backend/sirius-web-tests-data/src/main/resources/sirius-web-scripts/cleanup.sql
@@ -1,3 +1,5 @@
+DELETE FROM library_dependency;
+DELETE FROM library;
 DELETE FROM document;
 DELETE FROM semantic_data_domain;
 DELETE FROM semantic_data;

--- a/packages/sirius-web/backend/sirius-web-tests/src/main/java/org/eclipse/sirius/web/tests/graphql/LibrariesQueryRunner.java
+++ b/packages/sirius-web/backend/sirius-web-tests/src/main/java/org/eclipse/sirius/web/tests/graphql/LibrariesQueryRunner.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.tests.graphql;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.graphql.tests.api.IGraphQLRequestor;
+import org.eclipse.sirius.components.graphql.tests.api.IQueryRunner;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to get the libraries from the GraphQL API.
+ *
+ * @author gdaniel
+ */
+@Service
+public class LibrariesQueryRunner implements IQueryRunner {
+
+    private static final String LIBRARIES_QUERY = """
+            query getLibraries($page: Int!, $limit: Int!) {
+              viewer {
+                libraries(page: $page, limit: $limit) {
+                  edges {
+                    node {
+                      id
+                      namespace
+                      name
+                      version
+                      description
+                    }
+                  }
+                  pageInfo {
+                    hasPreviousPage
+                    hasNextPage
+                    startCursor
+                    endCursor
+                    count
+                  }
+                }
+              }
+            }
+            """;
+
+    private final IGraphQLRequestor graphQLRequestor;
+
+    public LibrariesQueryRunner(IGraphQLRequestor graphQLRequestor) {
+        this.graphQLRequestor = Objects.requireNonNull(graphQLRequestor);
+    }
+
+    @Override
+    public String run(Map<String, Object> variables) {
+        return this.graphQLRequestor.execute(LIBRARIES_QUERY, variables);
+    }
+}

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/libraries/LibraryControllerIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/libraries/LibraryControllerIntegrationTests.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.controllers.libraries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jayway.jsonpath.JsonPath;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.sirius.web.AbstractIntegrationTests;
+import org.eclipse.sirius.web.tests.data.GivenSiriusWebServer;
+import org.eclipse.sirius.web.tests.graphql.LibrariesQueryRunner;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Used to get libraries from the GraphQL API.
+ *
+ * @author gdaniel
+ */
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class LibraryControllerIntegrationTests extends AbstractIntegrationTests {
+
+    @Autowired
+    private LibrariesQueryRunner librariesQueryRunner;
+
+    @Test
+    @GivenSiriusWebServer
+    @DisplayName("Given a set of libraries, when a query is performed, then the libraries are returned")
+    public void givenSetOfLibrariesWhenQueryIsPerformedThenTheLibrariesAreReturned() {
+        Map<String, Object> variables = Map.of("page", 0, "limit", 10);
+        var result = this.librariesQueryRunner.run(variables);
+
+        boolean hasPreviousPage = JsonPath.read(result, "$.data.viewer.libraries.pageInfo.hasPreviousPage");
+        assertThat(hasPreviousPage).isFalse();
+
+        boolean hasNextPage = JsonPath.read(result, "$.data.viewer.libraries.pageInfo.hasNextPage");
+        assertThat(hasNextPage).isFalse();
+
+        String startCursor = JsonPath.read(result, "$.data.viewer.libraries.pageInfo.startCursor");
+        assertThat(startCursor).isNotBlank();
+
+        String endCursor = JsonPath.read(result, "$.data.viewer.libraries.pageInfo.endCursor");
+        assertThat(endCursor).isNotBlank();
+
+        int count = JsonPath.read(result, "$.data.viewer.libraries.pageInfo.count");
+        assertThat(count).isPositive();
+
+        List<String> libraryNamespaces = JsonPath.read(result, "$.data.viewer.libraries.edges[*].node.namespace");
+        assertThat(libraryNamespaces)
+                .isNotEmpty()
+                .anySatisfy(namespace -> assertThat(namespace).isEqualTo("java"));
+    }
+
+}

--- a/packages/sirius-web/frontend/sirius-web-application/src/extension/DefaultExtensionRegistry.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/extension/DefaultExtensionRegistry.tsx
@@ -47,19 +47,26 @@ import {
   ReferencePropertySection,
 } from '@eclipse-sirius/sirius-components-widget-reference';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import FileCopyIcon from '@mui/icons-material/FileCopy';
 import Filter from '@mui/icons-material/Filter';
+import FolderIcon from '@mui/icons-material/Folder';
 import ImageIcon from '@mui/icons-material/Image';
 import LinkIcon from '@mui/icons-material/Link';
 import MenuIcon from '@mui/icons-material/Menu';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import WarningIcon from '@mui/icons-material/Warning';
-import { useMatch } from 'react-router-dom';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import { Link as RouterLink, useMatch } from 'react-router-dom';
 import { DiagramFilter } from '../diagrams/DiagramFilter';
 import { ApolloLinkUndoRedoStack } from '../graphql/ApolloLinkUndoRedoStack';
 import { ApolloClientOptionsConfigurer } from '../graphql/useCreateApolloClient.types';
 import { apolloClientOptionsConfigurersExtensionPoint } from '../graphql/useCreateApolloClientExtensionPoints';
 import { NavigationBarRightContributionProps } from '../navigationBar/NavigationBar.types';
 import { navigationBarRightContributionExtensionPoint } from '../navigationBar/NavigationBarExtensionPoints';
+import { NavigationBarMenuItemProps } from '../navigationBar/NavigationBarMenu.types';
+import { navigationBarMenuEntryExtensionPoint } from '../navigationBar/NavigationBarMenuExtensionPoints';
 import { OnboardArea } from '../onboarding/OnboardArea';
 import { DiagramTreeItemContextMenuContribution } from '../views/edit-project/DiagramTreeItemContextMenuContribution';
 import { DocumentTreeItemContextMenuContribution } from '../views/edit-project/DocumentTreeItemContextMenuContribution';
@@ -198,6 +205,46 @@ export const OmniboxButtonContribution = ({}: NavigationBarRightContributionProp
 defaultExtensionRegistry.addComponent(navigationBarRightContributionExtensionPoint, {
   identifier: `siriusweb_${navigationBarRightContributionExtensionPoint.identifier}_omnibox`,
   Component: OmniboxButtonContribution,
+});
+
+/*******************************************************************************
+ *
+ * NavigationBar menu contributions
+ *
+ * Used to register actions in the navigation bar menu
+ *
+ *******************************************************************************/
+
+export const ProjectsButtonContribution = ({}: NavigationBarMenuItemProps) => {
+  return (
+    <MenuItem component={RouterLink} to="/projects">
+      <ListItemIcon>
+        <FolderIcon />
+      </ListItemIcon>
+      <ListItemText primary="Projects" />
+    </MenuItem>
+  );
+};
+
+defaultExtensionRegistry.addComponent(navigationBarMenuEntryExtensionPoint, {
+  identifier: `siriusweb_${navigationBarMenuEntryExtensionPoint.identifier}_projects`,
+  Component: ProjectsButtonContribution,
+});
+
+export const LibrariesButtonContribution = ({}: NavigationBarMenuItemProps) => {
+  return (
+    <MenuItem component={RouterLink} to="/libraries">
+      <ListItemIcon>
+        <FileCopyIcon />
+      </ListItemIcon>
+      <ListItemText primary="Libraries" />
+    </MenuItem>
+  );
+};
+
+defaultExtensionRegistry.addComponent(navigationBarMenuEntryExtensionPoint, {
+  identifier: `siriusweb_${navigationBarMenuEntryExtensionPoint.identifier}_libraries`,
+  Component: LibrariesButtonContribution,
 });
 
 /*******************************************************************************

--- a/packages/sirius-web/frontend/sirius-web-application/src/graphql/useCreateApolloClient.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/graphql/useCreateApolloClient.ts
@@ -30,6 +30,7 @@ import { useData } from '@eclipse-sirius/sirius-components-core';
 import { useMemo } from 'react';
 import { EditingContextStereotypesFragment, StereotypeFragment } from '../modals/new-document/useStereotypes.fragments';
 import { ProjectAndRepresentationFragment } from '../views/edit-project/useProjectAndRepresentationMetadata.fragment';
+import { LibraryFragment, ViewerLibrariesFragment } from '../views/library-browser/useLibraries.fragments';
 import {
   ProjectFragment,
   ViewerProjectsFragment,
@@ -67,6 +68,8 @@ export const useCreateApolloClient = (httpOrigin: string, wsOrigin: string): Apo
   fragmentRegistry.register(
     ViewerProjectsFragment,
     ProjectFragment,
+    ViewerLibrariesFragment,
+    LibraryFragment,
     ProjectAndRepresentationFragment,
     EditingContextStereotypesFragment,
     StereotypeFragment

--- a/packages/sirius-web/frontend/sirius-web-application/src/router/Router.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/router/Router.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Obeo.
+ * Copyright (c) 2023, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import { useData } from '@eclipse-sirius/sirius-components-core';
 import { Navigate, Route, Routes, useRouteError } from 'react-router-dom';
 import { EditProjectView } from '../views/edit-project/EditProjectView';
 import { ErrorView } from '../views/error/ErrorView';
+import { LibraryBrowser } from '../views/library-browser/LibraryBrowser';
 import { NewProjectView } from '../views/new-project/NewProjectView';
 import { ProjectBrowser } from '../views/project-browser/ProjectBrowser';
 import { ProjectSettingsView } from '../views/project-settings/ProjectSettingsView';
@@ -39,6 +40,7 @@ export const Router = () => {
         ErrorBoundary={ErrorBoundary}
       />
       <Route path="/projects/:projectId/settings/*" element={<ProjectSettingsView />} ErrorBoundary={ErrorBoundary} />
+      <Route path="/libraries" element={<LibraryBrowser />} ErrorBoundary={ErrorBoundary} />
       <Route path="/errors/:code" element={<ErrorView />} />
       {routes.map((props, index) => (
         <Route key={index} {...props} ErrorBoundary={ErrorBoundary} />

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/library-browser/LibraryBrowser.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/library-browser/LibraryBrowser.tsx
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { useComponent } from '@eclipse-sirius/sirius-components-core';
+import Container from '@mui/material/Container';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+import { MaterialReactTable, MRT_ColumnDef, MRT_PaginationState, useMaterialReactTable } from 'material-react-table';
+import { useEffect, useMemo, useState } from 'react';
+import { makeStyles } from 'tss-react/mui';
+import { footerExtensionPoint } from '../../footer/FooterExtensionPoints';
+import { NavigationBar } from '../../navigationBar/NavigationBar';
+import { LibrariesTableProps, LibrariesTableState } from './LibraryBrowser.types';
+import { useLibraries } from './useLibraries';
+import { GQLLibrary } from './useLibraries.types';
+
+const useLibrariesViewStyle = makeStyles()((theme) => ({
+  librariesView: {
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gridTemplateRows: 'min-content 1fr min-content',
+    minHeight: '100vh',
+  },
+  main: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(5),
+    paddingTop: theme.spacing(3),
+    paddingBottom: theme.spacing(3),
+  },
+  header: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+}));
+
+export const LibraryBrowser = () => {
+  const { classes } = useLibrariesViewStyle();
+  const { Component: Footer } = useComponent(footerExtensionPoint);
+
+  return (
+    <div className={classes.librariesView}>
+      <NavigationBar />
+      <Container maxWidth="xl">
+        <Grid container justifyContent="center">
+          <Grid item xs={8}>
+            <main className={classes.main}>
+              <div className={classes.header}>
+                <Typography variant="h4">Libraries</Typography>
+              </div>
+              <LibrariesTable />
+            </main>
+          </Grid>
+        </Grid>
+      </Container>
+      <Footer />
+    </div>
+  );
+};
+
+const LibrariesTable = ({}: LibrariesTableProps) => {
+  const [state, setState] = useState<LibrariesTableState>({
+    data: null,
+  });
+  const [pagination, setPagination] = useState<MRT_PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  });
+
+  const rows: GQLLibrary[] = state.data?.viewer.libraries.edges.map((edge) => edge.node) ?? [];
+  const count: number = state.data?.viewer.libraries.pageInfo.count ?? 0;
+
+  const { data } = useLibraries(pagination.pageIndex, pagination.pageSize);
+  useEffect(() => {
+    if (data) {
+      setState((prevState) => ({ ...prevState, data }));
+    }
+  }, [data]);
+
+  const columns = useMemo<MRT_ColumnDef<GQLLibrary>[]>(
+    () => [
+      {
+        accessorFn: (row) => row.name,
+        header: 'Name',
+        size: 200,
+        Cell: ({ renderedCellValue }) => <Typography noWrap>{renderedCellValue}</Typography>,
+      },
+      {
+        accessorFn: (row) => row.version,
+        header: 'Version',
+        size: 50,
+        Cell: ({ renderedCellValue }) => <Typography noWrap>{renderedCellValue}</Typography>,
+      },
+      {
+        accessorFn: (row) => new Date(row.createdOn).toISOString().split('T')[0],
+        header: 'Created On',
+        size: 50,
+        Cell: ({ renderedCellValue }) => <Typography noWrap>{renderedCellValue}</Typography>,
+      },
+      {
+        accessorFn: (row) => row.namespace,
+        header: 'Namespace',
+        size: 150,
+        Cell: ({ renderedCellValue }) => (
+          <Typography noWrap sx={{ opacity: '0.6' }}>
+            {renderedCellValue}
+          </Typography>
+        ),
+      },
+      {
+        accessorFn: (row) => row.description,
+        header: 'Description',
+        size: 200,
+        grow: true,
+        Cell: ({ renderedCellValue }) => <Typography noWrap>{renderedCellValue}</Typography>,
+      },
+    ],
+    []
+  );
+
+  const table = useMaterialReactTable<GQLLibrary>({
+    columns,
+    data: rows,
+
+    // Disable some unnecessary features (overkill here)
+    enableColumnActions: false,
+    enableColumnFilters: false,
+    enableFullScreenToggle: false,
+    enableDensityToggle: false,
+    enableHiding: false,
+    enableSorting: false,
+
+    // Configure pagination
+    enablePagination: true,
+    manualPagination: true,
+    onPaginationChange: setPagination,
+    state: { pagination },
+    rowCount: count,
+    autoResetPageIndex: false,
+  });
+
+  return <MaterialReactTable table={table} />;
+};

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/library-browser/LibraryBrowser.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/library-browser/LibraryBrowser.types.ts
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { GQLGetLibrariesQueryData } from './useLibraries.types';
+
+export interface LibrariesTableProps {}
+
+export interface LibrariesTableState {
+  data: GQLGetLibrariesQueryData | null;
+}

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/library-browser/useLibraries.fragments.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/library-browser/useLibraries.fragments.ts
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { gql } from '@apollo/client';
+
+export const ViewerLibrariesFragment = gql`
+  fragment ViewerLibraries on Viewer {
+    libraries(page: $page, limit: $limit) {
+      edges {
+        node {
+          ...Library
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+        count
+      }
+    }
+  }
+`;
+
+export const LibraryFragment = gql`
+  fragment Library on Library {
+    id
+    namespace
+    name
+    version
+    description
+    createdOn
+  }
+`;

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/library-browser/useLibraries.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/library-browser/useLibraries.ts
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { gql, useQuery } from '@apollo/client';
+import { useMultiToast } from '@eclipse-sirius/sirius-components-core';
+import { useEffect } from 'react';
+import { GQLGetLibrariesQueryData, GQLGetLibrariesQueryVariables, UseLibrariesValue } from './useLibraries.types';
+
+const getLibrariesQuery = gql`
+  query getLibraries($page: Int!, $limit: Int!) {
+    viewer {
+      ...ViewerLibraries
+    }
+  }
+`;
+
+export const useLibraries = (page: number, limit: number): UseLibrariesValue => {
+  const variables: GQLGetLibrariesQueryVariables = {
+    page,
+    limit,
+  };
+  const { data, loading, error, refetch } = useQuery<GQLGetLibrariesQueryData, GQLGetLibrariesQueryVariables>(
+    getLibrariesQuery,
+    {
+      variables,
+    }
+  );
+
+  const { addErrorMessage } = useMultiToast();
+  useEffect(() => {
+    if (error) {
+      addErrorMessage(error.message);
+    }
+  }, [error]);
+
+  const refreshLibraries = (page: number, limit: number) => refetch({ page, limit });
+
+  return {
+    data: data ?? null,
+    loading,
+    refreshLibraries,
+  };
+};

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/library-browser/useLibraries.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/library-browser/useLibraries.types.ts
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+export interface UseLibrariesValue {
+  data: GQLGetLibrariesQueryData | null;
+  loading: boolean;
+  refreshLibraries: (page: number, limit: number) => void;
+}
+
+export interface GQLGetLibrariesQueryVariables {
+  page: number;
+  limit: number;
+}
+
+export interface GQLGetLibrariesQueryData {
+  viewer: GQLViewer;
+}
+
+export interface GQLViewer {
+  libraries: GQLViewerLibraryConnection;
+}
+
+export interface GQLViewerLibraryConnection {
+  edges: GQLViewerLibraryEdge[];
+  pageInfo: GQLPageInfo;
+}
+
+export interface GQLViewerLibraryEdge {
+  node: GQLLibrary;
+}
+
+export interface GQLLibrary {
+  id: string;
+  namespace: string;
+  name: string;
+  version: string;
+  description: string;
+  createdOn: string;
+}
+
+export interface GQLPageInfo {
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+  count: number;
+}


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4462

This PR contains the following features (the other features related to library publication will be contributed in separated PRs to try to help with the reviews)
- New database table to store libraries and their dependencies
- New page `/libraries` to visualize the libraries stored in the database
- New GraphQL query to list libraries
- New mutation to publish libraries from a project
- First version of studio publication

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
Integration tests are provided in `LibraryControllerIntegrationTests`.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?