### PR TITLE
[3917] Disable edge path customization when diagram is in read-only mode

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -90,6 +90,8 @@ The following dependencies have been updated:
 These `useEffect` now read the state value from `prevState` instead of `state`, which may not be reflecting the modifications performed by other `useEffect`.
 - https://github.com/eclipse-sirius/sirius-web/issues/4967[#4967] [sirius-web] Fix representation creation when uploading whole projects
 - https://github.com/eclipse-sirius/sirius-web/issues/4979[#4977] [sirius-web] Fix a bug introduced with #4183 where collapsed views were still rendered (and updated by the backend)
+- https://github.com/eclipse-sirius/sirius-web/issues/3917[#3917] [diagram] Disable edge path customization when diagram is in read-only mode
+
 
 === New Features
 

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/edge/BendPoint.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/edge/BendPoint.tsx
@@ -10,14 +10,21 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { useRef, RefObject } from 'react';
+import { useRef, RefObject, useContext } from 'react';
 import { useViewport } from '@xyflow/react';
 import Draggable, { DraggableData } from 'react-draggable';
 import { BendPointProps, TemporaryMovingLineProps } from './BendPoint.types';
+import { DiagramContext } from '../../contexts/DiagramContext';
+import { DiagramContextValue } from '../../contexts/DiagramContext.types';
 
 export const BendPoint = ({ x, y, index, onDrag, onDragStop }: BendPointProps) => {
   const { zoom } = useViewport();
   const nodeRef = useRef<SVGCircleElement>(null);
+  const { readOnly } = useContext<DiagramContextValue>(DiagramContext);
+
+  if (readOnly) {
+    return null;
+  }
 
   return (
     <Draggable
@@ -42,6 +49,12 @@ export const TemporaryMovingLine = ({
 }: TemporaryMovingLineProps) => {
   const { zoom } = useViewport();
   const nodeRef = useRef<SVGRectElement>(null);
+  const { readOnly } = useContext<DiagramContextValue>(DiagramContext);
+
+  if (readOnly) {
+    return null;
+  }
+
   const segmentLengthWithoutBoundaries = segmentLength - 2;
 
   const width = direction === 'x' ? segmentLengthWithoutBoundaries : 4;

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/panel/DiagramPanel.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/panel/DiagramPanel.tsx
@@ -172,7 +172,8 @@ export const DiagramPanel = memo(
                   size="small"
                   aria-label="show helper lines"
                   onClick={() => onHelperLines(true)}
-                  data-testid="show-helper-lines">
+                  data-testid="show-helper-lines"
+                  disabled={readOnly}>
                   <HelperLinesIcon />
                 </IconButton>
               </Tooltip>
@@ -184,7 +185,8 @@ export const DiagramPanel = memo(
                   size="small"
                   aria-label="smart step edge"
                   onClick={() => onEdgeType('smartStepEdge')}
-                  data-testid="smart-step-edge">
+                  data-testid="smart-step-edge"
+                  disabled={readOnly}>
                   <SmoothStepEdgeIcon />
                 </IconButton>
               </Tooltip>
@@ -194,7 +196,8 @@ export const DiagramPanel = memo(
                   size="small"
                   aria-label="smooth step edge"
                   onClick={() => onEdgeType('smoothStepEdge')}
-                  data-testid="smooth-step-edge">
+                  data-testid="smooth-step-edge"
+                  disabled={readOnly}>
                   <SmartEdgeIcon />
                 </IconButton>
               </Tooltip>


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/3917

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?