### PR TITLE
[5240] Ensure semantic data doesn't contain proxies after library update

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -46,6 +46,7 @@ The code in question now use `com.github.ben-manes.caffeine` instead, the altern
 - https://github.com/eclipse-sirius/sirius-web/issues/4924[#4924] [tree] Fix graphical glitch in Chrome with tree items background not being properly reset during drag'n'drop.
 - https://github.com/eclipse-sirius/sirius-web/issues/5277[#5277] [sirius-web] Fix an issue where the project natures were not returned with its owning project using `IProjectSearchService#findAll(Before|After)`.
 - https://github.com/eclipse-sirius/sirius-web/issues/5356[#5356] [diagram] Fix React error on non-unique keys for palette
+- https://github.com/eclipse-sirius/sirius-web/issues/5240[#5240] [sirius-web] Ensure that the editing context does not contain proxies after a library update
 
 
 === New Features

--- a/packages/sirius-web/backend/sirius-web-tests-data/src/main/resources/sirius-web-scripts/papaya-library.sql
+++ b/packages/sirius-web/backend/sirius-web-tests-data/src/main/resources/sirius-web-scripts/papaya-library.sql
@@ -573,3 +573,91 @@ INSERT INTO library (
   '2025-03-14 12:25:11.524',
   '2025-03-14 12:25:11.524'
 );
+
+INSERT INTO semantic_data (
+  id,
+  created_on,
+  last_modified_on
+) VALUES (
+  '194ba253-70ee-4c09-928f-3541e8a0e906', 
+  '2025-07-09 12:00:00.703625+00', 
+  '2025-07-09 12:00:00.361539+00'
+);
+
+INSERT INTO semantic_data_domain (
+  semantic_data_id,
+  uri
+) VALUES (
+  '194ba253-70ee-4c09-928f-3541e8a0e906',
+  'https://www.eclipse.org/sirius-web/papaya'
+);
+
+INSERT INTO document (
+  id,
+  semantic_data_id,
+  name,
+  content,
+  created_on,
+  last_modified_on
+) VALUES (
+  '27d8bea1-c595-4616-9208-a97218ad2316', 
+  '194ba253-70ee-4c09-928f-3541e8a0e906', 
+  'Sirius Web Tests Data', 
+  '{
+    "json":{
+      "version":"1.0",
+      "encoding":"utf-8"
+    },
+    "ns":{
+      "papaya":"https://www.eclipse.org/sirius-web/papaya"
+    },"content":[
+      {
+        "id": "fd766e2d-dfdf-41b4-b3df-89066ecd975d",
+        "eClass": "papaya:Project",
+        "data": {
+          "name": "backend",
+          "elements": [
+            {
+              "id": "429fb025-f429-4f78-a314-a8502024997a",
+              "eClass": "papaya:Component",
+              "data": {
+                "name": "sirius-web-tests-data",
+                "packages": [
+                  {
+                    "id": "f7804002-16b6-4bac-935a-e2eda2e0a753",
+                    "eClass": "papaya:Package",
+                    "data": {
+                      "name": "org.eclipse.sirius.web.tests.data"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }',
+  '2025-03-14 12:58:52.703625+00', 
+  '2025-03-14 12:59:22.361539+00'
+);
+
+INSERT INTO library (
+  id,
+  namespace,
+  name,
+  version,
+  semantic_data_id,
+  description,
+  created_on,
+  last_modified_on
+) VALUES (
+  'af292062-6a2a-4484-a671-edae354a8a13',
+  'papaya',
+  'sirius-web-tests-data',
+  '3.0.0',
+  '194ba253-70ee-4c09-928f-3541e8a0e906',
+  'The Sirius Web Tests Data library',
+  '2025-07-09 12:00:00.524',
+  '2025-07-09 12:00:00.524'
+);


### PR DESCRIPTION
Fixes #5240 

Bug: https://github.com/eclipse-sirius/sirius-web/issues/5240

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?

Create a papaya project
Import papaya-java@0.0.3
Create an interface "Interface1"
Create an interface "Interface2"
Update "Interface2" to make it extend "Interface1" and "java.time.temporal.Temporal"
Update papaya-java to 0.0.1 (this version does not contain the `Temporal` interface)
Check that "Interface2" now extends "Interface1" and nothing else

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?