### PR TITLE
[4886] Remove 'workbenchConfiguration' parameter from URL after loading

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -140,6 +140,9 @@ This includes any resource that is not persisted, not only the libraries.
 - https://github.com/eclipse-sirius/sirius-web/issues/5063[#5063] [diagram] Modify the custom edge algorithm to create new bending points only when the source or target handle would change position (top, left, ...).
 - https://github.com/eclipse-sirius/sirius-web/issues/4886[#4886] [test] Add Cypress tests for the 'Share' action of a project, and for the resolution of a URL with search parameter `workbenchConfiguration`.
 - https://github.com/eclipse-sirius/sirius-web/issues/5091[#5091] [sirius-web] Remove state machine from used to manage project images
+- https://github.com/eclipse-sirius/sirius-web/issues/4886[#4886] [core] Remove the `workbenchConfiguration` query parameter from the URL after loading the workbench.
+
+
 
 == v2025.8.0
 

--- a/integration-tests/cypress/e2e/project/workbench/workbench-configuration.cy.ts
+++ b/integration-tests/cypress/e2e/project/workbench/workbench-configuration.cy.ts
@@ -48,6 +48,9 @@ describe('Workbench Configuration Resolution', () => {
         workbench.isIconHighlighted('right', 'Details');
         workbench.checkPanelContent('right', ['Details']);
       });
+      it('Then, in the URL, the "workbenchConfiguration" search param is removed', () => {
+        cy.url().should('not.include', 'workbenchConfiguration=');
+      });
     });
 
     context('When opening the project with a custom workbench configuration', () => {
@@ -71,6 +74,9 @@ describe('Workbench Configuration Resolution', () => {
         workbench.isIconHighlighted('right', 'Representations');
         workbench.isIconHighlighted('right', 'Related Elements');
         workbench.checkPanelContent('right', ['Representations', 'Related Elements']);
+      });
+      it('Then, in the URL, the "workbenchConfiguration" search param is removed', () => {
+        cy.url().should('not.include', 'workbenchConfiguration=');
       });
     });
   });

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/EditProjectView.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/EditProjectView.tsx
@@ -55,12 +55,7 @@ const useEditProjectViewStyles = makeStyles()((_) => ({
 export const EditProjectView = () => {
   const { projectId: rawProjectId, representationId } = useParams<EditProjectViewParams>();
   const { classes } = useEditProjectViewStyles();
-
-  const [state, setState] = useState<EditProjectViewState>({
-    project: null,
-    representation: null,
-  });
-  const [urlSearchParams] = useSearchParams();
+  const [urlSearchParams, setSearchParams] = useSearchParams();
 
   const separatorIndex = rawProjectId.indexOf(PROJECT_ID_SEPARATOR);
   const projectId: string = separatorIndex !== -1 ? rawProjectId.substring(0, separatorIndex) : rawProjectId;
@@ -69,6 +64,19 @@ export const EditProjectView = () => {
   const workbenchConfiguration: WorkbenchConfiguration | null = urlSearchParams.has('workbenchConfiguration')
     ? JSON.parse(urlSearchParams.get('workbenchConfiguration'))
     : null;
+
+  const [state, setState] = useState<EditProjectViewState>({
+    project: null,
+    representation: null,
+    workbenchConfiguration,
+  });
+
+  useEffect(() => {
+    if (urlSearchParams.has('workbenchConfiguration')) {
+      urlSearchParams.delete('workbenchConfiguration');
+      setSearchParams(urlSearchParams);
+    }
+  }, [urlSearchParams]);
 
   const { data, loading } = useProjectAndRepresentationMetadata(projectId, name, representationId);
   useEffect(() => {
@@ -142,7 +150,7 @@ export const EditProjectView = () => {
                       initialRepresentationSelected={state.representation}
                       onRepresentationSelected={onRepresentationSelected}
                       readOnly={!state.project.capabilities.canEdit}
-                      initialWorkbenchConfiguration={workbenchConfiguration}
+                      initialWorkbenchConfiguration={state.workbenchConfiguration}
                       ref={refWorkbenchHandle}
                     />
                   </TreeToolBarProvider>

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/EditProjectView.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/EditProjectView.types.ts
@@ -11,7 +11,7 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { RepresentationMetadata } from '@eclipse-sirius/sirius-components-core';
+import { RepresentationMetadata, WorkbenchConfiguration } from '@eclipse-sirius/sirius-components-core';
 import { GQLProject } from './useProjectAndRepresentationMetadata.types';
 
 export type EditProjectViewParams = 'projectId' | 'representationId';
@@ -19,6 +19,7 @@ export type EditProjectViewParams = 'projectId' | 'representationId';
 export type EditProjectViewState = {
   project: GQLProject | null;
   representation: RepresentationMetadata | null;
+  workbenchConfiguration: WorkbenchConfiguration | null;
 };
 
 export interface TreeItemContextMenuProviderProps {


### PR DESCRIPTION
Follow-up to #5187 for (part of) #4886.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [X] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
- Hooks are properly typed:
	- [X] `useState<STATE_TYPE>(…)`
- [X] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

* Create/open a project
* Tweak which views are selected in the left/right panels, optionally select an element in the explorer (e.g. in a representation or in the `Explorer` view)
* Create a shared URL (project contextual menu > share)
* Load it in the browser => selected views (and selection) get set up, and in the URL the parameter 'workbenchConfiguration' gets removed.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?