### PR TITLE
[4102] Add render variables to Tree (Explorer) and use it to fetch existing representations only once during Explorer render

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -50,7 +50,7 @@ The following dependencies have been updated:
 
 === New Features
 
-
+- https://github.com/eclipse-sirius/sirius-web/issues/4102[#4102] [tree] Add support for custom render variables
 
 === Improvements
 
@@ -65,7 +65,8 @@ This improves the time needed to open a project and other scenarios where we cre
 The improvement on project opening will be proportional to the size/complexity of the metamodels and the number of View-based representations available in the project.
 - https://github.com/eclipse-sirius/sirius-web/issues/4858[#4858] [view] Switch to a service based approach to convert forms
 - https://github.com/eclipse-sirius/sirius-web/issues/4835[#4835] [view] Order Node/Edge palette's tools/tools sections the same way.
-
+- https://github.com/eclipse-sirius/sirius-web/issues/4102[#4102] [sirius-web] Leverage custom render variables to improve render performances of the _Explorer_.
+Specifically, drastically reduce the number of database queries executed when rendering non-trivial explorer trees.
 
 
 == v2025.4.0

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerChildrenProvider.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerChildrenProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import org.eclipse.sirius.components.trees.renderer.TreeRenderer;
 import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerChildrenProvider;
 import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerServices;
 import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerTreeItemAlteredContentProvider;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.RepresentationMetadata;
 import org.springframework.stereotype.Service;
 
 /**
@@ -46,7 +47,9 @@ public class ExplorerChildrenProvider implements IExplorerChildrenProvider {
     public boolean hasChildren(VariableManager variableManager) {
         Object self = variableManager.getVariables().get(VariableManager.SELF);
         Optional<IEditingContext> optionalEditingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class);
-        return this.explorerServices.hasChildren(self, optionalEditingContext.orElse(null));
+        @SuppressWarnings("unchecked")
+        List<RepresentationMetadata> existingRepresentations = variableManager.get("existingRepresentations", List.class).orElse(List.of());
+        return this.explorerServices.hasChildren(self, optionalEditingContext.orElse(null), existingRepresentations);
     }
 
     @Override
@@ -78,7 +81,9 @@ public class ExplorerChildrenProvider implements IExplorerChildrenProvider {
         }
         var optionalEditingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class);
         Object self = variableManager.getVariables().get(VariableManager.SELF);
-        return this.explorerServices.getDefaultChildren(self, optionalEditingContext.orElse(null), expandedIds);
+        @SuppressWarnings("unchecked")
+        List<RepresentationMetadata> existingRepresentations = variableManager.get("existingRepresentations", List.class).orElse(List.of());
+        return this.explorerServices.getDefaultChildren(self, optionalEditingContext.orElse(null), expandedIds, existingRepresentations);
     }
 
     private List<String> getActiveFilterIds(VariableManager variableManager) {

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerServices.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerServices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.RepresentationMetadata;
 
 /**
  * Services used to perform operations in the explorer.
@@ -44,6 +45,8 @@ public interface IExplorerServices {
 
     boolean hasChildren(Object self, IEditingContext editingContext);
 
+    boolean hasChildren(Object self, IEditingContext editingContext, List<RepresentationMetadata> existingRepresentations);
+
     /**
      * Returns the un-filtered list of children for {@code self}.
      *
@@ -56,6 +59,8 @@ public interface IExplorerServices {
      * @return the list of children
      */
     List<Object> getDefaultChildren(Object self, IEditingContext editingContext, List<String> expandedIds);
+
+    List<Object> getDefaultChildren(Object self, IEditingContext editingContext, List<String> expandedIds, List<RepresentationMetadata> existingRepresentations);
 
     /**
      * Returns the un-filtered list of root elements.

--- a/packages/trees/backend/sirius-components-trees/src/main/java/org/eclipse/sirius/components/trees/description/TreeDescription.java
+++ b/packages/trees/backend/sirius-components-trees/src/main/java/org/eclipse/sirius/components/trees/description/TreeDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Obeo.
+ * Copyright (c) 2019, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -86,6 +86,8 @@ public final class TreeDescription implements IRepresentationDescription {
     private Function<VariableManager, StyledString> treeItemLabelProvider;
 
     private Function<VariableManager, List<String>> iconURLsProvider;
+
+    private Function<VariableManager, VariableManager> renderVariablesProvider;
 
     private TreeDescription() {
         // Prevent instantiation
@@ -186,6 +188,10 @@ public final class TreeDescription implements IRepresentationDescription {
         return this.iconURLsProvider;
     }
 
+    public Function<VariableManager, VariableManager> getRenderVariablesProvider() {
+        return this.renderVariablesProvider;
+    }
+
     @Override
     public String toString() {
         String pattern = "{0} '{'id: {1}, label: {2}'}'";
@@ -242,6 +248,8 @@ public final class TreeDescription implements IRepresentationDescription {
 
         private Function<VariableManager, List<String>> iconURLsProvider;
 
+        private Function<VariableManager, VariableManager> renderVariablesProvider = (vm) -> new VariableManager();
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -268,6 +276,7 @@ public final class TreeDescription implements IRepresentationDescription {
             this.treeItemObjectProvider = treeDescription.getTreeItemObjectProvider();
             this.treeItemLabelProvider = treeDescription.getTreeItemLabelProvider();
             this.iconURLsProvider = treeDescription.getIconURLsProvider();
+            this.renderVariablesProvider = treeDescription.getRenderVariablesProvider();
         }
 
         public Builder id(String id) {
@@ -375,6 +384,11 @@ public final class TreeDescription implements IRepresentationDescription {
             return this;
         }
 
+        public Builder renderVariablesProvider(Function<VariableManager, VariableManager> renderVariablesProvider) {
+            this.renderVariablesProvider =  Objects.requireNonNull(renderVariablesProvider);
+            return this;
+        }
+
         public TreeDescription build() {
             TreeDescription treeDescription = new TreeDescription();
             treeDescription.id = Objects.requireNonNull(this.id);
@@ -398,6 +412,7 @@ public final class TreeDescription implements IRepresentationDescription {
             treeDescription.treeItemObjectProvider = Objects.requireNonNull(this.treeItemObjectProvider);
             treeDescription.treeItemLabelProvider = Objects.requireNonNull(this.treeItemLabelProvider);
             treeDescription.iconURLsProvider = Objects.requireNonNull(this.iconURLsProvider);
+            treeDescription.renderVariablesProvider = Objects.requireNonNull(this.renderVariablesProvider);
             return treeDescription;
         }
     }

--- a/packages/trees/backend/sirius-components-trees/src/main/java/org/eclipse/sirius/components/trees/renderer/TreeRenderer.java
+++ b/packages/trees/backend/sirius-components-trees/src/main/java/org/eclipse/sirius/components/trees/renderer/TreeRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Obeo.
+ * Copyright (c) 2019, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import static java.util.stream.Collectors.joining;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -63,6 +64,17 @@ public class TreeRenderer {
         List<TreeItem> childrenItems = new ArrayList<>(rootElements.size());
 
         this.variableManager.put(ANCESTOR_IDS, new ArrayList<>());
+
+        // Compute any custom render variables and merge them (if they do not conflict with the default ones)
+        VariableManager renderVariables = this.treeDescription.getRenderVariablesProvider().apply(this.variableManager);
+        for (Map.Entry<String, Object> renderVariable : renderVariables.getVariables().entrySet()) {
+            String name = renderVariable.getKey();
+            Object value = renderVariable.getValue();
+            if (!this.variableManager.hasVariable(name)) {
+                this.variableManager.put(name, value);
+            }
+        }
+
         int index = 0;
         for (Object rootElement : rootElements) {
             VariableManager rootElementVariableManager = this.variableManager.createChild();


### PR DESCRIPTION
See https://github.com/eclipse-sirius/sirius-web/pull/4906 for the corresponding ADR.

Before the patch, expanding/rendering a tree which displays 2K semantic elements:

![1-baseline](https://github.com/user-attachments/assets/7277e889-1806-435d-871f-635f379a2551)

2010+3400+2308+3+3+3+2+1+1=7731 queries to the database

After the patch, same operation:

![2-wip-4102-render-variables](https://github.com/user-attachments/assets/99ab8c7a-b410-4dea-8509-d7afd8ca61df)

2010+15+3+3+3+2+2+1=2039 queries.

Still _way_ too much, but the remaining ones are unrelated to this particular issue.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/4102
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?