### PR TITLE
[4946] Add loading indicator in library publish/import/update dialogs

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -146,6 +146,7 @@ By itself, it will not be enough, one would also have to update the content of t
 - https://github.com/eclipse-sirius/sirius-web/issues/4932[#4932] [core] Add a pre/post processor mechanism to `EditingContextEventProcessorRegistry`.
 Thanks to this mechanism one can trigger some behavior after the entire loading of the editing context and before the creation of the `IEditingContextEventProcessor` or just after the creation of the `IEditingContextEventProcessor`.
 - https://github.com/eclipse-sirius/sirius-web/issues/4935[#4935] [sirius-web] Add loading indicator when uploading a project or document.
+- https://github.com/eclipse-sirius/sirius-web/issues/4946[#4946] [sirius-web] Add loading indicator in dialogs used to publish, import or update a library.
 
 
 == v2025.4.0

--- a/packages/sirius-web/frontend/sirius-web-application/src/libraries/PublishLibraryDialog.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/libraries/PublishLibraryDialog.tsx
@@ -56,7 +56,7 @@ export const PublishLibraryDialog = ({ open, title, message, publicationKind, on
     setState((prevState) => ({ ...prevState, description: value.toString() }));
   };
 
-  const { publishLibraries, data } = usePublishLibraries();
+  const { publishLibraries, loading, data } = usePublishLibraries();
   useEffect(() => {
     if (data) {
       onClose();
@@ -110,6 +110,7 @@ export const PublishLibraryDialog = ({ open, title, message, publicationKind, on
         <Button
           variant="contained"
           disabled={isInvalid}
+          loading={loading}
           data-testid="publish-library"
           color="primary"
           onClick={handlePublish}>

--- a/packages/sirius-web/frontend/sirius-web-application/src/omnibox/ImportLibraryDialog.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/omnibox/ImportLibraryDialog.types.ts
@@ -28,12 +28,12 @@ export interface ImportLibraryAction {
 }
 
 export interface ImportStudioSplitButtonProps {
+  selectedLibraries: string[];
   actions: ImportLibraryAction[];
-  onClick: (action: ImportLibraryAction) => void;
+  onLibraryImported: () => void;
 }
 
 export interface ImportStudioSplitButtonState {
-  actions: ImportLibraryAction[];
   selected: boolean;
   open: boolean;
   selectedIndex: number;

--- a/packages/sirius-web/frontend/sirius-web-application/src/omnibox/LibrariesImportTable.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/omnibox/LibrariesImportTable.tsx
@@ -23,7 +23,7 @@ import { useLibraries } from '../views/library-browser/useLibraries';
 import { GQLLibrary } from '../views/library-browser/useLibraries.types';
 import { LibrariesImportTableProps, LibrariesImportTableState } from './LibrariesImportTable.types';
 
-export const LibrariesImportTable = ({ onSelectionChange }: LibrariesImportTableProps) => {
+export const LibrariesImportTable = ({ onSelectedLibrariesChange }: LibrariesImportTableProps) => {
   const [state, setState] = useState<LibrariesImportTableState>({
     data: null,
   });
@@ -45,7 +45,7 @@ export const LibrariesImportTable = ({ onSelectionChange }: LibrariesImportTable
   }, [data]);
 
   useEffect(() => {
-    onSelectionChange(Object.keys(rowSelection));
+    onSelectedLibrariesChange(Object.keys(rowSelection));
   }, [rowSelection]);
 
   const columns = useMemo<MRT_ColumnDef<GQLLibrary>[]>(

--- a/packages/sirius-web/frontend/sirius-web-application/src/omnibox/LibrariesImportTable.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/omnibox/LibrariesImportTable.types.ts
@@ -13,7 +13,7 @@
 import { GQLGetLibrariesQueryData } from '../views/library-browser/useLibraries.types';
 
 export interface LibrariesImportTableProps {
-  onSelectionChange(selection: string[]);
+  onSelectedLibrariesChange(selectedLibraryIds: string[]);
 }
 
 export interface LibrariesImportTableState {

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/context-menu-contributions/update-library/UpdateLibraryModal.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/context-menu-contributions/update-library/UpdateLibraryModal.tsx
@@ -15,7 +15,7 @@ import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useCurrentProject } from '../../../../useCurrentProject';
 import { UpdateLibraryModalProps, UpdateLibraryModalState } from './UpdateLibraryModal.types';
 import { UpdateLibraryTable } from './UpdateLibraryTable';
@@ -26,7 +26,7 @@ export const UpdateLibraryModal = ({ open, title, namespace, name, version, onCl
     selectedLibraryId: null,
   });
 
-  const { updateLibrary, data } = useUpdateLibrary();
+  const { updateLibrary, loading, data } = useUpdateLibrary();
   useEffect(() => {
     if (data) {
       onClose();
@@ -63,6 +63,7 @@ export const UpdateLibraryModal = ({ open, title, namespace, name, version, onCl
         <Button
           variant="contained"
           disabled={state.selectedLibraryId === null}
+          loading={loading}
           data-testid="update-library"
           color="primary"
           onClick={handleUpdateLibrary}>


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4946

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?

* Create a new Studio project, use command "Publish Studio", upon hitting button "Publish" of the dialog, the button reflects the loading state.
* (from a studio project) use command "Import studio libraries", select one of the libraries and upon hitting button "Import" or "Copy", the button reflects the loading state.
* (from a project with a library imported by reference) from the Explorer view, in the contextual menu of a resource from the imported library, use action "Update Library", upon hitting button "Update" of the dialog, the button reflects the loading state.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?