### PR TITLE
[4102] Reduce the number of database queries when rendering a Tree/Explorer

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -41,7 +41,8 @@ Every implementation of `IRepresentationMetadataUpdateService` should add its ow
 * `MigrationData getMigrationData()` method has been renamed to `MigrationData getLastMigrationData()`.
 * `void setMigrationData()` method has been renamed/changed to `boolean addMigrationData()`.
 * A new method `List<MigrationData> getAllMigrationData()` method has been added.
-
+* https://github.com/eclipse-sirius/sirius-web/issues/4102[#4102] [sirius-web] The `hasChildren()` and `getDefaultChildren()` of the [`IExplorerSerices`](https://github.com/eclipse-sirius/sirius-web/blob/master/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerServices.java) interface now expect an additional `List<RepresentationMetadata> existingRepresentations` argument with the list of all the representations to consider when rendering explorer items.
+In the default implementation (in `ExplorerChildrenProvider`) its value comes from the new variable `existingRepresentations` injected by `ExplorerRenderVariablesCustomizer`.
 
 === Dependency update
 
@@ -101,7 +102,9 @@ For that, one should simply use the parameter `mode=svg-viewer`
 - https://github.com/eclipse-sirius/sirius-web/issues/4941[#4941] [diagram] Add the ability to perform an arrange all before displaying the diagram in the image viewer.
 For that, one should use the parameter `arrangeAll=true`
 - https://github.com/eclipse-sirius/sirius-web/issues/4918[#4918] [diagram] Add a node action to manage visibility of children
-
+- https://github.com/eclipse-sirius/sirius-web/issues/4102[#4102] [sirius-web] A new interface, `IRepresentationRenderVariableCustomizer`, can now be used to customize the set of variables available when rendering a Tree.
+In particular it can be used to add new variables which are costly to compute so that they can be set *once* per tree render, and then used from any expression in the tree definition.
+This mechanism is currently provisional and only available for `TreeDescription` but will probably be generalized (maybe in an updated form) for other representations in the future.
 
 === Improvements
 
@@ -158,6 +161,12 @@ Thanks to this mechanism one can trigger some behavior after the entire loading 
 - https://github.com/eclipse-sirius/sirius-web/issues/4822[#4822] [core] Allow the retrieval of all the representations.
 The onboard area can now display all the representations created in the project and it is not limited to the first 20 representations.
 - https://github.com/eclipse-sirius/sirius-web/issues/4963[#4963] [core] Avoid change recording overhead for some well-known read-only operations.
+- https://github.com/eclipse-sirius/sirius-web/issues/4102[#4102] [sirius-web] Rendering the contents of the _Explorer_ now uses much less accesses to the database, for faster results.
+The number of database queries used is now independent on the number of items to render.
+This is done thanks to the addition of a fast-path in `ExplorerServices#getTreeItemObject`.
+This avoids one DB query per tree item in most cases where the `IDefaultObjectSearchService` knows how to find the element.
+This changes the behavior if there are delegates which *override* the default response from `IDefaultObjectSearchService` instead of simply adding support for elements not handled at all by `IDefaultObjectSearchService`.
+
 
 
 == v2025.4.0

--- a/packages/core/backend/sirius-components-representations/src/main/java/org/eclipse/sirius/components/representations/IRepresentationRenderVariableCustomizer.java
+++ b/packages/core/backend/sirius-components-representations/src/main/java/org/eclipse/sirius/components/representations/IRepresentationRenderVariableCustomizer.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.representations;
+
+/**
+ * Used to customize the variables available during the refresh/render of a representation. For example this can be used
+ * to add new custom variables that will be computed only once per render, and leveraged many times inside the various
+ * expressions/providers invoked when rendering a complex representation.
+ *
+ * @author pcdavid
+ */
+public interface IRepresentationRenderVariableCustomizer {
+    VariableManager customize(IRepresentationDescription representationDescription, VariableManager variableManager);
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/representations/DomainExplorerServices.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/representations/DomainExplorerServices.java
@@ -28,6 +28,7 @@ import org.eclipse.sirius.components.domain.Domain;
 import org.eclipse.sirius.components.domain.Entity;
 import org.eclipse.sirius.web.application.UUIDParser;
 import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerServices;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.RepresentationMetadata;
 import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.services.api.IRepresentationMetadataSearchService;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.stereotype.Service;
@@ -68,7 +69,7 @@ public class DomainExplorerServices {
         return kind;
     }
 
-    public boolean hasChildren(IEditingContext editingContext, Object self) {
+    public boolean hasChildren(IEditingContext editingContext, Object self, List<RepresentationMetadata> existingRepresentations) {
         boolean hasChildren = false;
         if (self instanceof SettingWrapper wrapper) {
             var value = wrapper.setting.get(true);
@@ -76,7 +77,7 @@ public class DomainExplorerServices {
                 hasChildren = !collection.isEmpty();
             }
         } else {
-            hasChildren = this.explorerServices.hasChildren(self, editingContext);
+            hasChildren = this.explorerServices.hasChildren(self, editingContext, existingRepresentations);
             if (!hasChildren && self instanceof Entity) {
                 hasChildren = true;
             }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/representations/DomainViewTreeDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/representations/DomainViewTreeDescriptionProvider.java
@@ -36,6 +36,7 @@ import org.eclipse.sirius.components.view.tree.TreeItemLabelElementDescription;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
 import org.eclipse.sirius.web.application.editingcontext.EditingContext;
 import org.eclipse.sirius.web.application.studio.services.api.IStudioCapableEditingContextPredicate;
+import org.eclipse.sirius.web.application.views.explorer.services.ExplorerDescriptionProvider;
 import org.springframework.stereotype.Service;
 
 /**
@@ -124,7 +125,7 @@ public class DomainViewTreeDescriptionProvider implements IEditingContextProcess
                 .deletableExpression("aql:self.isDeletable()")
                 .editableExpression("aql:self.isEditable()")
                 .selectableExpression("aql:self.isSelectable()")
-                .hasChildrenExpression("aql:editingContext.hasChildren(self)")
+                .hasChildrenExpression("aql:editingContext.hasChildren(self, " + ExplorerDescriptionProvider.EXISTING_REPRESENTATIONS + ")")
                 .elementsExpression("aql:editingContext.getElements()")
                 .childrenExpression("aql:self.getChildren(editingContext, expanded)")
                 .parentExpression("aql:self.getParent(editingContext, id)")

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -60,6 +60,8 @@ public class ExplorerDescriptionProvider implements IEditingContextRepresentatio
     public static final String PREFIX = "explorer://";
 
     public static final String REPRESENTATION_NAME = "Explorer";
+
+    public static final String EXISTING_REPRESENTATIONS = "existingRepresentations";
 
     private final IObjectService objectService;
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerRenderVariablesCustomizer.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerRenderVariablesCustomizer.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.representations.IRepresentationDescription;
+import org.eclipse.sirius.components.representations.IRepresentationRenderVariableCustomizer;
+import org.eclipse.sirius.components.representations.VariableManager;
+import org.eclipse.sirius.web.application.UUIDParser;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.RepresentationMetadata;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.services.api.IRepresentationMetadataSearchService;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.stereotype.Service;
+
+/**
+ * Provides additional render variables to be used by {@link ExplorerDescriptionProvider} to reduce the amount of duplicate work (notably database access):
+ *
+ * <dl>
+ * <dt>{@code existingRepresentations}<dt>
+ * <dd>the list of all {@RepresentationMetadata representations} present in the current editing context.</dd>
+ * </dl>
+ *
+ * @author pcdavid
+ */
+@Service
+public class ExplorerRenderVariablesCustomizer implements IRepresentationRenderVariableCustomizer {
+
+    private final IRepresentationMetadataSearchService representationMetadataSearchService;
+
+    public ExplorerRenderVariablesCustomizer(IRepresentationMetadataSearchService representationMetadataSearchService) {
+        this.representationMetadataSearchService = Objects.requireNonNull(representationMetadataSearchService);
+    }
+
+    @Override
+    public VariableManager customize(IRepresentationDescription representationDescription, VariableManager variableManager) {
+        if (ExplorerDescriptionProvider.DESCRIPTION_ID.equals(representationDescription.getId())) {
+            var optionalEditingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class);
+            if (optionalEditingContext.isPresent()) {
+                VariableManager customizedVariableManager = variableManager.createChild();
+                String editingContextId = optionalEditingContext.get().getId();
+                var optionalSemanticDataId = new UUIDParser().parse(editingContextId);
+                List<RepresentationMetadata> allRepresentationMetadata = this.representationMetadataSearchService.findAllRepresentationMetadataBySemanticData(AggregateReference.to(optionalSemanticDataId.get()));
+                customizedVariableManager.put(ExplorerDescriptionProvider.EXISTING_REPRESENTATIONS, allRepresentationMetadata);
+                return customizedVariableManager;
+            }
+        }
+        return variableManager;
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerServices.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerServices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.RepresentationMetadata;
 
 /**
  * Services used to perform operations in the explorer.
@@ -42,7 +43,7 @@ public interface IExplorerServices {
 
     Object getParent(Object self, String treeItemId, IEditingContext editingContext);
 
-    boolean hasChildren(Object self, IEditingContext editingContext);
+    boolean hasChildren(Object self, IEditingContext editingContext, List<RepresentationMetadata> existingRepresentations);
 
     /**
      * Returns the un-filtered list of children for {@code self}.
@@ -53,9 +54,11 @@ public interface IExplorerServices {
      *            the editing context
      * @param expandedIds
      *            the list of expanded tree items
+     * @param existingRepresentations
+     *            the list of all currently existing representation in the editing context
      * @return the list of children
      */
-    List<Object> getDefaultChildren(Object self, IEditingContext editingContext, List<String> expandedIds);
+    List<Object> getDefaultChildren(Object self, IEditingContext editingContext, List<String> expandedIds, List<RepresentationMetadata> existingRepresentations);
 
     /**
      * Returns the un-filtered list of root elements.

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/TreeService.java
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/TreeService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Obeo.
+ * Copyright (c) 2019, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,10 +12,14 @@
  *******************************************************************************/
 package org.eclipse.sirius.components.collaborative.trees;
 
+import java.util.List;
+import java.util.Objects;
+
 import org.eclipse.sirius.components.collaborative.trees.api.ITreeService;
 import org.eclipse.sirius.components.collaborative.trees.api.TreeCreationParameters;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.representations.GetOrCreateRandomIdProvider;
+import org.eclipse.sirius.components.representations.IRepresentationRenderVariableCustomizer;
 import org.eclipse.sirius.components.representations.VariableManager;
 import org.eclipse.sirius.components.trees.Tree;
 import org.eclipse.sirius.components.trees.renderer.TreeRenderer;
@@ -29,17 +33,31 @@ import org.springframework.stereotype.Service;
 @Service
 public class TreeService implements ITreeService {
 
+    private final List<IRepresentationRenderVariableCustomizer> renderVariableCustomizers;
+
+    public TreeService(List<IRepresentationRenderVariableCustomizer> renderVariableCustomizers) {
+        this.renderVariableCustomizers = Objects.requireNonNull(renderVariableCustomizers);
+    }
+
     @Override
     public Tree create(TreeCreationParameters treeCreationParameters) {
+        VariableManager variableManager = this.createDefaultVariables(treeCreationParameters);
+        for (var renderVariableCustomizer : this.renderVariableCustomizers) {
+            variableManager = renderVariableCustomizer.customize(treeCreationParameters.getTreeDescription(), variableManager);
+        }
+
+        TreeRenderer treeRenderer = new TreeRenderer(variableManager, treeCreationParameters.getTreeDescription());
+        return treeRenderer.render();
+    }
+
+    private VariableManager createDefaultVariables(TreeCreationParameters treeCreationParameters) {
         VariableManager variableManager = new VariableManager();
         variableManager.put(GetOrCreateRandomIdProvider.PREVIOUS_REPRESENTATION_ID, treeCreationParameters.getId());
         variableManager.put(IEditingContext.EDITING_CONTEXT, treeCreationParameters.getEditingContext());
         variableManager.put(VariableManager.SELF, treeCreationParameters.getTargetObject());
         variableManager.put(TreeRenderer.EXPANDED, treeCreationParameters.getExpanded());
         variableManager.put(TreeRenderer.ACTIVE_FILTER_IDS, treeCreationParameters.getActiveFilterIds());
-
-        TreeRenderer treeRenderer = new TreeRenderer(variableManager, treeCreationParameters.getTreeDescription());
-        return treeRenderer.render();
+        return variableManager;
     }
 
 }

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/test/java/org/eclipse/sirius/components/collaborative/trees/architecture/handlers/DefaultExpandAllTreePathHandlerTests.java
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/test/java/org/eclipse/sirius/components/collaborative/trees/architecture/handlers/DefaultExpandAllTreePathHandlerTests.java
@@ -90,7 +90,7 @@ public class DefaultExpandAllTreePathHandlerTests {
             }
         };
 
-        var handler = new DefaultExpandAllTreePathHandler(new ITreeNavigationService.NoOp(), representationDescriptionSearchService, new IURLParser.NoOp());
+        var handler = new DefaultExpandAllTreePathHandler(new ITreeNavigationService.NoOp(), representationDescriptionSearchService, new IURLParser.NoOp(), List.of());
         Tree tree = this.createTree();
 
         var input = new ExpandAllTreePathInput(UUID.randomUUID(), "editingContextId", "representationId", "treeItemId");
@@ -143,7 +143,7 @@ public class DefaultExpandAllTreePathHandlerTests {
             }
         };
 
-        var handler = new DefaultExpandAllTreePathHandler(new ITreeNavigationService.NoOp(), representationDescriptionSearchService, new IURLParser.NoOp());
+        var handler = new DefaultExpandAllTreePathHandler(new ITreeNavigationService.NoOp(), representationDescriptionSearchService, new IURLParser.NoOp(), List.of());
         Tree tree = this.createTree();
 
         var input = new ExpandAllTreePathInput(UUID.randomUUID(), "editingContextId", "representationId", "treeItemId");


### PR DESCRIPTION
- **[4102] Add IRepresentationRenderVariableCustomizer mechanism**
- **[4102] Provide a new existingRepresentations variable for Explorers**
- **[4102] Leverage the new variable in ExplorerServices**
- **[4102] Add a fast-path in ExplorerServices.getTreeItemObject**
- **[4102] Update the CHANGELOG**

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?