### PR TITLE
[4931] Add updateTargetObjectId to IRepresentationMetadataUpdateService

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,6 +33,8 @@ JsonResource resource = jsonResourceFactory.createResource(uri, customOptions);
 ----
 +
 See https://github.com/eclipse-sirius/sirius-emf-json/blob/master/CHANGELOG.adoc#v250[the Sirius EMF JSON changelog] for details.
+- https://github.com/eclipse-sirius/sirius-web/issues/4931[#4931] [sirius-web] Add a new `updateTargetObjectId` method to `IRepresentationMetadataUpdateService`.
+Every implementation of `IRepresentationMetadataUpdateService` should add its own implementation of `updateTargetObjectId`.
 
 
 === Dependency update
@@ -126,7 +128,9 @@ This can be disabled with a system property for easy testing/comparison and if s
 - https://github.com/eclipse-sirius/sirius-web/issues/4875[#4875] [table] Improve table representation lifecycle
 - https://github.com/eclipse-sirius/sirius-web/issues/4825[#4825] [table] Add support for tooltip on table cells
 - https://github.com/eclipse-sirius/sirius-web/issues/4332[#4332] [table] Remove table dependency in `sirius-components-form`
-
+- https://github.com/eclipse-sirius/sirius-web/issues/4931[#4931] [sirius-web] Add the ability to change programmatically the object to which a representation is attached.
+For that the service `IRepresentationMetadataUpdateService` has a new method named `updateTargetObjectId`.
+By itself, it will not be enough, one would also have to update the content of the representation too but `IRepresentationContentUpdateService` already support that.
 
 
 == v2025.4.0

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/representationdata/RepresentationMetadata.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/representationdata/RepresentationMetadata.java
@@ -141,6 +141,17 @@ public class RepresentationMetadata extends AbstractValidatingAggregateRoot<Repr
         }
     }
 
+    public void updateTargetObjectId(ICause cause, String newTargetObjectId) {
+        if (!newTargetObjectId.isEmpty() || !this.targetObjectId.equals(newTargetObjectId)) {
+            this.targetObjectId = newTargetObjectId;
+
+            var now = Instant.now();
+            this.lastModifiedOn = now;
+
+            this.registerEvent(new RepresentationMetadataUpdatedEvent(UUID.randomUUID(), now, cause, this));
+        }
+    }
+
     public void dispose(ICause cause) {
         this.registerEvent(new RepresentationMetadataDeletedEvent(UUID.randomUUID(), Instant.now(), cause, this));
     }

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/representationdata/services/RepresentationMetadataUpdateService.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/representationdata/services/RepresentationMetadataUpdateService.java
@@ -89,4 +89,19 @@ public class RepresentationMetadataUpdateService implements IRepresentationMetad
 
         return result;
     }
+
+    @Override
+    public IResult<Void> updateTargetObjectId(ICause cause, UUID representationMetadataId, String targetObjectId) {
+        IResult<Void> result = new Failure<>(this.messageService.notFound());
+
+        var optionalRepresentationMetadata = this.representationMetadataRepository.findMetadataById(representationMetadataId);
+        if (optionalRepresentationMetadata.isPresent()) {
+            var representationMetadata = optionalRepresentationMetadata.get();
+            representationMetadata.updateTargetObjectId(cause, targetObjectId);
+            this.representationMetadataRepository.save(representationMetadata);
+
+            result = new Success<>(null);
+        }
+        return result;
+    }
 }

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/representationdata/services/api/IRepresentationMetadataUpdateService.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/representationdata/services/api/IRepresentationMetadataUpdateService.java
@@ -30,4 +30,6 @@ public interface IRepresentationMetadataUpdateService {
     IResult<RepresentationMetadata> updateDocumentation(ICause cause, UUID representationMetadataId, String documentation);
 
     IResult<Void> updateDescriptionId(ICause cause, UUID representationMetadataId, String descriptionId);
+
+    IResult<Void> updateTargetObjectId(ICause cause, UUID representationMetadataId, String targetObjectId);
 }

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/data/TestIdentifiers.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/data/TestIdentifiers.java
@@ -33,8 +33,6 @@ public final class TestIdentifiers {
     public static final UUID EPACKAGE_PORTAL_REPRESENTATION = UUID.fromString("e81eec5c-42d6-491c-8bcc-9beb951356f8");
     public static final UUID EPACKAGE_EMPTY_PORTAL_REPRESENTATION = UUID.fromString("05e44ccc-9363-443f-a816-25fc73e3e7f7");
 
-    public static final UUID PORTAL_REPRESENTATION_DESCRIPTION = UUID.fromString("69030a1b-0b5f-3c1d-8399-8ca260e4a672");
-
     private TestIdentifiers() {
         // Prevent instantiation
     }


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4931

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [x] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?