### PR TITLE
[4534] Used full representation id when retrieve row context menu

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -40,6 +40,8 @@ Given that it is an application service, it comes with some constraints with reg
 - https://github.com/eclipse-sirius/sirius-web/issues/4636[#4636] [sirius-web] Remove an useless div in the `EditProjectView`
 - https://github.com/eclipse-sirius/sirius-web/issues/4618[#4618] [diagram] Restore diagram layout propagation
 - https://github.com/eclipse-sirius/sirius-web/issues/4257[#4257] [diagram] Prevent the width of list parent nodes from increasing on each layout.
+- https://github.com/eclipse-sirius/sirius-web/issues/4534[#4534] [table] Fix an issue that prevent row action to be trigger on row in the next paginated data
+
 
 === New Features
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/representation/services/PersistentRepresentationMetadataProvider.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/representation/services/PersistentRepresentationMetadataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class PersistentRepresentationMetadataProvider implements IRepresentationMetadataProvider {
 
+    private static final String URL_PARAM = "?";
+
     private final IRepresentationMetadataSearchService representationMetadataSearchService;
 
     public PersistentRepresentationMetadataProvider(IRepresentationMetadataSearchService representationMetadataSearchService) {
@@ -38,7 +40,11 @@ public class PersistentRepresentationMetadataProvider implements IRepresentation
 
     @Override
     public Optional<RepresentationMetadata> getMetadata(String representationId) {
-        return new UUIDParser().parse(representationId)
+        var cleanRepresentationId = representationId;
+        if (representationId.indexOf(URL_PARAM) > 0) {
+            cleanRepresentationId = representationId.substring(0, representationId.indexOf(URL_PARAM));
+        }
+        return new UUIDParser().parse(cleanRepresentationId)
                 .flatMap(this.representationMetadataSearchService::findMetadataById)
                 .map(representation -> RepresentationMetadata.newRepresentationMetadata(representation.getId().toString())
                         .kind(representation.getKind())

--- a/packages/sirius-web/backend/sirius-web-tests/src/main/java/org/eclipse/sirius/web/tests/services/representation/RepresentationIdBuilder.java
+++ b/packages/sirius-web/backend/sirius-web-tests/src/main/java/org/eclipse/sirius/web/tests/services/representation/RepresentationIdBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -101,5 +101,14 @@ public class RepresentationIdBuilder {
                 .toList();
 
         return treeId + "?expandedIds=[" + String.join(",", expandedObjectIds) + "]";
+    }
+
+    public String buildTableRepresentationId(String tableId, String cursor, String direction, int size) {
+        return tableId + "?cursor=" +
+                cursor +
+                "&direction=" +
+                direction +
+                "&size=" +
+                size;
     }
 }

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/data/PapayaIdentifiers.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/data/PapayaIdentifiers.java
@@ -41,6 +41,8 @@ public final class PapayaIdentifiers {
 
     public static final UUID PAPAYA_PACKAGE_TABLE_REPRESENTATION = UUID.fromString("dd0080f8-430d-441f-99a4-f46c7d9b28ef");
 
+    public static final UUID PAPAYA_SUCCESS_CLASS_OBJECT = UUID.fromString("c715807f-73f6-44fb-b17b-df6d12558458");
+
     private PapayaIdentifiers() {
         // Prevent instantiation
     }

--- a/packages/tables/frontend/sirius-components-tables/src/rows/RowContextMenuContent.tsx
+++ b/packages/tables/frontend/sirius-components-tables/src/rows/RowContextMenuContent.tsx
@@ -72,7 +72,7 @@ export const RowContextMenuContent = ({
   >(getRowContextMenuEntriesQuery, {
     variables: {
       editingContextId,
-      representationId: tableId,
+      representationId,
       tableId,
       rowId: row.original.id,
     },


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4534

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?