### PR TITLE
[4886] Make shareable URL include side panels open/closed state

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -402,6 +402,7 @@ The dialog can now display an impact analysis report, but isn't in charge of ret
 - https://github.com/eclipse-sirius/sirius-web/issues/5171[#5171] [core] Rename representations in one event instead of two in `EditingContextEventProcessor` by directly renaming the representation in the concerned handlers.
 - https://github.com/eclipse-sirius/sirius-web/issues/5174[#5174] [core] Delete representations in one event instead of two in `EditingContextEventProcessor` by directly deleting the representation in the concerned handlers.
 - https://github.com/eclipse-sirius/sirius-web/issues/5013[#5013] [diagram] Improve edge path for source and target segments
+- https://github.com/eclipse-sirius/sirius-web/issues/4886[#4886] [core] The shareable URL now includes the open/closed state of the left and right panels.
 
 
 

--- a/integration-tests/cypress/e2e/project/workbench/workbench-configuration.cy.ts
+++ b/integration-tests/cypress/e2e/project/workbench/workbench-configuration.cy.ts
@@ -53,27 +53,58 @@ describe('Workbench Configuration Resolution', () => {
       });
     });
 
-    context('When opening the project with a custom workbench configuration', () => {
+    context('When opening the project with a workbench configuration where the side panels are collapsed', () => {
       let workbench: Workbench;
       beforeEach(() => {
         new Project().visit(projectId, {
           qs: {
-            workbenchConfiguration: workbenchConfigurationWithCustomValues,
+            workbenchConfiguration: workbenchConfigurationWithClosedPanels,
           },
         });
         workbench = new Workbench();
       });
-      it('Then, the left side panel is expanded, and the "Explorer" and "Validation" views are highlighted and active', () => {
+      it('Then, the left panel is collapsed and all views ("Explorer", "Validation") are not highlighted and not active', () => {
+        workbench.checkPanelState('left', 'collapsed');
+        workbench.isIconHighlighted('left', 'Explorer', false);
+        workbench.isIconHighlighted('left', 'Validation', false);
+        cy.getByTestId('site-left').should('not.exist');
+      });
+      it('Then, the right panel is collapsed and all views ("Details", "Query", "Representations", "Related Elements") are highlighted and active', () => {
+        workbench.checkPanelState('right', 'collapsed');
+        workbench.isIconHighlighted('right', 'Details');
+        workbench.isIconHighlighted('right', 'Query');
+        workbench.isIconHighlighted('right', 'Representations');
+        workbench.isIconHighlighted('right', 'Related Elements');
+        cy.getByTestId('site-right').should('not.exist');
+      });
+      it('Then, in the URL, the "workbenchConfiguration" search param is removed', () => {
+        cy.url().should('not.include', 'workbenchConfiguration=');
+      });
+    });
+
+    context('When opening the project with a workbench configuration where the side panels are expanded', () => {
+      let workbench: Workbench;
+      beforeEach(() => {
+        new Project().visit(projectId, {
+          qs: {
+            workbenchConfiguration: workbenchConfigurationWithExpandedPanels,
+          },
+        });
+        workbench = new Workbench();
+      });
+      it('Then, the left panel is expanded and all views ("Explorer", "Validation") are highlighted and active', () => {
         workbench.checkPanelState('left', 'expanded');
         workbench.isIconHighlighted('left', 'Explorer');
         workbench.isIconHighlighted('left', 'Validation');
         workbench.checkPanelContent('left', ['Explorer', 'Validation']);
       });
-      it('Then, the right side panel is expanded, and the "Representations" and "Related Elements" views are highlighted and active', () => {
+      it('Then, the right panel is expanded and all views ("Details", "Query", "Representations", "Related Elements") are highlighted and active', () => {
         workbench.checkPanelState('right', 'expanded');
+        workbench.isIconHighlighted('right', 'Details');
+        workbench.isIconHighlighted('right', 'Query');
         workbench.isIconHighlighted('right', 'Representations');
         workbench.isIconHighlighted('right', 'Related Elements');
-        workbench.checkPanelContent('right', ['Representations', 'Related Elements']);
+        workbench.checkPanelContent('right', ['Details', 'Query', 'Representations', 'Related Elements']);
       });
       it('Then, in the URL, the "workbenchConfiguration" search param is removed', () => {
         cy.url().should('not.include', 'workbenchConfiguration=');
@@ -83,10 +114,33 @@ describe('Workbench Configuration Resolution', () => {
 });
 
 const nullWorkbenchConfiguration: string = JSON.stringify(null);
-const workbenchConfigurationWithCustomValues: string = JSON.stringify({
+const workbenchConfigurationWithClosedPanels: string = JSON.stringify({
   sidePanels: [
     {
       id: 'left',
+      isOpen: false,
+      views: [
+        { id: 'explorer', isActive: false },
+        { id: 'validation', isActive: false },
+      ],
+    },
+    {
+      id: 'right',
+      isOpen: false,
+      views: [
+        { id: 'details', isActive: true },
+        { id: 'query', isActive: true },
+        { id: 'representations', isActive: true },
+        { id: 'related-elements', isActive: true },
+      ],
+    },
+  ],
+});
+const workbenchConfigurationWithExpandedPanels: string = JSON.stringify({
+  sidePanels: [
+    {
+      id: 'left',
+      isOpen: true,
       views: [
         { id: 'explorer', isActive: true },
         { id: 'validation', isActive: true },
@@ -94,9 +148,10 @@ const workbenchConfigurationWithCustomValues: string = JSON.stringify({
     },
     {
       id: 'right',
+      isOpen: true,
       views: [
-        { id: 'details', isActive: false },
-        { id: 'query', isActive: false },
+        { id: 'details', isActive: true },
+        { id: 'query', isActive: true },
         { id: 'representations', isActive: true },
         { id: 'related-elements', isActive: true },
       ],

--- a/packages/core/frontend/sirius-components-core/src/workbench/Panels.tsx
+++ b/packages/core/frontend/sirius-components-core/src/workbench/Panels.tsx
@@ -95,11 +95,11 @@ export const Panels = forwardRef<PanelsHandle | null, PanelsProps>(
 
     const leftInitialState: PanelState = {
       selectedContributionIds: leftInitialActiveConfigurationIds,
-      isOpen: false,
+      isOpen: leftPanelConfiguration?.isOpen ?? true,
     };
     const rightInitialState: PanelState = {
       selectedContributionIds: rightInitialActiveConfigurationIds,
-      isOpen: false,
+      isOpen: rightPanelConfiguration?.isOpen ?? true,
     };
 
     const { classes } = usePanelStyles();
@@ -129,13 +129,20 @@ export const Panels = forwardRef<PanelsHandle | null, PanelsProps>(
               isActive: rightPanelState.selectedContributionIds.includes(contribution.id),
             }));
             return [
-              { id: 'left', views: leftViewConfigurations },
-              { id: 'right', views: rightViewConfigurations },
+              { id: 'left', isOpen: leftPanelState?.isOpen, views: leftViewConfigurations },
+              { id: 'right', isOpen: rightPanelState?.isOpen, views: rightViewConfigurations },
             ];
           },
         };
       },
-      [leftSelectedContributions, rightSelectedContributions]
+      [
+        leftContributions,
+        leftSelectedContributions,
+        leftPanelState,
+        rightContributions,
+        rightSelectedContributions,
+        rightPanelState,
+      ]
     );
 
     const handleLeftContributionClicked = (id: string) => {
@@ -198,13 +205,15 @@ export const Panels = forwardRef<PanelsHandle | null, PanelsProps>(
       });
     };
 
-    const toggleLeftPanelOpen = () => {
-      setLeftPanelState((prevState) => ({ ...prevState, isOpen: !prevState.isOpen }));
+    const toggleLeftPanel = (isOpen: boolean) => {
+      setLeftPanelState((prevState) => ({ ...prevState, isOpen }));
     };
 
-    const toggleRightPanelOpen = () => {
-      setRightPanelState((prevState) => ({ ...prevState, isOpen: !prevState.isOpen }));
+    const toggleRightPanel = (isOpen: boolean) => {
+      setRightPanelState((prevState) => ({ ...prevState, isOpen }));
     };
+
+    const collapsedSize: number = 0;
 
     return (
       <div style={{ display: 'flex' }}>
@@ -218,12 +227,12 @@ export const Panels = forwardRef<PanelsHandle | null, PanelsProps>(
           <Panel
             id="left"
             className={classes.panel}
-            defaultSize={leftPanelInitialSize}
+            defaultSize={leftPanelState.isOpen ? leftPanelInitialSize : collapsedSize}
             collapsible
-            collapsedSize={0}
+            collapsedSize={collapsedSize}
             minSize={10}
-            onExpand={toggleLeftPanelOpen}
-            onCollapse={toggleLeftPanelOpen}
+            onExpand={() => toggleLeftPanel(true)}
+            onCollapse={() => toggleLeftPanel(false)}
             ref={leftRef}>
             {leftPanelState.isOpen ? (
               <PanelGroup direction="vertical">
@@ -258,12 +267,12 @@ export const Panels = forwardRef<PanelsHandle | null, PanelsProps>(
           <Panel
             id="right"
             className={classes.panel}
-            defaultSize={rightPanelInitialSize}
+            defaultSize={rightPanelState.isOpen ? rightPanelInitialSize : collapsedSize}
             collapsible
-            collapsedSize={0}
+            collapsedSize={collapsedSize}
             minSize={10}
-            onExpand={toggleRightPanelOpen}
-            onCollapse={toggleRightPanelOpen}
+            onExpand={() => toggleRightPanel(true)}
+            onCollapse={() => toggleRightPanel(false)}
             ref={rightRef}>
             {rightPanelState.isOpen ? (
               <PanelGroup direction="vertical">

--- a/packages/core/frontend/sirius-components-core/src/workbench/Workbench.types.ts
+++ b/packages/core/frontend/sirius-components-core/src/workbench/Workbench.types.ts
@@ -84,6 +84,7 @@ export interface WorkbenchConfiguration {
 
 export interface WorkbenchSidePanelConfiguration {
   id: string;
+  isOpen: boolean;
   views: WorkbenchViewConfiguration[];
 }
 


### PR DESCRIPTION
Follow-up to #5187 for (part of) #4886.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Frontend

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing

- [X] Variables have a proper type
- [X] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [X] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Review

### How to test this PR?

* Open a project
* Notice that the left and right panels are both initially opened
* In the left and right panels, select any of the views
* Close both left and right panels (by clicking on the icon of the selected views in the sidebar)
* Create a shareable URL from the project contextual menu
* Load the shareable URL => the left and right panels are both closed initially

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?