### PR TITLE
[fix] Hide the toolbar when the richtext widget is read-only

### DIFF
--- a/packages/forms/frontend/sirius-components-forms/src/richtexteditor/RichTextEditor.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/richtexteditor/RichTextEditor.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Obeo.
+ * Copyright (c) 2022, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -22,9 +22,9 @@ import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPl
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin';
 import { HeadingNode, QuoteNode } from '@lexical/rich-text';
-import { makeStyles } from 'tss-react/mui';
 import { $setSelection, TextNode } from 'lexical';
 import { FocusEvent, useCallback, useEffect } from 'react';
+import { makeStyles } from 'tss-react/mui';
 import { ListPlugin } from './ListPlugin';
 import {
   ContentEditableProps,
@@ -214,7 +214,7 @@ export const RichTextEditor = ({ value, placeholder, readOnly, onBlur }: RichTex
     <LexicalComposer initialConfig={initialConfig}>
       <OnBlurPlugin onBlur={onBlur}>
         <UpdateValuePlugin markdownText={value} />
-        <ToolbarPlugin readOnly={readOnly} />
+        {!readOnly ? <ToolbarPlugin readOnly={readOnly} /> : null}
         <div className={classes.editorContainer}>
           <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
           <ListPlugin />


### PR DESCRIPTION
When the RichTextEditor is disabled via `isEnabledExpression`, the toolbar remains visible, creating misleading UX (toolbar appears interactive but does nothing). This commit uses conditional rendering to completely hide the toolbar when the editor is read-only.

This also allows the widget to serve as a rich-text display (like a label), with correct markdown rendering but no editing affordances.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [X] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
Use a RichTextEditor with isEnabledExpression which returns true or false depending on some value  (I used "aql:not self.name.startsWith('locked')" ) in a form.
Confirm that:
- The toolbar is not rendered when the name starts with "locked"
- The text content is visible and correctly styled.
- When the editor is enabled again (after a rename), the toolbar reappears.

No impact is expected on interactive behavior when readOnly is false.


- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?