### PR TITLE
[4866] Disable the "last tool" shortcut in the palette if is not available in the current state

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -107,6 +107,8 @@ On large projects this can significantly reduce the amount of data fetched from 
 This is mostly visible when cold-opening projects with large documents (load performance), and when saving semantic data after edition operations.
 Note that the improvements will only be visible for projects created or modified after the update; existing semantic data which has not been modified will continue to be "slow" to load/read until it is modified at least once and saved in the new, improved format.
 - [releng] Switch to Sirius EMF JSON 2.5.1 and thus add the ability for a migration participant to change the URI used by a proxy during a migration.
+- https://github.com/eclipse-sirius/sirius-web/issues/4866[#4866] [diagram] Disable the last executed tool when opening the palette, if it is not available in the current state, it is still displayed for information.
+
 
 
 == v2025.4.0

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/palette/Palette.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/palette/Palette.tsx
@@ -73,6 +73,8 @@ export const isToolSection = (entry: GQLPaletteEntry): entry is GQLToolSection =
 export const isPaletteDivider = (entry: GQLPaletteDivider): entry is GQLToolSection =>
   entry.__typename === 'PaletteDivider';
 
+export const isTool = (entry: GQLPaletteEntry): entry is GQLTool => !isPaletteDivider(entry) && !isToolSection(entry);
+
 const computeDraggableBounds = (bounds?: DOMRect): XYPosition => {
   return {
     x: bounds?.width ?? 0,

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/palette/tool-list-item/ToolListItem.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/palette/tool-list-item/ToolListItem.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -48,7 +48,7 @@ const useStyle = makeStyles()((theme) => ({
     marginRight: theme.spacing(2),
   },
 }));
-export const ToolListItem = ({ tool, onToolClick }: ToolListItemProps) => {
+export const ToolListItem = ({ tool, disabled, onToolClick }: ToolListItemProps) => {
   const { classes } = useStyle();
 
   const handleToolClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>, tool: GQLTool) => {
@@ -60,6 +60,7 @@ export const ToolListItem = ({ tool, onToolClick }: ToolListItemProps) => {
     <Tooltip title={tool.label} placement="right">
       <ListItemButton
         className={classes.listItemButton}
+        disabled={disabled}
         onClick={(event) => handleToolClick(event, tool)}
         data-testid={`tool-${tool.label}`}>
         <ListItemIcon className={classes.listItemIcon}>

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/palette/tool-list-item/ToolListItem.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/palette/tool-list-item/ToolListItem.types.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,5 +14,6 @@
 import { GQLTool } from '../Palette.types';
 export interface ToolListItemProps {
   tool: GQLTool;
+  disabled: boolean;
   onToolClick: (tool: GQLTool) => void;
 }

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/palette/tool-list/PaletteToolSectionList.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/palette/tool-list/PaletteToolSectionList.tsx
@@ -71,7 +71,7 @@ export const PaletteToolSectionList = ({ toolSection, onToolClick, onBackToMainL
         </ListItemButton>
       </Tooltip>
       {toolSection.tools.filter(isSingleClickOnDiagramElementTool).map((tool) => (
-        <ToolListItem onToolClick={onToolClick} tool={tool} key={tool.id} />
+        <ToolListItem onToolClick={onToolClick} tool={tool} disabled={false} key={tool.id} />
       ))}
     </List>
   );


### PR DESCRIPTION
For example with a "New Entity1" tool with this precondition:

![Capture d’écran du 2025-04-24 10-59-11](https://github.com/user-attachments/assets/a9faf44b-fed2-4d3e-bb23-7ae1805a1b8b)

On a diagram, after invoking the tool 3 times, the palette now shows:

![Capture d’écran du 2025-04-24 10-58-57](https://github.com/user-attachments/assets/19622d00-0bba-41fa-ab67-446069fc40cf)

The information that "New Entity1" was the last tool executed is still present, but given that this particular tool is no longer among the valid/applicable tools, it is disabled and can not be re-invoked.

Deleting one of the elements from the _Explorer_ and re-opening the palette afterward correctly shows "New Entity1" as still the last (diagram) tool invoked, and it is availabel again:

![image](https://github.com/user-attachments/assets/27602d20-2430-4bd1-9367-6b9d6b6e249e)



Bug: https://github.com/eclipse-sirius/sirius-web/issues/4866
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?