### PR TITLE
[4099] Improve the file upload mechanism

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -119,6 +119,7 @@ In the case of UML for example, which includes *many* derived references, this c
 It is safe to only look for proxies in "plain" (non-derived) references: if none is found there, there is no (sane) way for a derived reference to produce one.
 In all strictness, it *is* possible for the Java code inside a derived reference to produce a proxy object, but that is highly non-standard behavior, and given the performance benefit of ignoring these references it seems a good default.
 If we really want to support "pathological" metamodels maybe we could introduce some flags and/or other mechanism as a possible but non-default behavior.
+- https://github.com/eclipse-sirius/sirius-web/issues/4099[#4099] [sirius-web] Use low-level code for performance-critical ProxyValidator
 
 
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -114,6 +114,12 @@ We need the actual Resource to perform the validation, so do this inside `Docume
 This is a first step to ensure that we do not have unintended side-effects on the ResourceSet used, so that later on we can perform all the upload-related operations inside the already existing EditingContext's ResourceSet and avoid creating a new only (at great cost).
 - https://github.com/eclipse-sirius/sirius-web/issues/4099[#4099] [sirius-web] Cleanup temporary resources in `DocumentSanitizedJsonContentProvider`.
 This has a non-trivial cost for medium to large models as removing the resources triggers `oes.components.emf.services.EditingContextCrossReferenceAdapter.clearReferencesTo(EObject)`, which can be quite costly. But it is required to avoid unintended side-effects if we want to be able to perform the whole upload operation directly inside the already active EditingContext's ResourceSet.
+- https://github.com/eclipse-sirius/sirius-web/issues/4099[#4099] [sirius-web] Consider only non-derived refrences when testing for proxies.
+In the case of UML for example, which includes *many* derived references, this can have a significant impact.
+It is safe to only look for proxies in "plain" (non-derived) references: if none is found there, there is no (sane) way for a derived reference to produce one.
+In all strictness, it *is* possible for the Java code inside a derived reference to produce a proxy object, but that is highly non-standard behavior, and given the performance benefit of ignoring these references it seems a good default.
+If we really want to support "pathological" metamodels maybe we could introduce some flags and/or other mechanism as a possible but non-default behavior.
+
 
 
 == v2025.4.0

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -108,6 +108,7 @@ This is mostly visible when cold-opening projects with large documents (load per
 Note that the improvements will only be visible for projects created or modified after the update; existing semantic data which has not been modified will continue to be "slow" to load/read until it is modified at least once and saved in the new, improved format.
 - [releng] Switch to Sirius EMF JSON 2.5.1 and thus add the ability for a migration participant to change the URI used by a proxy during a migration.
 - https://github.com/eclipse-sirius/sirius-web/issues/4866[#4866] [diagram] Disable the last executed tool when opening the palette, if it is not available in the current state, it is still displayed for information.
+- https://github.com/eclipse-sirius/sirius-web/issues/4099[#4099] [sirius-web] Create the bytes array for the original contents only once
 
 
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -112,7 +112,8 @@ Note that the improvements will only be visible for projects created or modified
 - https://github.com/eclipse-sirius/sirius-web/issues/4099[#4099] [sirius-web] Move proxy validation into `DocumentSanitizedJsonContentProvider`.
 We need the actual Resource to perform the validation, so do this inside `DocumentSanitizedJsonContentProvider` so that we can cleanup after ourself and remove the resource used to obtain the initial JSON content from the resource set.
 This is a first step to ensure that we do not have unintended side-effects on the ResourceSet used, so that later on we can perform all the upload-related operations inside the already existing EditingContext's ResourceSet and avoid creating a new only (at great cost).
-
+- https://github.com/eclipse-sirius/sirius-web/issues/4099[#4099] [sirius-web] Cleanup temporary resources in `DocumentSanitizedJsonContentProvider`.
+This has a non-trivial cost for medium to large models as removing the resources triggers `oes.components.emf.services.EditingContextCrossReferenceAdapter.clearReferencesTo(EObject)`, which can be quite costly. But it is required to avoid unintended side-effects if we want to be able to perform the whole upload operation directly inside the already active EditingContext's ResourceSet.
 
 
 == v2025.4.0

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -109,6 +109,9 @@ Note that the improvements will only be visible for projects created or modified
 - [releng] Switch to Sirius EMF JSON 2.5.1 and thus add the ability for a migration participant to change the URI used by a proxy during a migration.
 - https://github.com/eclipse-sirius/sirius-web/issues/4866[#4866] [diagram] Disable the last executed tool when opening the palette, if it is not available in the current state, it is still displayed for information.
 - https://github.com/eclipse-sirius/sirius-web/issues/4099[#4099] [sirius-web] Create the bytes array for the original contents only once
+- https://github.com/eclipse-sirius/sirius-web/issues/4099[#4099] [sirius-web] Move proxy validation into `DocumentSanitizedJsonContentProvider`.
+We need the actual Resource to perform the validation, so do this inside `DocumentSanitizedJsonContentProvider` so that we can cleanup after ourself and remove the resource used to obtain the initial JSON content from the resource set.
+This is a first step to ensure that we do not have unintended side-effects on the ResourceSet used, so that later on we can perform all the upload-related operations inside the already existing EditingContext's ResourceSet and avoid creating a new only (at great cost).
 
 
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -120,6 +120,8 @@ It is safe to only look for proxies in "plain" (non-derived) references: if none
 In all strictness, it *is* possible for the Java code inside a derived reference to produce a proxy object, but that is highly non-standard behavior, and given the performance benefit of ignoring these references it seems a good default.
 If we really want to support "pathological" metamodels maybe we could introduce some flags and/or other mechanism as a possible but non-default behavior.
 - https://github.com/eclipse-sirius/sirius-web/issues/4099[#4099] [sirius-web] Use low-level code for performance-critical ProxyValidator
+- https://github.com/eclipse-sirius/sirius-web/issues/4099[#4099] [sirius-web] Upload new models directly into the existing ResourceSet.
+This can be disabled with a system property for easy testing/comparison and if some applications decide that it is too risky in their context and accept the additional cost of re-creating a whole temporary editing context for the upload operation.
 
 
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/document/services/DocumentSanitizedJsonContentProvider.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/document/services/DocumentSanitizedJsonContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -107,9 +107,10 @@ public class DocumentSanitizedJsonContentProvider implements IDocumentSanitizedJ
         } catch (IOException exception) {
             this.logger.warn(exception.getMessage(), exception);
         }
+        byte[] bytes = baos.toByteArray();
         return this.externalResourceLoaderServices.stream()
-                .filter(loader -> loader.canHandle(new ByteArrayInputStream(baos.toByteArray()), resourceURI, resourceSet))
+                .filter(loader -> loader.canHandle(new ByteArrayInputStream(bytes), resourceURI, resourceSet))
                 .findFirst()
-                .flatMap(loader -> loader.getResource(new ByteArrayInputStream(baos.toByteArray()), resourceURI, resourceSet, applyMigrationParticipants));
+                .flatMap(loader -> loader.getResource(new ByteArrayInputStream(bytes), resourceURI, resourceSet, applyMigrationParticipants));
     }
 }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/document/services/DocumentSanitizedJsonContentProvider.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/document/services/DocumentSanitizedJsonContentProvider.java
@@ -16,6 +16,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +68,10 @@ public class DocumentSanitizedJsonContentProvider implements IDocumentSanitizedJ
         if (optionalInputResource.isPresent()) {
             Resource inputResource = optionalInputResource.get();
             try {
+                long start = System.nanoTime();
                 var hasProxies = this.proxyValidator.hasProxies(inputResource);
+                Duration timeToTestProxies = Duration.ofNanos(System.nanoTime() - start);
+                this.logger.info("Checked for proxies in {}ms", timeToTestProxies.toMillis());
                 if (hasProxies) {
                     this.logger.warn("The resource {} contains unresolvable proxies and will not be uploaded.", name);
                 } else {

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/document/services/ProxyValidator.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/document/services/ProxyValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,7 @@ public class ProxyValidator implements IProxyValidator {
 
     private boolean hasProxies(EObject eObject) {
         return eObject.eClass().getEAllReferences().stream()
-                .filter(eReference -> !eReference.isContainment() && eObject.eIsSet(eReference))
+                .filter(eReference -> !eReference.isContainment() && !eReference.isDerived() && eObject.eIsSet(eReference))
                 .anyMatch(eReference -> this.hasProxies(eObject, eReference));
     }
 


### PR DESCRIPTION
- **[4099] Only create the bytes array for the original contents once**
- **[4099] Move proxy validation into DocumentSanitizedJsonContentProvider**
- **[4099] Cleanup temporary resources in DocumentSanitizedJsonContentProvider**
- **[4099] Only consider non-derived refrences when testing for proxies**
- **[4099] Use low-level code for performance-critical ProxyValidator**
- **[4099] Upload new models directly into the existing ResourceSet**

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?