### PR TITLE
[4691] Set the local diagram's state even when in read-only

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -77,6 +77,7 @@ We will also remove `GQLTreeItem#kind` later.
 - https://github.com/eclipse-sirius/sirius-web/issues/4661[#4661] [table] Prevent table pagination to be reset on the first page
 - https://github.com/eclipse-sirius/sirius-web/issues/4684[#4684] [diagram] Prevent diagram crash when switch to read-only
 - https://github.com/eclipse-sirius/sirius-web/issues/4693[#4693] [diagram] Fix an issue with nodes not correctly hidden on diagram representation
+- https://github.com/eclipse-sirius/sirius-web/issues/4691[#4691] [diagram] Fixed a bug where diagrams could appear empty when opened in a read-only context
 
 
 === New Features

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/DiagramRenderer.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/DiagramRenderer.tsx
@@ -213,7 +213,7 @@ export const DiagramRenderer = memo(({ diagramRefreshedEventPayload }: DiagramRe
 
       setEdges(convertedDiagram.edges);
       setNodes(convertedDiagram.nodes);
-    } else if (cause === 'refresh' && !readOnly) {
+    } else if (cause === 'refresh') {
       const previousDiagram: RawDiagram = {
         nodes,
         edges,
@@ -245,7 +245,9 @@ export const DiagramRenderer = memo(({ diagramRefreshedEventPayload }: DiagramRe
         setNodes(laidOutDiagram.nodes);
         hideAllPalettes();
 
-        synchronizeLayoutData(diagramRefreshedEventPayload.id, 'refresh', laidOutDiagram);
+        if (!readOnly) {
+          synchronizeLayoutData(diagramRefreshedEventPayload.id, 'refresh', laidOutDiagram);
+        }
       });
     }
   }, [diagramRefreshedEventPayload, diagramDescription, edgeType]);


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4691
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?