### PR TITLE
[releng] Use a distinct name for the diagram image server Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,7 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         if: env.GITHUB_EVENT_NAME == 'push' && startsWith(env.GITHUB_REF, 'refs/tags/v')
         with:
-          images: eclipsesirius/sirius-web
+          images: eclipsesirius/sirius-web-diagram-image-server
           tags: |
             type=ref,event=branch
             type=ref,event=tag


### PR DESCRIPTION
On "normal" commits we publish the result of building `packages/sirius-web/backend/sirius-web/Dockerfile` as `eclipsesirius/sirius-web`. Fine (altough maybe we don't need to do it so often).

On tags, we do this, and *then* we build and publish *under the same name* the result of building `diagram-image-server/Dockerfile`, which overwrites the actual Sirius Web docker image with the diagram-image-server one.
