### PR TITLE
[5057] Add support for customizing the behavior of the Duplicate object operation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -99,6 +99,7 @@ A new button is displayed to export the results when a query returns one or mult
 * `EditEllipseNodeAppearanceEventHandler implements IDiagramEventHandler` adds the needed `appearanceChanges` to the `diagramContext` after receiving the mutation
 * `EllipseNodeAppearanceHandler implements INodeAppearanceHandler` handles how the node is updated from the `appearanceChanges`
 * A GraphQL mutation is also added `editEllipseNodeAppearance`.
+- https://github.com/eclipse-sirius/sirius-web/issues/5057[#5057] [sirius-web] It is now possible to customize the behavior of the _Duplicate object_ operation on the backend using the new `org.eclipse.sirius.web.application.views.explorer.services.api.IObjectDuplicatorDelegate` API.
 
 
 === Improvements

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ComposedExplorerLabelService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ComposedExplorerLabelService.java
@@ -41,7 +41,8 @@ public class ComposedExplorerLabelService implements IExplorerLabelService {
     public boolean isEditable(Object self) {
         return this.explorerLabelServiceDelegates.stream()
                 .filter(delegate -> delegate.canHandle(self))
-                .findFirst().map(delegate -> delegate.isEditable(self))
+                .findFirst()
+                .map(delegate -> delegate.isEditable(self))
                 .orElseGet(() -> this.defaultExplorerLabelService.isEditable(self));
     }
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ComposedObjectDuplicator.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ComposedObjectDuplicator.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.representations.IStatus;
+import org.eclipse.sirius.web.application.views.explorer.services.api.DuplicationSettings;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IDefaultObjectDuplicator;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IObjectDuplicator;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IObjectDuplicatorDelegate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to duplicate objects.
+ *
+ * @author sbegaudeau
+ */
+@Service
+public class ComposedObjectDuplicator implements IObjectDuplicator {
+
+    private final IDefaultObjectDuplicator defaultObjectDuplicator;
+
+    private final List<IObjectDuplicatorDelegate> objectDuplicatorDelegates;
+
+
+    public ComposedObjectDuplicator(IDefaultObjectDuplicator defaultObjectDuplicator, List<IObjectDuplicatorDelegate> objectDuplicatorDelegates) {
+        this.defaultObjectDuplicator = Objects.requireNonNull(defaultObjectDuplicator);
+        this.objectDuplicatorDelegates = Objects.requireNonNull(objectDuplicatorDelegates);
+    }
+
+    @Override
+    public IStatus duplicateObject(IEditingContext editingContext, EObject objectToDuplicate, EObject containerEObject, String containmentFeature, DuplicationSettings settings) {
+        return this.objectDuplicatorDelegates.stream()
+                .filter(delegate -> delegate.canHandle(editingContext, objectToDuplicate, containerEObject, containmentFeature, settings))
+                .findFirst()
+                .map(delegate -> delegate.duplicateObject(editingContext, objectToDuplicate, containerEObject, containmentFeature, settings))
+                .orElseGet(() -> this.defaultObjectDuplicator.duplicateObject(editingContext, objectToDuplicate, containerEObject, containmentFeature, settings));
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/DefaultObjectDuplicator.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/DefaultObjectDuplicator.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.util.ECrossReferenceAdapter;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.edit.command.AddCommand;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.sirius.components.collaborative.api.ChangeKind;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
+import org.eclipse.sirius.components.emf.utils.SiriusEMFCopier;
+import org.eclipse.sirius.components.representations.Failure;
+import org.eclipse.sirius.components.representations.IStatus;
+import org.eclipse.sirius.components.representations.Success;
+import org.eclipse.sirius.web.application.views.explorer.services.api.DuplicationSettings;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IDefaultObjectDuplicator;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IObjectDuplicator;
+import org.eclipse.sirius.web.domain.services.api.IMessageService;
+import org.springframework.stereotype.Service;
+
+/**
+ * The default implementation if IObectDuplicator, used only if no more specific implementation applies.
+ *
+ * @author pcdavid
+ */
+@Service
+public class DefaultObjectDuplicator implements IDefaultObjectDuplicator {
+
+    private final IMessageService messageService;
+
+    public DefaultObjectDuplicator(IMessageService messageService) {
+        this.messageService = Objects.requireNonNull(messageService);
+    }
+
+    @Override
+    public IStatus duplicateObject(IEditingContext editingContext, EObject objectToDuplicate, EObject containerEObject, String containmentFeature, DuplicationSettings settings) {
+        IStatus result = new Failure(this.messageService.objectDuplicationFailed());
+        var optionalEditingDomain = Optional.of(editingContext)
+                .filter(IEMFEditingContext.class::isInstance)
+                .map(IEMFEditingContext.class::cast)
+                .map(IEMFEditingContext::getDomain);
+
+        if (optionalEditingDomain.isPresent()) {
+            Optional<EReference> optionalEReference = containerEObject.eClass().getEAllContainments().stream()
+                    .filter(reference -> containmentFeature.equals(reference.getName()))
+                    .findFirst();
+
+            Optional<Object> optionalDuplicatedObject = Optional.empty();
+
+            if (optionalEReference.isPresent()) {
+                if (this.canFeatureBeSet(containerEObject, optionalEReference.get())) {
+                    optionalDuplicatedObject = this.duplicateObject(objectToDuplicate, settings)
+                            .flatMap(eObject -> this.addOrSetEObjet(optionalEditingDomain.get(), eObject, containerEObject, optionalEReference.get()));
+                    if (optionalDuplicatedObject.isPresent()) {
+                        result = new Success(ChangeKind.SEMANTIC_CHANGE, Map.of(IObjectDuplicator.NEW_OBJECT, optionalDuplicatedObject.get()));
+                    }
+                } else {
+                    result = new Failure(this.messageService.upperBoundaryReached(objectToDuplicate.eClass().getName(), containmentFeature));
+                }
+            }
+
+            if (settings.updateIncomingReferences() && optionalDuplicatedObject.isPresent() && optionalDuplicatedObject.get() instanceof EObject duplicatedEObject) {
+                this.updateIncomingReferences(duplicatedEObject, objectToDuplicate);
+            }
+        }
+        return result;
+    }
+
+    private void updateIncomingReferences(EObject duplicatedEObject, EObject objectToDuplicate) {
+        duplicatedEObject.eAdapters().stream()
+                .filter(ECrossReferenceAdapter.class::isInstance)
+                .map(ECrossReferenceAdapter.class::cast)
+                .flatMap(eCrossReferenceAdapter -> eCrossReferenceAdapter.getInverseReferences(objectToDuplicate).stream())
+                .filter(setting -> {
+                    boolean canFeatureBeSet = false;
+                    if (setting.getEStructuralFeature() instanceof EReference eReference && eReference.isMany() && !eReference.isContainment()) {
+                        List<?> list = (List<?>) setting.getEObject().eGet(eReference);
+                        int upperBound = eReference.getUpperBound();
+                        canFeatureBeSet = upperBound == -1 || (upperBound > 0 && list.size() < upperBound);
+                    }
+                    return canFeatureBeSet;
+                })
+                .forEach(setting -> {
+                    if (setting.getEStructuralFeature() instanceof EReference eReference && eReference.isMany()) {
+                        List<EObject> list = (List<EObject>) setting.getEObject().eGet(eReference);
+                        list.add(duplicatedEObject);
+                    }
+                });
+    }
+
+    private Optional<Object> addOrSetEObjet(EditingDomain editingDomain, EObject duplicatedObject, EObject container, EReference eReference) {
+        Command command;
+        if (eReference.isMany()) {
+            command = new AddCommand(editingDomain, container, eReference, List.of(duplicatedObject));
+        } else {
+            command = new SetCommand(editingDomain, container, eReference, duplicatedObject);
+        }
+        editingDomain.getCommandStack().execute(command);
+        if (command.getResult().size() == 1) {
+            return Optional.of(command.getResult().iterator().next());
+        }
+        return Optional.empty();
+    }
+
+    private Optional<EObject> duplicateObject(EObject eObjectToDuplicate, DuplicationSettings settings) {
+        Optional<EObject> duplicateObject;
+        if (settings.duplicateContent()) {
+            EcoreUtil.Copier copier = new EcoreUtil.Copier();
+            EObject duplicatedObject = copier.copy(eObjectToDuplicate);
+            if (settings.copyOutgoingReferences()) {
+                copier.copyReferences();
+            }
+            duplicateObject = Optional.ofNullable(duplicatedObject);
+        } else {
+            SiriusEMFCopier copier = new SiriusEMFCopier();
+            EObject duplicatedObject = copier.copyWithoutContent(eObjectToDuplicate);
+            if (settings.copyOutgoingReferences()) {
+                copier.copyReferences();
+            }
+            duplicateObject = Optional.ofNullable(duplicatedObject);
+        }
+
+        return duplicateObject;
+    }
+
+    private boolean canFeatureBeSet(EObject owner, EReference eReference) {
+        boolean canFeatureBeSet;
+        if (eReference.isMany()) {
+            List<?> list = (List<?>) owner.eGet(eReference);
+            int upperBound = eReference.getUpperBound();
+            canFeatureBeSet = upperBound == -1 || (upperBound > 0 && list.size() < upperBound);
+        } else {
+            canFeatureBeSet = eReference.isUnsettable() && !owner.eIsSet(eReference) || owner.eGet(eReference) == null;
+        }
+        return canFeatureBeSet;
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/DuplicateObjectEventHandler.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/DuplicateObjectEventHandler.java
@@ -13,18 +13,12 @@
 package org.eclipse.sirius.web.application.views.explorer.services;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.eclipse.emf.common.command.Command;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EReference;
-import org.eclipse.emf.ecore.util.ECrossReferenceAdapter;
-import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.emf.edit.command.AddCommand;
-import org.eclipse.emf.edit.command.SetCommand;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.collaborative.api.IEditingContextEventHandler;
@@ -32,10 +26,8 @@ import org.eclipse.sirius.components.collaborative.api.Monitoring;
 import org.eclipse.sirius.components.core.api.ErrorPayload;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IInput;
-import org.eclipse.sirius.components.core.api.IObjectService;
+import org.eclipse.sirius.components.core.api.IObjectSearchService;
 import org.eclipse.sirius.components.core.api.IPayload;
-import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
-import org.eclipse.sirius.components.emf.utils.SiriusEMFCopier;
 import org.eclipse.sirius.components.representations.Failure;
 import org.eclipse.sirius.components.representations.IStatus;
 import org.eclipse.sirius.components.representations.Message;
@@ -43,11 +35,10 @@ import org.eclipse.sirius.components.representations.MessageLevel;
 import org.eclipse.sirius.components.representations.Success;
 import org.eclipse.sirius.web.application.views.explorer.dto.DuplicateObjectInput;
 import org.eclipse.sirius.web.application.views.explorer.dto.DuplicateObjectSuccessPayload;
+import org.eclipse.sirius.web.application.views.explorer.services.api.DuplicationSettings;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IObjectDuplicator;
 import org.eclipse.sirius.web.domain.services.api.IMessageService;
 import org.springframework.stereotype.Service;
-
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import reactor.core.publisher.Sinks.Many;
 import reactor.core.publisher.Sinks.One;
 
@@ -61,16 +52,18 @@ public class DuplicateObjectEventHandler implements IEditingContextEventHandler 
 
     private static final String NEW_OBJECT = "newObject";
 
-    private final IObjectService objectService;
+    private final IObjectSearchService objectSearchService;
+
+    private final IObjectDuplicator objectDuplicator;
 
     private final IMessageService messageService;
 
     private final Counter counter;
 
-    public DuplicateObjectEventHandler(IObjectService objectService, IMessageService messageService, MeterRegistry meterRegistry) {
-        this.objectService = Objects.requireNonNull(objectService);
+    public DuplicateObjectEventHandler(IObjectSearchService objectSearchService, IObjectDuplicator objectDuplicator, IMessageService messageService, MeterRegistry meterRegistry) {
+        this.objectSearchService = Objects.requireNonNull(objectSearchService);
+        this.objectDuplicator = Objects.requireNonNull(objectDuplicator);
         this.messageService = Objects.requireNonNull(messageService);
-
         this.counter = Counter.builder(Monitoring.EVENT_HANDLER).tag(Monitoring.NAME, this.getClass().getSimpleName()).register(meterRegistry);
     }
 
@@ -88,9 +81,9 @@ public class DuplicateObjectEventHandler implements IEditingContextEventHandler 
         IPayload payload = new ErrorPayload(input.id(), messages);
 
         if (input instanceof DuplicateObjectInput duplicateObjectInput) {
-            IStatus duplicationResult = this.duplicateObject(editingContext, duplicateObjectInput.objectId(), duplicateObjectInput.containerId(),
-                    duplicateObjectInput.containmentFeatureName(), duplicateObjectInput.duplicateContent(), duplicateObjectInput.copyOutgoingReferences(),
-                    duplicateObjectInput.updateIncomingReferences());
+            var settings = new DuplicationSettings(duplicateObjectInput.duplicateContent(), duplicateObjectInput.copyOutgoingReferences(), duplicateObjectInput.updateIncomingReferences());
+            IStatus duplicationResult = this.duplicateObject(editingContext, duplicateObjectInput.objectId(), duplicateObjectInput.containerId(), duplicateObjectInput.containmentFeatureName(),
+                    settings);
 
             if (duplicationResult instanceof Success success) {
                 payload = new DuplicateObjectSuccessPayload(input.id(), success.getParameters().get(NEW_OBJECT), success.getMessages());
@@ -104,129 +97,24 @@ public class DuplicateObjectEventHandler implements IEditingContextEventHandler 
         changeDescriptionSink.tryEmitNext(changeDescription);
     }
 
-    private IStatus duplicateObject(IEditingContext editingContext, String objectToDuplicateId, String containerId, String containmentFeature, boolean duplicateContent,
-            boolean copyOutgoingReferences, boolean updateIncomingReferences) {
-
+    private IStatus duplicateObject(IEditingContext editingContext, String objectToDuplicateId, String containerId, String containmentFeature, DuplicationSettings settings) {
         IStatus result;
-        Optional<EObject> objectToDuplicateOpt = this.objectService.getObject(editingContext, objectToDuplicateId)
+
+        Optional<EObject> optionalObjectToDuplicate = this.objectSearchService.getObject(editingContext, objectToDuplicateId)
                 .filter(EObject.class::isInstance)
                 .map(EObject.class::cast);
-        Optional<EObject> containerEObjectOpt = this.objectService.getObject(editingContext, containerId)
+        Optional<EObject> optionalContainerEObject = this.objectSearchService.getObject(editingContext, containerId)
                 .filter(EObject.class::isInstance)
                 .map(EObject.class::cast);
 
-        if (objectToDuplicateOpt.isEmpty()) {
+        if (optionalObjectToDuplicate.isEmpty()) {
             result = new Failure(this.messageService.objectDoesNotExist(objectToDuplicateId));
-        } else if (containerEObjectOpt.isEmpty()) {
+        } else if (optionalContainerEObject.isEmpty()) {
             result = new Failure(this.messageService.objectDoesNotExist(containerId));
         } else {
-            result = this.duplicateObject(editingContext, containmentFeature, duplicateContent, copyOutgoingReferences, updateIncomingReferences,
-                    containerEObjectOpt.get(), objectToDuplicateOpt.get());
+            result = this.objectDuplicator.duplicateObject(editingContext, optionalObjectToDuplicate.get(), optionalContainerEObject.get(), containmentFeature, settings);
         }
 
         return result;
-    }
-
-    private IStatus duplicateObject(IEditingContext editingContext, String containmentFeature, boolean duplicateContent, boolean copyOutgoingReferences, boolean updateIncomingReferences,
-            EObject containerEObject, EObject objectToDuplicate) {
-        IStatus result = new Failure(this.messageService.objectDuplicationFailed());
-        var optionalEditingDomain = Optional.of(editingContext)
-                .filter(IEMFEditingContext.class::isInstance)
-                .map(IEMFEditingContext.class::cast)
-                .map(IEMFEditingContext::getDomain);
-
-        if (optionalEditingDomain.isPresent()) {
-            Optional<EReference> eReferenceOpt = containerEObject.eClass().getEAllContainments().stream()
-                    .filter(reference -> containmentFeature.equals(reference.getName()))
-                    .findFirst();
-
-            Optional<Object> duplicatedObjectOptional = Optional.empty();
-
-            if (eReferenceOpt.isPresent()) {
-                if (this.canFeatureBeSet(containerEObject, eReferenceOpt.get())) {
-                    duplicatedObjectOptional = this.duplicateObject(objectToDuplicate, duplicateContent, copyOutgoingReferences)
-                            .flatMap(eObject -> this.addOrSetEObjet(optionalEditingDomain.get(), eObject, containerEObject, eReferenceOpt.get()));
-                    if (duplicatedObjectOptional.isPresent()) {
-                        result = new Success(ChangeKind.SEMANTIC_CHANGE, Map.of(NEW_OBJECT, duplicatedObjectOptional.get()));
-                    }
-                } else {
-                    result = new Failure(this.messageService.upperBoundaryReached(objectToDuplicate.eClass().getName(), containmentFeature));
-                }
-            }
-
-            if (updateIncomingReferences && duplicatedObjectOptional.isPresent() && duplicatedObjectOptional.get() instanceof EObject duplicatedEObject) {
-                this.updateIncomingReferences(duplicatedEObject, objectToDuplicate);
-            }
-        }
-        return result;
-    }
-
-    private void updateIncomingReferences(EObject duplicatedEObject, EObject objectToDuplicate) {
-        duplicatedEObject.eAdapters().stream()
-                .filter(ECrossReferenceAdapter.class::isInstance)
-                .map(ECrossReferenceAdapter.class::cast)
-                .flatMap(eCrossReferenceAdapter -> eCrossReferenceAdapter.getInverseReferences(objectToDuplicate).stream())
-                .filter(setting -> {
-                    boolean canFeatureBeSet = false;
-                    if (setting.getEStructuralFeature() instanceof EReference eReference && eReference.isMany() && !eReference.isContainment()) {
-                        List<?> list = (List<?>) setting.getEObject().eGet(eReference);
-                        int upperBound = eReference.getUpperBound();
-                        canFeatureBeSet = upperBound == -1 || (upperBound > 0 && list.size() < upperBound);
-                    }
-                    return canFeatureBeSet;
-                })
-                .forEach(setting -> {
-                    if (setting.getEStructuralFeature() instanceof EReference eReference && eReference.isMany()) {
-                        List<EObject> list = (List<EObject>) setting.getEObject().eGet(eReference);
-                        list.add(duplicatedEObject);
-                    }
-                });
-    }
-
-    private Optional<Object> addOrSetEObjet(EditingDomain editingDomain, EObject duplicatedObject, EObject container, EReference eReference) {
-        Command command;
-        if (eReference.isMany()) {
-            command = new AddCommand(editingDomain, container, eReference, List.of(duplicatedObject));
-        } else {
-            command = new SetCommand(editingDomain, container, eReference, duplicatedObject);
-        }
-        editingDomain.getCommandStack().execute(command);
-        if (command.getResult().size() == 1) {
-            return Optional.of(command.getResult().iterator().next());
-        }
-        return Optional.empty();
-    }
-
-    private Optional<EObject> duplicateObject(EObject eObjectToDuplicate, boolean duplicateContent, boolean copyOutgoingReferences) {
-        Optional<EObject> duplicateObject;
-        if (duplicateContent) {
-            EcoreUtil.Copier copier = new EcoreUtil.Copier();
-            EObject duplicatedObject = copier.copy(eObjectToDuplicate);
-            if (copyOutgoingReferences) {
-                copier.copyReferences();
-            }
-            duplicateObject = Optional.ofNullable(duplicatedObject);
-        } else {
-            SiriusEMFCopier copier = new SiriusEMFCopier();
-            EObject duplicatedObject = copier.copyWithoutContent(eObjectToDuplicate);
-            if (copyOutgoingReferences) {
-                copier.copyReferences();
-            }
-            duplicateObject = Optional.ofNullable(duplicatedObject);
-        }
-
-        return duplicateObject;
-    }
-
-    private boolean canFeatureBeSet(EObject owner, EReference eReference) {
-        boolean canFeatureBeSet;
-        if (eReference.isMany()) {
-            List<?> list = (List<?>) owner.eGet(eReference);
-            int upperBound = eReference.getUpperBound();
-            canFeatureBeSet = upperBound == -1 || (upperBound > 0 && list.size() < upperBound);
-        } else {
-            canFeatureBeSet = eReference.isUnsettable() && !owner.eIsSet(eReference) || owner.eGet(eReference) == null;
-        }
-        return canFeatureBeSet;
     }
 }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/DuplicationSettings.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/DuplicationSettings.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services.api;
+
+/**
+ * Wraps configuration settings for object duplication in a single object.
+ *
+ * @author pcdavid
+ */
+public record DuplicationSettings(boolean duplicateContent, boolean copyOutgoingReferences, boolean updateIncomingReferences) {
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IDefaultObjectDuplicator.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IDefaultObjectDuplicator.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services.api;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.representations.IStatus;
+
+/**
+ * Used to provide the default behavior for object duplication.
+ *
+ * @author pcdavid
+ */
+public interface IDefaultObjectDuplicator {
+
+    IStatus duplicateObject(IEditingContext editingContext, EObject objectToDuplicate, EObject containerEObject, String containmentFeature, DuplicationSettings settings);
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IObjectDuplicator.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IObjectDuplicator.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services.api;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.representations.IStatus;
+import org.eclipse.sirius.components.representations.Success;
+
+/**
+ * Used to duplicate objects.
+ *
+ * @author pcdavid
+ */
+public interface IObjectDuplicator {
+    /**
+     * The key to use to advertise the duplicate object created in {@link Success#getParameters()} on success.
+     */
+    String NEW_OBJECT = "newObject";
+
+    IStatus duplicateObject(IEditingContext editingContext, EObject objectToDuplicate, EObject containerEObject, String containmentFeature, DuplicationSettings settings);
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IObjectDuplicatorDelegate.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IObjectDuplicatorDelegate.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services.api;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.representations.IStatus;
+
+/**
+ * Used to provide customized behavior for object duplication.
+ *
+ * @author pcdavid
+ */
+public interface IObjectDuplicatorDelegate {
+
+    boolean canHandle(IEditingContext editingContext, EObject objectToDuplicate, EObject containerEObject, String containmentFeature, DuplicationSettings settings);
+
+    IStatus duplicateObject(IEditingContext editingContext, EObject objectToDuplicate, EObject containerEObject, String containmentFeature, DuplicationSettings settings);
+}

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/explorer/PapayaObjectDuplicatorDelegate.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/explorer/PapayaObjectDuplicatorDelegate.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.services.explorer;
+
+import java.util.Objects;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.papaya.NamedElement;
+import org.eclipse.sirius.components.representations.IStatus;
+import org.eclipse.sirius.components.representations.Success;
+import org.eclipse.sirius.web.application.views.explorer.services.DefaultObjectDuplicator;
+import org.eclipse.sirius.web.application.views.explorer.services.api.DuplicationSettings;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IObjectDuplicator;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IObjectDuplicatorDelegate;
+import org.eclipse.sirius.web.domain.services.api.IMessageService;
+import org.springframework.stereotype.Service;
+
+/**
+ * Custom object duplication logic for Papaya named elements to give a distinct name to the new copy.
+ *
+ * @author pcdavid
+ */
+@Service
+public class PapayaObjectDuplicatorDelegate implements IObjectDuplicatorDelegate {
+
+    private final IMessageService messageService;
+
+    public PapayaObjectDuplicatorDelegate(IMessageService messageService) {
+        this.messageService = Objects.requireNonNull(messageService);
+    }
+
+    @Override
+    public boolean canHandle(IEditingContext editingContext, EObject objectToDuplicate, EObject containerEObject, String containmentFeature, DuplicationSettings settings) {
+        return objectToDuplicate instanceof NamedElement;
+    }
+
+    @Override
+    public IStatus duplicateObject(IEditingContext editingContext, EObject objectToDuplicate, EObject containerEObject, String containmentFeature, DuplicationSettings settings) {
+        var defaultResut = new DefaultObjectDuplicator(this.messageService).duplicateObject(editingContext, objectToDuplicate, containerEObject, containmentFeature, settings);
+        if (defaultResut instanceof Success success) {
+            var copiedObject = success.getParameters().get(IObjectDuplicator.NEW_OBJECT);
+            if (copiedObject instanceof NamedElement namedElement) {
+                namedElement.setName(namedElement.getName() + " (copy)");
+            }
+        }
+        return defaultResut;
+    }
+
+}


### PR DESCRIPTION
See https://github.com/eclipse-sirius/sirius-web/pull/5373 for the correspondig ADR.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/5057
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?