### PR TITLE
[4581] Make data fetchers go through IEditingContextDispatcher

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -41,6 +41,7 @@ Our backend integration tests actual use the `postgres:latest` image (see `Abstr
 - https://github.com/eclipse-sirius/sirius-web/issues/4609[#4609] [sirius-web] Separate the representation metadata from the project bounded context.
 - https://github.com/eclipse-sirius/sirius-web/issues/4618[#4618] [diagram] Ensure layout-related mutations use a unique event id.
 Except for the specific case where `cause === 'refresh'` in `DiagramRenderer` (which corresponds to a layout update *after* an existing operation which caused the refresh, in which case we must reuse the original event id), other diagram-related mutations should behave like all the others and get a unique event id to clearly identify them.
+- https://github.com/eclipse-sirius/sirius-web/issues/4581[#4581] [sirius-web] Make (almost) all data fetchers use `IEditingContextDispatcher` instead of using `IEditingContextEventProcessorRegistry` directly.
 
 
 == v2025.2.0
@@ -200,7 +201,6 @@ A new search command as been contributed to the palette in Sirius Web, which can
 - https://github.com/eclipse-sirius/sirius-web/issues/4329[#4329] [form] Add support for tables as widget in the form view DSL
 - https://github.com/eclipse-sirius/sirius-web/issues/4586[#4586] [core] Allow to override the default behavior of commands in the command palette.
 The `omniboxCommandOverrideContributionExtensionPoint` extension point can be used to contribute components to use when a command is selected.
-
 
 === Improvements
 

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/DiagramDescriptionConnectorToolsDataFetcher.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/DiagramDescriptionConnectorToolsDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -20,11 +20,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.GetConnectorToolsInput;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.GetConnectorToolsSuccessPayload;
 import org.eclipse.sirius.components.diagrams.tools.ITool;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -42,10 +42,10 @@ public class DiagramDescriptionConnectorToolsDataFetcher implements IDataFetcher
 
     private static final String TARGET_DIAGRAM_ELEMENT_ID = "targetDiagramElementId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public DiagramDescriptionConnectorToolsDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public DiagramDescriptionConnectorToolsDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -59,13 +59,11 @@ public class DiagramDescriptionConnectorToolsDataFetcher implements IDataFetcher
         if (editingContextId != null && representationId != null) {
             GetConnectorToolsInput input = new GetConnectorToolsInput(UUID.randomUUID(), editingContextId, representationId, sourceDiagramElementId, targetDiagramElementId);
 
-            // @formatter:off
-            return this.editingContextEventProcessorRegistry.dispatchEvent(input.editingContextId(), input)
+            return this.editingContextDispatcher.dispatchQuery(input.editingContextId(), input)
                     .filter(GetConnectorToolsSuccessPayload.class::isInstance)
                     .map(GetConnectorToolsSuccessPayload.class::cast)
                     .map(GetConnectorToolsSuccessPayload::connectorTools)
                     .toFuture();
-            // @formatter:on
         }
 
         return Mono.<List<ITool>> empty().toFuture();

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/DiagramDescriptionDropNodeCompatibilityDataFetcher.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/DiagramDescriptionDropNodeCompatibilityDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -20,11 +20,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.DropNodeCompatibilityEntry;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.GetDropNodeCompatibilitySuccessPayload;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.GetDropNodeCompatibiliyInput;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -37,10 +37,10 @@ import reactor.core.publisher.Mono;
  */
 @QueryDataFetcher(type = "DiagramDescription", field = "dropNodeCompatibility")
 public class DiagramDescriptionDropNodeCompatibilityDataFetcher  implements IDataFetcherWithFieldCoordinates<CompletableFuture<List<DropNodeCompatibilityEntry>>> {
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public DiagramDescriptionDropNodeCompatibilityDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public DiagramDescriptionDropNodeCompatibilityDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -51,7 +51,7 @@ public class DiagramDescriptionDropNodeCompatibilityDataFetcher  implements IDat
         if (editingContextId != null && representationId != null) {
             GetDropNodeCompatibiliyInput input = new GetDropNodeCompatibiliyInput(UUID.randomUUID(), editingContextId, representationId);
 
-            return this.editingContextEventProcessorRegistry.dispatchEvent(input.editingContextId(), input)
+            return this.editingContextDispatcher.dispatchQuery(input.editingContextId(), input)
                     .filter(GetDropNodeCompatibilitySuccessPayload.class::isInstance)
                     .map(GetDropNodeCompatibilitySuccessPayload.class::cast)
                     .map(GetDropNodeCompatibilitySuccessPayload::entries)

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/DiagramDescriptionInitialDirectEditElementLabelDataFetcher.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/DiagramDescriptionInitialDirectEditElementLabelDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,10 +19,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.InitialDirectEditElementLabelInput;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.InitialDirectEditElementLabelSuccessPayload;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -38,10 +38,10 @@ public class DiagramDescriptionInitialDirectEditElementLabelDataFetcher implemen
 
     private static final String LABEL_ID = "labelId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public DiagramDescriptionInitialDirectEditElementLabelDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public DiagramDescriptionInitialDirectEditElementLabelDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -53,13 +53,11 @@ public class DiagramDescriptionInitialDirectEditElementLabelDataFetcher implemen
 
         if (editingContextId != null && representationId != null && labelId != null) {
             var input = new InitialDirectEditElementLabelInput(UUID.randomUUID(), editingContextId, representationId, labelId);
-            // @formatter:off
-            return this.editingContextEventProcessorRegistry.dispatchEvent(editingContextId, input)
+            return this.editingContextDispatcher.dispatchQuery(editingContextId, input)
                     .filter(InitialDirectEditElementLabelSuccessPayload.class::isInstance)
                     .map(InitialDirectEditElementLabelSuccessPayload.class::cast)
                     .map(InitialDirectEditElementLabelSuccessPayload::initialDirectEditElementLabel)
                     .toFuture();
-            // @formatter:on
         }
 
         return Mono.<String> empty().toFuture();

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/DiagramDescriptionPaletteDataFetcher.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/DiagramDescriptionPaletteDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,11 +19,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
-import org.eclipse.sirius.components.collaborative.diagrams.dto.GetPaletteSuccessPayload;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.GetPaletteInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.GetPaletteSuccessPayload;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.Palette;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -39,10 +39,10 @@ public class DiagramDescriptionPaletteDataFetcher implements IDataFetcherWithFie
 
     private static final String DIAGRAM_ELEMENT_ID = "diagramElementId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public DiagramDescriptionPaletteDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public DiagramDescriptionPaletteDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -55,7 +55,7 @@ public class DiagramDescriptionPaletteDataFetcher implements IDataFetcherWithFie
         if (editingContextId != null && representationId != null) {
             GetPaletteInput input = new GetPaletteInput(UUID.randomUUID(), editingContextId, representationId, diagramElementId);
 
-            return this.editingContextEventProcessorRegistry.dispatchEvent(input.editingContextId(), input)
+            return this.editingContextDispatcher.dispatchQuery(input.editingContextId(), input)
                     .filter(GetPaletteSuccessPayload.class::isInstance)
                     .map(GetPaletteSuccessPayload.class::cast)
                     .map(GetPaletteSuccessPayload::palette)

--- a/packages/forms/backend/sirius-components-widget-reference-graphql/src/main/java/org/eclipse/sirius/components/widget/reference/graphql/datafetchers/query/ReferenceWidgetChildCreationDescriptionsDataFetcher.java
+++ b/packages/forms/backend/sirius-components-widget-reference-graphql/src/main/java/org/eclipse/sirius/components/widget/reference/graphql/datafetchers/query/ReferenceWidgetChildCreationDescriptionsDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,11 +18,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.dto.EditingContextChildObjectCreationDescriptionsPayload;
 import org.eclipse.sirius.components.collaborative.widget.reference.dto.ReferenceWidgetChildCreationDescriptionsInput;
 import org.eclipse.sirius.components.core.api.ChildCreationDescription;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 
 import graphql.schema.DataFetchingEnvironment;
 
@@ -38,10 +38,10 @@ public class ReferenceWidgetChildCreationDescriptionsDataFetcher implements IDat
     private static final String REFERENCE_KIND_ARGUMENT = "referenceKind";
     private static final String WIDGET_DESCRIPTION_ID_ARGUMENT = "descriptionId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public ReferenceWidgetChildCreationDescriptionsDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public ReferenceWidgetChildCreationDescriptionsDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -54,7 +54,7 @@ public class ReferenceWidgetChildCreationDescriptionsDataFetcher implements IDat
         ReferenceWidgetChildCreationDescriptionsInput input = new ReferenceWidgetChildCreationDescriptionsInput(UUID.randomUUID(), editingContextId, kind,
                 referenceKind, descriptionId);
 
-        return this.editingContextEventProcessorRegistry.dispatchEvent(input.editingContextId(), input)
+        return this.editingContextDispatcher.dispatchQuery(input.editingContextId(), input)
                 .filter(EditingContextChildObjectCreationDescriptionsPayload.class::isInstance)
                 .map(EditingContextChildObjectCreationDescriptionsPayload.class::cast)
                 .map(EditingContextChildObjectCreationDescriptionsPayload::childCreationDescriptions)

--- a/packages/forms/backend/sirius-components-widget-reference-graphql/src/main/java/org/eclipse/sirius/components/widget/reference/graphql/datafetchers/query/ReferenceWidgetRootCreationDescriptionsDataFetcher.java
+++ b/packages/forms/backend/sirius-components-widget-reference-graphql/src/main/java/org/eclipse/sirius/components/widget/reference/graphql/datafetchers/query/ReferenceWidgetRootCreationDescriptionsDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,11 +18,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.dto.EditingContextRootObjectCreationDescriptionsPayload;
 import org.eclipse.sirius.components.collaborative.widget.reference.dto.ReferenceWidgetRootCreationDescriptionsInput;
 import org.eclipse.sirius.components.core.api.ChildCreationDescription;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 
 import graphql.schema.DataFetchingEnvironment;
 
@@ -39,10 +39,10 @@ public class ReferenceWidgetRootCreationDescriptionsDataFetcher implements IData
     private static final String REFERENCE_KIND_ARGUMENT = "referenceKind";
     private static final String WIDGET_DESCRIPTION_ID = "descriptionId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public ReferenceWidgetRootCreationDescriptionsDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public ReferenceWidgetRootCreationDescriptionsDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -55,7 +55,7 @@ public class ReferenceWidgetRootCreationDescriptionsDataFetcher implements IData
         ReferenceWidgetRootCreationDescriptionsInput input = new ReferenceWidgetRootCreationDescriptionsInput(UUID.randomUUID(), editingContextId, domainId,
                 referenceKind, descriptionId);
 
-        return this.editingContextEventProcessorRegistry.dispatchEvent(input.editingContextId(), input)
+        return this.editingContextDispatcher.dispatchQuery(input.editingContextId(), input)
                 .filter(EditingContextRootObjectCreationDescriptionsPayload.class::isInstance)
                 .map(EditingContextRootObjectCreationDescriptionsPayload.class::cast)
                 .map(EditingContextRootObjectCreationDescriptionsPayload::childCreationDescriptions)

--- a/packages/selection/backend/sirius-components-selection-graphql/src/main/java/org/eclipse/sirius/components/selection/graphql/datafetchers/selection/SelectionDescriptionMessageDataFetcher.java
+++ b/packages/selection/backend/sirius-components-selection-graphql/src/main/java/org/eclipse/sirius/components/selection/graphql/datafetchers/selection/SelectionDescriptionMessageDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -22,11 +22,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.selection.dto.GetSelectionDescriptionMessageInput;
 import org.eclipse.sirius.components.collaborative.selection.dto.GetSelectionDescriptionMessagePayload;
 import org.eclipse.sirius.components.collaborative.selection.dto.SelectionDialogVariable;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
 import org.eclipse.sirius.components.selection.description.SelectionDescription;
 
@@ -41,13 +41,13 @@ public class SelectionDescriptionMessageDataFetcher  implements IDataFetcherWith
 
     private static final String VARIABLES = "variables";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
     private final ObjectMapper objectMapper;
 
-    public SelectionDescriptionMessageDataFetcher(ObjectMapper objectMapper, IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
+    public SelectionDescriptionMessageDataFetcher(ObjectMapper objectMapper, IEditingContextDispatcher editingContextDispatcher) {
         this.objectMapper = Objects.requireNonNull(objectMapper);
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class SelectionDescriptionMessageDataFetcher  implements IDataFetcherWith
                 .toList();
 
         var input = new GetSelectionDescriptionMessageInput(UUID.randomUUID(), variables, selectionDescription);
-        return this.editingContextEventProcessorRegistry.dispatchEvent(editingContextId.get(), input)
+        return this.editingContextDispatcher.dispatchQuery(editingContextId.get(), input)
                .filter(GetSelectionDescriptionMessagePayload.class::isInstance)
                .map(GetSelectionDescriptionMessagePayload.class::cast)
                .map(GetSelectionDescriptionMessagePayload::message)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/representation/controllers/EditingContextRepresentationDescriptionsDataFetcher.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/representation/controllers/EditingContextRepresentationDescriptionsDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,12 +18,12 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.api.RepresentationDescriptionMetadata;
 import org.eclipse.sirius.components.collaborative.dto.EditingContextRepresentationDescriptionsInput;
 import org.eclipse.sirius.components.collaborative.dto.EditingContextRepresentationDescriptionsPayload;
 import org.eclipse.sirius.components.core.graphql.dto.PageInfoWithCount;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 
 import graphql.relay.Connection;
 import graphql.relay.ConnectionCursor;
@@ -47,10 +47,10 @@ public class EditingContextRepresentationDescriptionsDataFetcher implements IDat
 
     private static final String OBJECT_ID_ARGUMENT = "objectId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public EditingContextRepresentationDescriptionsDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public EditingContextRepresentationDescriptionsDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -60,7 +60,7 @@ public class EditingContextRepresentationDescriptionsDataFetcher implements IDat
 
         EditingContextRepresentationDescriptionsInput input = new EditingContextRepresentationDescriptionsInput(UUID.randomUUID(), editingContextId, objectId);
 
-        return this.editingContextEventProcessorRegistry.dispatchEvent(input.editingContextId(), input)
+        return this.editingContextDispatcher.dispatchQuery(input.editingContextId(), input)
                 .filter(EditingContextRepresentationDescriptionsPayload.class::isInstance)
                 .map(EditingContextRepresentationDescriptionsPayload.class::cast)
                 .map(this::toConnection)

--- a/packages/tables/backend/sirius-components-tables-graphql/src/main/java/org/eclipse/sirius/components/tables/graphql/datafetchers/TableDescriptionRowContextMenuDataFetcher.java
+++ b/packages/tables/backend/sirius-components-tables-graphql/src/main/java/org/eclipse/sirius/components/tables/graphql/datafetchers/TableDescriptionRowContextMenuDataFetcher.java
@@ -21,11 +21,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.tables.dto.RowContextMenuEntriesInput;
 import org.eclipse.sirius.components.collaborative.tables.dto.RowContextMenuEntry;
 import org.eclipse.sirius.components.collaborative.tables.dto.RowContextMenuSuccessPayload;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -42,10 +42,10 @@ public class TableDescriptionRowContextMenuDataFetcher implements IDataFetcherWi
 
     private static final String ROW_ID_ARGUMENT = "rowId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public TableDescriptionRowContextMenuDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public TableDescriptionRowContextMenuDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class TableDescriptionRowContextMenuDataFetcher implements IDataFetcherWi
         String rowId = environment.getArgument(ROW_ID_ARGUMENT);
 
         var input = new RowContextMenuEntriesInput(UUID.randomUUID(), editingContextId, representationId, tableId, UUID.fromString(rowId));
-        return this.editingContextEventProcessorRegistry.dispatchEvent(editingContextId, input)
+        return this.editingContextDispatcher.dispatchQuery(editingContextId, input)
                 .filter(RowContextMenuSuccessPayload.class::isInstance)
                 .map(RowContextMenuSuccessPayload.class::cast)
                 .map(RowContextMenuSuccessPayload::entries)

--- a/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/editingcontext/EditingContextExpandAllTreePathDataFetcher.java
+++ b/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/editingcontext/EditingContextExpandAllTreePathDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,11 +17,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.trees.dto.ExpandAllTreePathInput;
 import org.eclipse.sirius.components.collaborative.trees.dto.ExpandAllTreePathSuccessPayload;
 import org.eclipse.sirius.components.collaborative.trees.dto.TreePath;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 
 import graphql.schema.DataFetchingEnvironment;
 
@@ -37,10 +37,10 @@ public class EditingContextExpandAllTreePathDataFetcher implements IDataFetcherW
 
     private static final String TREE_ITEM_ID = "treeItemId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public EditingContextExpandAllTreePathDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public EditingContextExpandAllTreePathDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -50,7 +50,7 @@ public class EditingContextExpandAllTreePathDataFetcher implements IDataFetcherW
         String treeItemId = environment.getArgument(TREE_ITEM_ID);
 
         ExpandAllTreePathInput input = new ExpandAllTreePathInput(UUID.randomUUID(), editingContextId, treeId, treeItemId);
-        return this.editingContextEventProcessorRegistry.dispatchEvent(editingContextId, input)
+        return this.editingContextDispatcher.dispatchQuery(editingContextId, input)
                 .filter(ExpandAllTreePathSuccessPayload.class::isInstance)
                 .map(ExpandAllTreePathSuccessPayload.class::cast)
                 .map(ExpandAllTreePathSuccessPayload::treePath)

--- a/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/editingcontext/EditingContextTreePathDataFetcher.java
+++ b/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/editingcontext/EditingContextTreePathDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Obeo.
+ * Copyright (c) 2022, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,11 +18,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.trees.dto.TreePath;
 import org.eclipse.sirius.components.collaborative.trees.dto.TreePathInput;
 import org.eclipse.sirius.components.collaborative.trees.dto.TreePathSuccessPayload;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 
 import graphql.schema.DataFetchingEnvironment;
 
@@ -38,10 +38,10 @@ public class EditingContextTreePathDataFetcher implements IDataFetcherWithFieldC
 
     private static final String SELECTION_ENTRY_IDS = "selectionEntryIds";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public EditingContextTreePathDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public EditingContextTreePathDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -51,13 +51,11 @@ public class EditingContextTreePathDataFetcher implements IDataFetcherWithFieldC
         List<String> selectionEntryIds = environment.getArgument(SELECTION_ENTRY_IDS);
 
         TreePathInput input = new TreePathInput(UUID.randomUUID(), editingContextId, treeId, selectionEntryIds);
-        // @formatter:off
-        return this.editingContextEventProcessorRegistry.dispatchEvent(editingContextId, input)
+        return this.editingContextDispatcher.dispatchQuery(editingContextId, input)
                 .filter(TreePathSuccessPayload.class::isInstance)
                 .map(TreePathSuccessPayload.class::cast)
                 .map(TreePathSuccessPayload::treePath)
                 .toFuture();
-        // @formatter:on
     }
 
 }

--- a/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/tree/TreeDescriptionContextMenuDataFetcher.java
+++ b/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/tree/TreeDescriptionContextMenuDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -20,11 +20,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.trees.dto.ITreeItemContextMenuEntry;
-import org.eclipse.sirius.components.collaborative.trees.dto.TreeItemContextMenuSuccessPayload;
 import org.eclipse.sirius.components.collaborative.trees.dto.TreeItemContextMenuInput;
+import org.eclipse.sirius.components.collaborative.trees.dto.TreeItemContextMenuSuccessPayload;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -39,10 +39,10 @@ public class TreeDescriptionContextMenuDataFetcher implements IDataFetcherWithFi
 
     private static final String INPUT_ARGUMENT = "treeItemId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public TreeDescriptionContextMenuDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public TreeDescriptionContextMenuDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class TreeDescriptionContextMenuDataFetcher implements IDataFetcherWithFi
         String treeItemId = environment.getArgument(INPUT_ARGUMENT);
 
         var input = new TreeItemContextMenuInput(UUID.randomUUID(), editingContextId, representationId, treeItemId);
-        return this.editingContextEventProcessorRegistry.dispatchEvent(editingContextId, input)
+        return this.editingContextDispatcher.dispatchQuery(editingContextId, input)
                 .filter(TreeItemContextMenuSuccessPayload.class::isInstance)
                 .map(TreeItemContextMenuSuccessPayload.class::cast)
                 .map(TreeItemContextMenuSuccessPayload::actions)

--- a/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/tree/TreeDescriptionFetchTreeItemContextMenuEntryDataDataFetcher.java
+++ b/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/tree/TreeDescriptionFetchTreeItemContextMenuEntryDataDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,11 +19,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.trees.dto.FetchTreeItemContextMenuEntryData;
 import org.eclipse.sirius.components.collaborative.trees.dto.FetchTreeItemContextMenuEntryDataInput;
 import org.eclipse.sirius.components.collaborative.trees.dto.FetchTreeItemContextMenuEntryDataSuccessPayload;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -40,10 +40,10 @@ public class TreeDescriptionFetchTreeItemContextMenuEntryDataDataFetcher impleme
 
     private static final String MENU_ENTRY_ID_INPUT_ARGUMENT = "menuEntryId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public TreeDescriptionFetchTreeItemContextMenuEntryDataDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public TreeDescriptionFetchTreeItemContextMenuEntryDataDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -55,7 +55,7 @@ public class TreeDescriptionFetchTreeItemContextMenuEntryDataDataFetcher impleme
         String menuEntryId = environment.getArgument(MENU_ENTRY_ID_INPUT_ARGUMENT);
 
         var input = new FetchTreeItemContextMenuEntryDataInput(UUID.randomUUID(), editingContextId, representationId, treeItemId, menuEntryId);
-        return this.editingContextEventProcessorRegistry.dispatchEvent(editingContextId, input)
+        return this.editingContextDispatcher.dispatchQuery(editingContextId, input)
                 .filter(FetchTreeItemContextMenuEntryDataSuccessPayload.class::isInstance)
                 .map(FetchTreeItemContextMenuEntryDataSuccessPayload.class::cast)
                 .map(FetchTreeItemContextMenuEntryDataSuccessPayload::data)

--- a/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/tree/TreeItemInitialDirectEditLabelDataFetcher.java
+++ b/packages/trees/backend/sirius-components-trees-graphql/src/main/java/org/eclipse/sirius/components/trees/graphql/datafetchers/tree/TreeItemInitialDirectEditLabelDataFetcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,10 +19,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
-import org.eclipse.sirius.components.collaborative.api.IEditingContextEventProcessorRegistry;
 import org.eclipse.sirius.components.collaborative.trees.dto.InitialDirectEditElementLabelInput;
 import org.eclipse.sirius.components.collaborative.trees.dto.InitialDirectEditElementLabelSuccessPayload;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
 import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -38,10 +38,10 @@ public class TreeItemInitialDirectEditLabelDataFetcher implements IDataFetcherWi
 
     private static final String INPUT_ARGUMENT = "treeItemId";
 
-    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+    private final IEditingContextDispatcher editingContextDispatcher;
 
-    public TreeItemInitialDirectEditLabelDataFetcher(IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
-        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    public TreeItemInitialDirectEditLabelDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
     }
 
     @Override
@@ -53,13 +53,11 @@ public class TreeItemInitialDirectEditLabelDataFetcher implements IDataFetcherWi
 
         if (editingContextId != null && representationId != null && treeItemId != null) {
             var input = new InitialDirectEditElementLabelInput(UUID.randomUUID(), editingContextId, representationId, treeItemId, "");
-            // @formatter:off
-            return this.editingContextEventProcessorRegistry.dispatchEvent(editingContextId, input)
+            return this.editingContextDispatcher.dispatchQuery(editingContextId, input)
                     .filter(InitialDirectEditElementLabelSuccessPayload.class::isInstance)
                     .map(InitialDirectEditElementLabelSuccessPayload.class::cast)
                     .map(InitialDirectEditElementLabelSuccessPayload::initialDirectEditElementLabel)
                     .toFuture();
-            // @formatter:on
         }
         return Mono.<String> empty().toFuture();
     }


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4581
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

  #

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?