### PR TITLE
[4783] Fix label layout of nodes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -121,11 +121,12 @@ They are now in `org.eclipse.sirius.web.application.views.table.customcells` pac
 - https://github.com/eclipse-sirius/sirius-web/issues/4771[#4771] [table] Fix an issue that prevent table representation to be forked
 - [diagram] Fix an issue where an edge was not reconnectable after a refresh
 - https://github.com/eclipse-sirius/sirius-web/issues/4528[#4528] [sirius-web] Fix an issue where FlowProjectTemplatesInitializer could use the wrong view description
-- https://github.com/eclipse-sirius/sirius-web/issues/4791[#4791] [sirius-web] Fix an issue where loading representation indicator could be broken whith an empty selection
+- https://github.com/eclipse-sirius/sirius-web/issues/4791[#4791] [sirius-web] Fix an issue where loading representation indicator could be broken with an empty selection
 - https://github.com/eclipse-sirius/sirius-web/issues/4795[#4795] [table] Prevent table representation to be disposed after few seconds
 - https://github.com/eclipse-sirius/sirius-web/issues/4802[#4802] [sirius-web] Make sure all hooks are always rendered in EditProjectView
 - https://github.com/eclipse-sirius/sirius-web/issues/4786[#4786] [sirius-web] Fix an issue that prevent to navigate between library pages during import libraries action
 - https://github.com/eclipse-sirius/sirius-web/issues/4793[#4793] [diagram] Handle 'transparent' background color in SVG Export
+- https://github.com/eclipse-sirius/sirius-web/issues/4783[#4783] [diagram] Fix an issue where the labels of graphical nodes were not wrapped or had ellipsis anymore.
 
 === New Features
 

--- a/integration-tests/cypress/e2e/project/diagrams/diagram-label.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/diagram-label.cy.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import { Diagram } from '../../../workbench/Diagram';
 import { Explorer } from '../../../workbench/Explorer';
 
 describe('Diagram - inside outside labels', () => {
-  let domainName: string = 'diagramLabel';
+  const domainName: string = 'diagramLabel';
   context('Given a view with inside label on rectangular node with none strategy', () => {
     context('When we create a new instance project', () => {
       let instanceProjectId: string = '';
@@ -28,7 +28,6 @@ describe('Diagram - inside outside labels', () => {
         const studio = new Studio();
         studio.createProjectFromDomain('Cypress - Studio Instance', domainName, 'Root').then((res) => {
           instanceProjectId = res.projectId;
-
           new Explorer().createRepresentation('Root', diagramDescriptionName, diagramTitle);
         });
       });
@@ -52,7 +51,11 @@ describe('Diagram - inside outside labels', () => {
             initialHeight = nodeHeight / scale;
           });
         });
-        details.getTextField('Name').type('{selectAll}very large label one line fully displayed{enter}');
+        details
+          .getTextField('Name')
+          .should('exist')
+          .type('{selectAll}very large label one line fully displayed{enter}');
+        details.getTextField('Name').should('have.value', 'very large label one line fully displayed');
         diagram.getDiagramScale(diagramTitle).then((scale) => {
           diagram
             .getNodeCssValue(diagramTitle, 'very large label one line fully displayed', 'width')
@@ -86,7 +89,7 @@ describe('Diagram - inside outside labels', () => {
 
       afterEach(() => cy.deleteProject(instanceProjectId));
 
-      it('Then inside label is wrapped and the node width is not updated', () => {
+      it('Then inside label with several small words is wrapped and the node width is not updated', () => {
         const explorer = new Explorer();
         const diagram = new Diagram();
         const details = new Details();
@@ -103,23 +106,61 @@ describe('Diagram - inside outside labels', () => {
             initialHeight = nodeHeight / scale;
           });
         });
-        details.getTextField('Name').type('{selectAll}very large label one multi line after wrap{enter}');
+        details
+          .getTextField('Name')
+          .should('exist')
+          .type('{selectAll}very large label on multi lines after wrap{enter}');
+        details.getTextField('Name').should('have.value', 'very large label on multi lines after wrap');
         diagram.getDiagramScale(diagramTitle).then((scale) => {
           diagram
-            .getNodeCssValue(diagramTitle, 'very large label one multi line after wrap', 'width')
+            .getNodeCssValue(diagramTitle, 'very large label on multi lines after wrap', 'width')
             .then((nodeWidth) => {
               expect(nodeWidth / scale).to.approximately(initialWidth, 2);
               diagram
-                .getLabelCssValue(diagramTitle, 'very large label one multi line after wrap', 'width')
+                .getLabelCssValue(diagramTitle, 'very large label on multi lines after wrap', 'width')
                 .then((labelWidth) => {
                   expect(labelWidth / scale).to.be.below(nodeWidth / scale);
                 });
             });
           diagram
-            .getNodeCssValue(diagramTitle, 'very large label one multi line after wrap', 'height')
+            .getNodeCssValue(diagramTitle, 'very large label on multi lines after wrap', 'height')
             .then((nodeHeight) => {
               expect(nodeHeight / scale).to.greaterThan(initialHeight);
             });
+        });
+      });
+
+      it('Then inside label with only one long word is wrapped and the node width is not updated', () => {
+        const explorer = new Explorer();
+        const diagram = new Diagram();
+        const details = new Details();
+        explorer.createObject('Root', 'entity1s-Entity1');
+        details.getTextField('Name').type('small{enter}');
+        diagram.fitToScreen();
+        let initialWidth: number;
+        let initialHeight: number;
+        diagram.getDiagramScale(diagramTitle).then((scale) => {
+          diagram.getNodeCssValue(diagramTitle, 'small', 'width').then((nodeWidth) => {
+            initialWidth = nodeWidth / scale;
+          });
+          diagram.getNodeCssValue(diagramTitle, 'small', 'height').then((nodeHeight) => {
+            initialHeight = nodeHeight / scale;
+          });
+        });
+        details.getTextField('Name').should('exist').type('{selectAll}verylargelabelonmultilinesafterwrap{enter}');
+        details.getTextField('Name').should('have.value', 'verylargelabelonmultilinesafterwrap');
+        diagram.getDiagramScale(diagramTitle).then((scale) => {
+          diagram.getNodeCssValue(diagramTitle, 'verylargelabelonmultilinesafterwrap', 'width').then((nodeWidth) => {
+            expect(nodeWidth / scale).to.approximately(initialWidth, 2);
+            diagram
+              .getLabelCssValue(diagramTitle, 'verylargelabelonmultilinesafterwrap', 'width')
+              .then((labelWidth) => {
+                expect(labelWidth / scale).to.be.below(nodeWidth / scale);
+              });
+          });
+          diagram.getNodeCssValue(diagramTitle, 'verylargelabelonmultilinesafterwrap', 'height').then((nodeHeight) => {
+            expect(nodeHeight / scale).to.greaterThan(initialHeight);
+          });
         });
       });
     });
@@ -142,7 +183,7 @@ describe('Diagram - inside outside labels', () => {
 
       afterEach(() => cy.deleteProject(instanceProjectId));
 
-      it.skip('Then inside label has an ellipsis and the node width is not updated', () => {
+      it('Then inside label with several small words has an ellipsis and the node width is not updated', () => {
         const explorer = new Explorer();
         const diagram = new Diagram();
         const details = new Details();
@@ -159,15 +200,48 @@ describe('Diagram - inside outside labels', () => {
             initialHeight = nodeHeight / scale;
           });
         });
-        details.getTextField('Name').type('{selectAll}very large label with an ellipsis{enter}');
+        details.getTextField('Name').should('exist').type('{selectAll}very long label with an ellipsis{enter}');
+        details.getTextField('Name').should('have.value', 'very long label with an ellipsis');
         diagram.getDiagramScale(diagramTitle).then((scale) => {
-          diagram.getNodeCssValue(diagramTitle, 'very large label with an ellipsis', 'width').then((nodeWidth) => {
+          diagram.getNodeCssValue(diagramTitle, 'very long label with an ellipsis', 'width').then((nodeWidth) => {
             expect(nodeWidth / scale).to.approximately(initialWidth, 2);
-            diagram.getLabelCssValue(diagramTitle, 'very large label with an ellipsis', 'width').then((labelWidth) => {
+            diagram.getLabelCssValue(diagramTitle, 'very long label with an ellipsis', 'width').then((labelWidth) => {
               expect(labelWidth / scale).to.be.below(nodeWidth / scale);
             });
           });
-          diagram.getNodeCssValue(diagramTitle, 'very large label with an ellipsis', 'height').then((nodeHeight) => {
+          diagram.getNodeCssValue(diagramTitle, 'very long label with an ellipsis', 'height').then((nodeHeight) => {
+            expect(nodeHeight / scale).to.approximately(initialHeight, 2);
+          });
+        });
+      });
+
+      it('Then inside label with one very long word has an ellipsis and the node width is not updated', () => {
+        const explorer = new Explorer();
+        const diagram = new Diagram();
+        const details = new Details();
+        explorer.createObject('Root', 'entity1s-Entity1');
+        details.getTextField('Name').type('small{enter}');
+        diagram.fitToScreen();
+        let initialWidth: number;
+        let initialHeight: number;
+        diagram.getDiagramScale(diagramTitle).then((scale) => {
+          diagram.getNodeCssValue(diagramTitle, 'small', 'width').then((nodeWidth) => {
+            initialWidth = nodeWidth / scale;
+          });
+          diagram.getNodeCssValue(diagramTitle, 'small', 'height').then((nodeHeight) => {
+            initialHeight = nodeHeight / scale;
+          });
+        });
+        details.getTextField('Name').should('exist').type('{selectAll}oneverylonglabelwithanellipsis{enter}');
+        details.getTextField('Name').should('have.value', 'oneverylonglabelwithanellipsis');
+        diagram.getDiagramScale(diagramTitle).then((scale) => {
+          diagram.getNodeCssValue(diagramTitle, 'oneverylonglabelwithanellipsis', 'width').then((nodeWidth) => {
+            expect(nodeWidth / scale).to.approximately(initialWidth, 2);
+            diagram.getLabelCssValue(diagramTitle, 'oneverylonglabelwithanellipsis', 'width').then((labelWidth) => {
+              expect(labelWidth / scale).to.be.below(nodeWidth / scale);
+            });
+          });
+          diagram.getNodeCssValue(diagramTitle, 'oneverylonglabelwithanellipsis', 'height').then((nodeHeight) => {
             expect(nodeHeight / scale).to.approximately(initialHeight, 2);
           });
         });

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/node/FreeFormNode.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/node/FreeFormNode.tsx
@@ -80,7 +80,7 @@ const useStyles = makeStyles()((_) => ({
   labelAndAction: {
     display: 'grid',
     gridTemplateRows: '1fr',
-    gridTemplateColumns: '1fr',
+    gridTemplateColumns: 'minmax(0, 1fr)',
   },
   label: {
     gridRow: 1,

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/node/ListNode.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/node/ListNode.tsx
@@ -60,7 +60,7 @@ const useStyles = makeStyles()((_) => ({
   labelAndAction: {
     display: 'grid',
     gridTemplateRows: '1fr',
-    gridTemplateColumns: '1fr',
+    gridTemplateColumns: 'minmax(0, 1fr)',
   },
   label: {
     gridRow: 1,


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4783

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [x] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?