### PR TITLE
[fix] Fix an issue where treem items could wrongly stay rendered as 'hovered'

### DIFF
--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItem.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItem.tsx
@@ -137,7 +137,7 @@ export const TreeItem = ({
 
   const onTreeItemAction = () => {
     setState((prevState) => {
-      return { ...prevState, isHovered: false };
+      return { ...prevState, partHovered: null };
     });
   };
 


### PR DESCRIPTION
Before:


https://github.com/user-attachments/assets/a9eb4cae-c136-45ef-870f-39725a432d3c

After:


https://github.com/user-attachments/assets/d0490dc3-935e-4ac1-bb30-aedb05334d04

