### PR TITLE
[test] Add Cypress tests for project 'Share' action

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -133,6 +133,7 @@ This includes any resource that is not persisted, not only the libraries.
 * The _Upload new model_ dialog now contains a split button to let user import with read-write or read-only permissions.
 - https://github.com/eclipse-sirius/sirius-web/issues/5270[#5270] [diagram] Export these stateful components `AppearanceColorPicker`, `AppearanceNumberTextfield ` and `AppearanceSelect` to use in custom node appearance section
 - https://github.com/eclipse-sirius/sirius-web/issues/5063[#5063] [diagram] Modify the custom edge algorithm to create new bending points only when the source or target handle would change position (top, left, ...).
+- https://github.com/eclipse-sirius/sirius-web/issues/4886[#4886] [test] Add Cypress tests for the 'Share' action of a project, and for the resolution of a URL with search parameter `workbenchConfiguration`.
 
 
 == v2025.8.0

--- a/integration-tests/cypress/e2e/project/project.cy.ts
+++ b/integration-tests/cypress/e2e/project/project.cy.ts
@@ -14,8 +14,9 @@
 import { Project } from '../../pages/Project';
 import { Flow } from '../../usecases/Flow';
 
-const projectName = 'Cypress - Project rename';
-describe('Project - Rename', () => {
+const projectName = 'Cypress - Project Contextual Menu Actions';
+
+describe('Project - Contextual Menu Actions', () => {
   context('Given a Robot flow project', () => {
     let projectId: string = '';
     beforeEach(() => {
@@ -27,11 +28,28 @@ describe('Project - Rename', () => {
 
     afterEach(() => cy.deleteProject(projectId));
 
-    context('When we try to rename with an invalid project name', () => {
-      it('Then the rename button from the rename modal should be disabled', () => {
-        const renameDialog = new Project().getProjectNavigationBar().getRenameDialog();
-        renameDialog.clearValue();
-        renameDialog.validate(false);
+    context('Rename Action', () => {
+      context('When we try to rename with an invalid project name', () => {
+        it('Then the rename button from the rename modal should be disabled', () => {
+          const renameDialog = new Project().getProjectNavigationBar().getRenameDialog();
+          renameDialog.clearValue();
+          renameDialog.validate(false);
+        });
+      });
+    });
+
+    context('Share Action', () => {
+      context('When we use the Share action', () => {
+        it('Then the share dialog appears', () => {
+          const shareDialog = new Project().getProjectNavigationBar().getShareDialog();
+          shareDialog.getSharePathTextField().should('exist');
+          cy.url().then((url) => {
+            shareDialog
+              .getSharePathTextField()
+              .should('include.text', url)
+              .should('include.text', '?workbenchConfiguration=');
+          });
+        });
       });
     });
   });

--- a/integration-tests/cypress/e2e/project/workbench/workbench-configuration.cy.ts
+++ b/integration-tests/cypress/e2e/project/workbench/workbench-configuration.cy.ts
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { Project } from '../../../pages/Project';
+import { Flow } from '../../../usecases/Flow';
+import { Workbench } from '../../../workbench/Workbench';
+
+const projectName = 'Cypress - Workbench Configuration Resolution';
+
+describe('Workbench Configuration Resolution', () => {
+  context('Given a flow project with a robot document', () => {
+    let projectId: string = '';
+    before(() =>
+      new Flow().createRobotProject(projectName).then((createdProjectData) => {
+        projectId = createdProjectData.projectId;
+      })
+    );
+
+    after(() => cy.deleteProject(projectId));
+
+    context('When opening the project with a "null" workbench configuration', () => {
+      let workbench: Workbench;
+      beforeEach(() => {
+        new Project().visit(projectId, {
+          qs: {
+            workbenchConfiguration: nullWorkbenchConfiguration,
+          },
+        });
+        workbench = new Workbench();
+      });
+      it('Then, the left side panel is expanded, and the "Explorer" view is highlighted and active', () => {
+        workbench.checkPanelState('left', 'expanded');
+        workbench.isIconHighlighted('left', 'Explorer');
+        workbench.checkPanelContent('left', ['Explorer']);
+      });
+      it('Then, the right side panel is expanded, and the "Details" view is highlighted and active', () => {
+        workbench.checkPanelState('right', 'expanded');
+        workbench.isIconHighlighted('right', 'Details');
+        workbench.checkPanelContent('right', ['Details']);
+      });
+    });
+
+    context('When opening the project with a custom workbench configuration', () => {
+      let workbench: Workbench;
+      beforeEach(() => {
+        new Project().visit(projectId, {
+          qs: {
+            workbenchConfiguration: workbenchConfigurationWithCustomValues,
+          },
+        });
+        workbench = new Workbench();
+      });
+      it('Then, the left side panel is expanded, and the "Explorer" and "Validation" views are highlighted and active', () => {
+        workbench.checkPanelState('left', 'expanded');
+        workbench.isIconHighlighted('left', 'Explorer');
+        workbench.isIconHighlighted('left', 'Validation');
+        workbench.checkPanelContent('left', ['Explorer', 'Validation']);
+      });
+      it('Then, the right side panel is expanded, and the "Representations" and "Related Elements" views are highlighted and active', () => {
+        workbench.checkPanelState('right', 'expanded');
+        workbench.isIconHighlighted('right', 'Representations');
+        workbench.isIconHighlighted('right', 'Related Elements');
+        workbench.checkPanelContent('right', ['Representations', 'Related Elements']);
+      });
+    });
+  });
+});
+
+const nullWorkbenchConfiguration: string = JSON.stringify(null);
+const workbenchConfigurationWithCustomValues: string = JSON.stringify({
+  sidePanels: [
+    {
+      id: 'left',
+      views: [
+        { id: 'explorer', isActive: true },
+        { id: 'validation', isActive: true },
+      ],
+    },
+    {
+      id: 'right',
+      views: [
+        { id: 'details', isActive: false },
+        { id: 'query', isActive: false },
+        { id: 'representations', isActive: true },
+        { id: 'related-elements', isActive: true },
+      ],
+    },
+  ],
+});

--- a/integration-tests/cypress/pages/Project.ts
+++ b/integration-tests/cypress/pages/Project.ts
@@ -14,8 +14,9 @@
 import { RenameProjectDialog } from './RenameProject';
 
 export class Project {
-  public visit(projectId: string): Cypress.Chainable<Cypress.AUTWindow> {
+  public visit(projectId: string, options?: Partial<Cypress.VisitOptions>): Cypress.Chainable<Cypress.AUTWindow> {
     return cy.visit(`/projects/${projectId}/edit`, {
+      ...options,
       onBeforeLoad(win) {
         cy.spy(win.console, 'debug').as('consoleDebug');
       },
@@ -71,11 +72,26 @@ class ProjectNavigationBar {
     return new RenameProjectDialog();
   }
 
+  public getShareButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.getByTestId('share');
+  }
+
+  public getShareDialog(): ShareProjectDialog {
+    this.getShareButton().should('exist').click();
+    return new ShareProjectDialog();
+  }
+
   public getDeleteButton(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.getByTestId('delete');
   }
 
   public getSettingsButton(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.getByTestId('project-settings-link');
+  }
+}
+
+class ShareProjectDialog {
+  public getSharePathTextField(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.getByTestId('share-path');
   }
 }

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectMenuItem.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectMenuItem.tsx
@@ -26,7 +26,7 @@ export const ShareProjectMenuItem = ({ projectId, workbenchHandle }: ShareProjec
 
   return (
     <>
-      <MenuItem onClick={() => setState((prevState) => ({ ...prevState, isOpen: true }))}>
+      <MenuItem onClick={() => setState((prevState) => ({ ...prevState, isOpen: true }))} data-testid="share">
         <ListItemIcon>
           <ShareIcon />
         </ListItemIcon>

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectModal.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectModal.tsx
@@ -54,7 +54,7 @@ export const ShareProjectModal = ({ projectId, workbenchConfiguration, onClose }
     <Dialog open onClose={onClose} aria-labelledby="dialog-title" fullWidth>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent ref={refCallback}>
-        <DialogContentText>{path}</DialogContentText>
+        <DialogContentText data-testid="share-path">{path}</DialogContentText>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
Adds some tests as mentioned by Stéphane in [this comment](https://github.com/eclipse-sirius/sirius-web/pull/5287#issuecomment-3199590617). So far they only tests what was implemented as part of #5187.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [X] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Review

### How to test this PR?

- project.cy.ts now validates that the 'Share' action for a project provides a URL that seems OK, and copies it into the clipboard.
- workbench-configuration.cy.ts ensures that when we open a project and there is a workbenchConfiguration parameter in the URL, then it gets taken into account when setting up the views on the left/right sidebars.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?