### PR TITLE
[4899] Synchronize active project setting tab with the URL

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -141,6 +141,10 @@ While very small, this change is being made in a very important part of the code
 In case of issue with this change, it may have a performance impact and also be the cause of some regressions.
 - https://github.com/eclipse-sirius/sirius-web/issues/4513[#4513] [core] Add `descriptionId` in frontend `RepresentationMetadata`
 - https://github.com/eclipse-sirius/sirius-web/issues/5064[#5064] [diagram] Increase the interaction radius of bendpoints, they are now easier to move
+- https://github.com/eclipse-sirius/sirius-web/issues/4899[#4899] [sirius-web] Synchronize the active project setting tab with the URL.
+The route entry of the setting page has been updated to "/projects/:projectId/settings/:tabId?".
+In `ProjectSettingsView`, we will now rely on the `tabId` from the URL to identify the setting tab that should be opened, and update the URL whenever the selected tab changes.
+The page will now redirect to a 404 if the `tabId` in the URL is not a known tab.
 
 
 

--- a/packages/sirius-web/frontend/sirius-web-application/src/extension/DefaultExtensionRegistry.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/extension/DefaultExtensionRegistry.tsx
@@ -104,8 +104,8 @@ import { editProjectNavbarMenuEntryExtensionPoint } from '../views/edit-project/
 import { EditProjectView } from '../views/edit-project/EditProjectView';
 import { DetailsView } from '../views/edit-project/workbench-views/details/DetailsView';
 import { DiagramTreeItemContextMenuContribution } from '../views/edit-project/workbench-views/explorer/context-menu-contributions/DiagramTreeItemContextMenuContribution';
-import { ExpandAllTreeItemContextMenuContribution } from '../views/edit-project/workbench-views/explorer/context-menu-contributions/ExpandAllTreeItemContextMenuContribution';
 import { DocumentTreeItemContextMenuContribution } from '../views/edit-project/workbench-views/explorer/context-menu-contributions/DocumentTreeItemContextMenuContribution';
+import { ExpandAllTreeItemContextMenuContribution } from '../views/edit-project/workbench-views/explorer/context-menu-contributions/ExpandAllTreeItemContextMenuContribution';
 import { ObjectTreeItemContextMenuContribution } from '../views/edit-project/workbench-views/explorer/context-menu-contributions/ObjectTreeItemContextMenuContribution';
 import { RepresentationTreeItemContextMenuContribution } from '../views/edit-project/workbench-views/explorer/context-menu-contributions/RepresentationTreeItemContextMenuContribution';
 import { UpdateLibraryTreeItemContextMenuContribution } from '../views/edit-project/workbench-views/explorer/context-menu-contributions/UpdateLibraryTreeItemContextMenuContribution';
@@ -626,7 +626,7 @@ export const siriusWebRouterContributions: PathRouteProps[] = [
     element: <EditProjectView />,
   },
   {
-    path: '/projects/:projectId/settings/*',
+    path: '/projects/:projectId/settings/:tabId?',
     element: <ProjectSettingsView />,
   },
   {

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/project-settings/ProjectSettingsView.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/project-settings/ProjectSettingsView.types.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-export type ProjectSettingsParams = 'projectId';
+export type ProjectSettingsParams = 'projectId' | 'tabId';
 
 export interface ProjectSettingTabContribution {
   id: string;
@@ -21,10 +21,6 @@ export interface ProjectSettingTabContribution {
 }
 
 export interface ProjectSettingTabProps {}
-
-export interface ProjectSettingsViewState {
-  selectedTabId: string | null;
-}
 
 export interface GQLGetProjectVariables {
   projectId: string;


### PR DESCRIPTION
This PR fixes #4899 by implementing [this shape](https://github.com/eclipse-sirius/sirius-web/blob/master/doc/iterations/2025.8/add_selected_project_setting_tab_to_the_url.adoc).

This implementation synchronizes the URL with the currently active project setting tab.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [X] Variables have a proper type
- [X] Functions’ arguments have a proper type
- [X] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [X] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Review

### How to test this PR?
* Since the Sirius Web application only has 1 project setting tabs, we need to add another one.
In _packages/sirius-web/frontend/sirius-web-application/src/extension/DefaultExtensionRegistry.tsx_, extend defaultSettingPages with:
```
{
  id: 'images2',
  title: 'Images2',
  icon: <ImageIcon />,
  component: ProjectImagesSettings,
}
```
* Start the backend and frontend.
* Create a project and open its settings.
* The first setting tab is selected, and the URL updated accordingly.
* Select the second tab and observe that the URL changes accordingly.
* Reload that URL and observe that the settings page gets opened on the specified tab.
* Tweak the URL manually so that the tabId is invalid (e.g. "images3") and observe that the page loads by opening the first tab and the URL gets updated.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?