### PR TITLE
[fix] Fix default values for TextStyleDescription attributes

### DIFF
--- a/packages/view/backend/sirius-components-view/src/main/java/org/eclipse/sirius/components/view/TextStyleDescription.java
+++ b/packages/view/backend/sirius-components-view/src/main/java/org/eclipse/sirius/components/view/TextStyleDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -112,12 +112,12 @@ public interface TextStyleDescription extends EObject {
 
     /**
      * Returns the value of the '<em><b>Is Bold Expression</b></em>' attribute. The default value is
-     * <code>"aql:\'false\'"</code>. <!-- begin-user-doc --> <!-- end-user-doc -->
+     * <code>"aql:false"</code>. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @return the value of the '<em>Is Bold Expression</em>' attribute.
      * @see #setIsBoldExpression(String)
      * @see org.eclipse.sirius.components.view.ViewPackage#getTextStyleDescription_IsBoldExpression()
-     * @model default="aql:\'false\'" dataType="org.eclipse.sirius.components.view.InterpretedExpression"
+     * @model default="aql:false" dataType="org.eclipse.sirius.components.view.InterpretedExpression"
      * @generated
      */
     String getIsBoldExpression();
@@ -135,12 +135,12 @@ public interface TextStyleDescription extends EObject {
 
     /**
      * Returns the value of the '<em><b>Is Italic Expression</b></em>' attribute. The default value is
-     * <code>"aql:\'false\'"</code>. <!-- begin-user-doc --> <!-- end-user-doc -->
+     * <code>"aql:false"</code>. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @return the value of the '<em>Is Italic Expression</em>' attribute.
      * @see #setIsItalicExpression(String)
      * @see org.eclipse.sirius.components.view.ViewPackage#getTextStyleDescription_IsItalicExpression()
-     * @model default="aql:\'false\'" dataType="org.eclipse.sirius.components.view.InterpretedExpression"
+     * @model default="aql:false" dataType="org.eclipse.sirius.components.view.InterpretedExpression"
      * @generated
      */
     String getIsItalicExpression();
@@ -158,12 +158,12 @@ public interface TextStyleDescription extends EObject {
 
     /**
      * Returns the value of the '<em><b>Is Underline Expression</b></em>' attribute. The default value is
-     * <code>"aql:\'false\'"</code>. <!-- begin-user-doc --> <!-- end-user-doc -->
+     * <code>"aql:false"</code>. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @return the value of the '<em>Is Underline Expression</em>' attribute.
      * @see #setIsUnderlineExpression(String)
      * @see org.eclipse.sirius.components.view.ViewPackage#getTextStyleDescription_IsUnderlineExpression()
-     * @model default="aql:\'false\'" dataType="org.eclipse.sirius.components.view.InterpretedExpression"
+     * @model default="aql:false" dataType="org.eclipse.sirius.components.view.InterpretedExpression"
      * @generated
      */
     String getIsUnderlineExpression();

--- a/packages/view/backend/sirius-components-view/src/main/java/org/eclipse/sirius/components/view/impl/TextStyleDescriptionImpl.java
+++ b/packages/view/backend/sirius-components-view/src/main/java/org/eclipse/sirius/components/view/impl/TextStyleDescriptionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -110,7 +110,7 @@ public class TextStyleDescriptionImpl extends MinimalEObjectImpl.Container imple
      * @generated
      * @ordered
      */
-    protected static final String IS_BOLD_EXPRESSION_EDEFAULT = "aql:\'false\'";
+    protected static final String IS_BOLD_EXPRESSION_EDEFAULT = "aql:false";
 
     /**
      * The cached value of the '{@link #getIsBoldExpression() <em>Is Bold Expression</em>}' attribute. <!--
@@ -130,7 +130,7 @@ public class TextStyleDescriptionImpl extends MinimalEObjectImpl.Container imple
      * @generated
      * @ordered
      */
-    protected static final String IS_ITALIC_EXPRESSION_EDEFAULT = "aql:\'false\'";
+    protected static final String IS_ITALIC_EXPRESSION_EDEFAULT = "aql:false";
 
     /**
      * The cached value of the '{@link #getIsItalicExpression() <em>Is Italic Expression</em>}' attribute. <!--
@@ -150,7 +150,7 @@ public class TextStyleDescriptionImpl extends MinimalEObjectImpl.Container imple
      * @generated
      * @ordered
      */
-    protected static final String IS_UNDERLINE_EXPRESSION_EDEFAULT = "aql:\'false\'";
+    protected static final String IS_UNDERLINE_EXPRESSION_EDEFAULT = "aql:false";
 
     /**
      * The cached value of the '{@link #getIsUnderlineExpression() <em>Is Underline Expression</em>}' attribute. <!--

--- a/packages/view/backend/sirius-components-view/src/main/java/org/eclipse/sirius/components/view/impl/ViewPackageImpl.java
+++ b/packages/view/backend/sirius-components-view/src/main/java/org/eclipse/sirius/components/view/impl/ViewPackageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Obeo.
+ * Copyright (c) 2021, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -1163,11 +1163,11 @@ public class ViewPackageImpl extends EPackageImpl implements ViewPackage {
                 !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         this.initEAttribute(this.getTextStyleDescription_BackgroundColorExpression(), this.getInterpretedExpression(), "backgroundColorExpression", "", 0, 1, TextStyleDescription.class, !IS_TRANSIENT,
                 !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEAttribute(this.getTextStyleDescription_IsBoldExpression(), this.getInterpretedExpression(), "isBoldExpression", "aql:\'false\'", 0, 1, TextStyleDescription.class, !IS_TRANSIENT,
+        this.initEAttribute(this.getTextStyleDescription_IsBoldExpression(), this.getInterpretedExpression(), "isBoldExpression", "aql:false", 0, 1, TextStyleDescription.class, !IS_TRANSIENT,
                 !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEAttribute(this.getTextStyleDescription_IsItalicExpression(), this.getInterpretedExpression(), "isItalicExpression", "aql:\'false\'", 0, 1, TextStyleDescription.class, !IS_TRANSIENT,
+        this.initEAttribute(this.getTextStyleDescription_IsItalicExpression(), this.getInterpretedExpression(), "isItalicExpression", "aql:false", 0, 1, TextStyleDescription.class, !IS_TRANSIENT,
                 !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        this.initEAttribute(this.getTextStyleDescription_IsUnderlineExpression(), this.getInterpretedExpression(), "isUnderlineExpression", "aql:\'false\'", 0, 1, TextStyleDescription.class,
+        this.initEAttribute(this.getTextStyleDescription_IsUnderlineExpression(), this.getInterpretedExpression(), "isUnderlineExpression", "aql:false", 0, 1, TextStyleDescription.class,
                 !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         // Initialize data types

--- a/packages/view/backend/sirius-components-view/src/main/resources/model/view.ecore
+++ b/packages/view/backend/sirius-components-view/src/main/resources/model/view.ecore
@@ -110,10 +110,10 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="backgroundColorExpression"
         eType="#//InterpretedExpression" defaultValueLiteral=""/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="isBoldExpression" eType="#//InterpretedExpression"
-        defaultValueLiteral="aql:'false'"/>
+        defaultValueLiteral="aql:false"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="isItalicExpression" eType="#//InterpretedExpression"
-        defaultValueLiteral="aql:'false'"/>
+        defaultValueLiteral="aql:false"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="isUnderlineExpression"
-        eType="#//InterpretedExpression" defaultValueLiteral="aql:'false'"/>
+        eType="#//InterpretedExpression" defaultValueLiteral="aql:false"/>
   </eClassifiers>
 </ecore:EPackage>


### PR DESCRIPTION
While the string "false" will indeed be interpreted as boolean false
by Result.asBoolean(), it's a bit ugly and confusing to use an AQL
expression to return a string to be interpreted as a boolean.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?