### PR TITLE
[4829] Add extension points for diagram default snap to grid behavior

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -186,6 +186,7 @@ Actions are visible on nodes on diagrams, on the top right corner of the nodes, 
 - https://github.com/eclipse-sirius/sirius-web/issues/4626[#4626] [diagram] Conserve rectilinearity of custom edges
 - https://github.com/eclipse-sirius/sirius-web/issues/4770[#4770] [diagram] Allow reconnecting an edge on another edge
 - https://github.com/eclipse-sirius/sirius-web/issues/4745[#4745] Add table cell extension point
+- https://github.com/eclipse-sirius/sirius-web/issues/4829[#4829] [diagram] Allow customization of the default snap to grid behavior
 
 
 === Improvements

--- a/doc/iterations/2025.6/diagram_read_only_visual_cue.adoc
+++ b/doc/iterations/2025.6/diagram_read_only_visual_cue.adoc
@@ -1,0 +1,18 @@
+= Add the ability to give users an obvious visual cue as to whether the diagram is editable or read-only
+
+== Problem
+
+There is a lack of visual cues as to whether a diagram is in read-only or is editable.
+The grid background conditionned to the "snap to grid" state would be a good visual cue but it is hardcoded to be disabled by default.
+
+== Key Result
+
+Give the ability to applications to choose the default "snap to grid" state and how it can be changed depending on whether the diagram is read-only or editable.
+
+== Solution
+
+== Cutting Backs
+
+== Rabbit Holes
+
+== No-Gos

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/DiagramRenderer.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/DiagramRenderer.tsx
@@ -40,7 +40,11 @@ import { useDiagramDescription } from '../contexts/useDiagramDescription';
 import { convertDiagram } from '../converter/convertDiagram';
 import { useStore } from '../representation/useStore';
 import { Diagram, DiagramRendererProps, EdgeData, NodeData, ReactFlowPropsCustomizer } from './DiagramRenderer.types';
-import { diagramRendererReactFlowPropsCustomizerExtensionPoint } from './DiagramRendererExtensionPoints';
+import {
+  diagramRendererCanUserSnapToGridExtensionPoint,
+  diagramRendererDefaultSnapToGridExtensionPoint,
+  diagramRendererReactFlowPropsCustomizerExtensionPoint,
+} from './DiagramRendererExtensionPoints';
 import { useBorderChange } from './border/useBorderChange';
 import { ConnectorContextualMenu } from './connector/ConnectorContextualMenu';
 import { useConnector } from './connector/useConnector';
@@ -343,7 +347,15 @@ export const DiagramRenderer = memo(({ diagramRefreshedEventPayload }: DiagramRe
     onDelete(event);
   }, []);
 
-  const { snapToGrid, onSnapToGrid } = useSnapToGrid();
+  const { data: defaultSnapToGrid } = useData<(readOnly: boolean) => boolean>(
+    diagramRendererDefaultSnapToGridExtensionPoint
+  );
+  const { data: canSnapToGrid } = useData<(readOnly: boolean) => boolean>(
+    diagramRendererCanUserSnapToGridExtensionPoint
+  );
+  const defaultSnapToGridState = useMemo(() => defaultSnapToGrid(readOnly), [readOnly]);
+  const canSnapToGridState = useMemo(() => canSnapToGrid(readOnly), [readOnly]);
+  const { snapToGrid, onSnapToGrid } = useSnapToGrid(defaultSnapToGridState, canSnapToGridState);
 
   const hideAllPalettes = useCallback(() => {
     hideDiagramPalette();

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/DiagramRendererExtensionPoints.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/DiagramRendererExtensionPoints.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,4 +19,14 @@ export const diagramRendererReactFlowPropsCustomizerExtensionPoint: DataExtensio
 > = {
   identifier: 'diagramRenderer#reactFlowPropsCustomizer',
   fallback: [],
+};
+
+export const diagramRendererDefaultSnapToGridExtensionPoint: DataExtensionPoint<(readOnly: boolean) => boolean> = {
+  identifier: 'diagramRenderer#defaultSnapToGrid',
+  fallback: () => false,
+};
+
+export const diagramRendererCanUserSnapToGridExtensionPoint: DataExtensionPoint<(readOnly: boolean) => boolean> = {
+  identifier: 'diagramRenderer#canUserSnapToGrid',
+  fallback: (readOnly) => !readOnly,
 };

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/panel/DiagramPanel.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/panel/DiagramPanel.tsx
@@ -11,7 +11,12 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { ComponentExtension, ShareRepresentationModal, useComponents } from '@eclipse-sirius/sirius-components-core';
+import {
+  ComponentExtension,
+  ShareRepresentationModal,
+  useComponents,
+  useData,
+} from '@eclipse-sirius/sirius-components-core';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import AspectRatioIcon from '@mui/icons-material/AspectRatio';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
@@ -37,6 +42,7 @@ import { SmartEdgeIcon } from '../../icons/SmartEdgeIcon';
 import { SmoothStepEdgeIcon } from '../../icons/SmoothStepEdgeIcon';
 import { UnpinIcon } from '../../icons/UnpinIcon';
 import { EdgeData, NodeData } from '../DiagramRenderer.types';
+import { diagramRendererCanUserSnapToGridExtensionPoint } from '../DiagramRendererExtensionPoints';
 import { useFadeDiagramElements } from '../fade/useFadeDiagramElements';
 import { useFullscreen } from '../fullscreen/useFullscreen';
 import { useHideDiagramElements } from '../hide/useHideDiagramElements';
@@ -65,6 +71,9 @@ export const DiagramPanel = memo(
     const { readOnly } = useContext<DiagramContextValue>(DiagramContext);
     const diagramPanelActionComponents: ComponentExtension<DiagramPanelActionProps>[] = useComponents(
       diagramPanelActionExtensionPoint
+    );
+    const { data: canSnapToGrid } = useData<(readOnly: boolean) => boolean>(
+      diagramRendererCanUserSnapToGridExtensionPoint
     );
 
     const { getNodes, getEdges, zoomIn, zoomOut, fitView } = useReactFlow<Node<NodeData>, Edge<EdgeData>>();
@@ -154,7 +163,11 @@ export const DiagramPanel = memo(
               </Tooltip>
             ) : (
               <Tooltip title="Toggle snap to grid mode">
-                <IconButton size="small" aria-label="toggle snap to grid mode" onClick={() => onSnapToGrid(true)}>
+                <IconButton
+                  disabled={!canSnapToGrid(readOnly)}
+                  size="small"
+                  aria-label="toggle snap to grid mode"
+                  onClick={() => onSnapToGrid(true)}>
                   <GridOnIcon />
                 </IconButton>
               </Tooltip>

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/snap-to-grid/useSnapToGrid.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/snap-to-grid/useSnapToGrid.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Obeo.
+ * Copyright (c) 2023, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,11 +11,17 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { UseSnapToGridValue } from './useSnapToGrid.types';
 
-export const useSnapToGrid = (): UseSnapToGridValue => {
-  const [state, setState] = useState<boolean>(false);
+export const useSnapToGrid = (defaultState: boolean, canSnapToGrid: boolean): UseSnapToGridValue => {
+  const [state, setState] = useState<boolean>(defaultState);
+
+  useEffect(() => {
+    if (!canSnapToGrid) {
+      setState(false);
+    }
+  }, [state, canSnapToGrid]);
 
   return {
     snapToGrid: state,


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4829

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?

Put a diagram representation in a portal representation and verify that the extension points functions are taken into account. With the default functions the only visible changes will be that a read-only diagram can not be in snap to grid mode.


https://github.com/user-attachments/assets/f687b640-a583-4faa-bf72-a4093e2bd554



- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?