### PR TITLE
[4886] Add opened representations to the shared URL

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -141,6 +141,7 @@ This includes any resource that is not persisted, not only the libraries.
 - https://github.com/eclipse-sirius/sirius-web/issues/4886[#4886] [test] Add Cypress tests for the 'Share' action of a project, and for the resolution of a URL with search parameter `workbenchConfiguration`.
 - https://github.com/eclipse-sirius/sirius-web/issues/5091[#5091] [sirius-web] Remove state machine from used to manage project images
 - https://github.com/eclipse-sirius/sirius-web/issues/4886[#4886] [core] Remove the `workbenchConfiguration` query parameter from the URL after loading the workbench.
+- https://github.com/eclipse-sirius/sirius-web/issues/4886[#4886] [core] Add in the shared URL for a project which representations are opened.
 
 
 

--- a/integration-tests-cypress/cypress/e2e/project/workbench/workbench-configuration.cy.ts
+++ b/integration-tests-cypress/cypress/e2e/project/workbench/workbench-configuration.cy.ts
@@ -13,16 +13,33 @@
 
 import { Project } from '../../../pages/Project';
 import { Flow } from '../../../usecases/Flow';
+import { Diagram } from '../../../workbench/Diagram';
+import { Explorer } from '../../../workbench/Explorer';
 import { Workbench } from '../../../workbench/Workbench';
+import {
+  workbenchConfigurationWithClosedPanels,
+  workbenchConfigurationWithExpandedPanels,
+} from './workbench-configuration.data';
 
 const projectName = 'Cypress - Workbench Configuration Resolution';
 
 describe('Workbench Configuration Resolution', () => {
   context('Given a flow project with a robot document', () => {
-    let projectId: string = '';
+    let projectId: string;
+    let topography1Id: string;
+    let topography2Id: string;
     before(() =>
       new Flow().createRobotProject(projectName).then((createdProjectData) => {
         projectId = createdProjectData.projectId;
+        new Project().visit(projectId);
+        const explorer: Explorer = new Explorer();
+        explorer.expandWithDoubleClick('robot');
+        explorer.createRepresentation('System', 'Topography', 'Topography1').then((createdRepresentationData) => {
+          topography1Id = createdRepresentationData.representationId;
+        });
+        explorer.createRepresentation('System', 'Topography', 'Topography2').then((createdRepresentationData) => {
+          topography2Id = createdRepresentationData.representationId;
+        });
       })
     );
 
@@ -31,44 +48,53 @@ describe('Workbench Configuration Resolution', () => {
     context('When opening the project with a "null" workbench configuration', () => {
       let workbench: Workbench;
       beforeEach(() => {
-        new Project().visit(projectId, {
+        new Project().visit(projectId, undefined, {
           qs: {
-            workbenchConfiguration: nullWorkbenchConfiguration,
+            workbenchConfiguration: JSON.stringify(null),
           },
         });
         workbench = new Workbench();
       });
+
       it('Then, the left side panel is expanded, and the "Explorer" view is highlighted and active', () => {
         workbench.checkPanelState('left', 'expanded');
         workbench.isIconHighlighted('left', 'Explorer');
         workbench.checkPanelContent('left', ['Explorer']);
       });
+
       it('Then, the right side panel is expanded, and the "Details" view is highlighted and active', () => {
         workbench.checkPanelState('right', 'expanded');
         workbench.isIconHighlighted('right', 'Details');
         workbench.checkPanelContent('right', ['Details']);
       });
+
       it('Then, in the URL, the "workbenchConfiguration" search param is removed', () => {
         cy.url().should('not.include', 'workbenchConfiguration=');
+      });
+
+      it('Then, in the main area, no representation editor is opened', () => {
+        workbench.checkRepresentationEditorTabs([]);
       });
     });
 
     context('When opening the project with a workbench configuration where the side panels are collapsed', () => {
       let workbench: Workbench;
       beforeEach(() => {
-        new Project().visit(projectId, {
+        new Project().visit(projectId, undefined, {
           qs: {
-            workbenchConfiguration: workbenchConfigurationWithClosedPanels,
+            workbenchConfiguration: JSON.stringify(workbenchConfigurationWithClosedPanels),
           },
         });
         workbench = new Workbench();
       });
+
       it('Then, the left panel is collapsed and all views ("Explorer", "Validation") are not highlighted and not active', () => {
         workbench.checkPanelState('left', 'collapsed');
         workbench.isIconHighlighted('left', 'Explorer', false);
         workbench.isIconHighlighted('left', 'Validation', false);
         cy.getByTestId('site-left').should('not.exist');
       });
+
       it('Then, the right panel is collapsed and all views ("Details", "Query", "Representations", "Related Elements") are highlighted and active', () => {
         workbench.checkPanelState('right', 'collapsed');
         workbench.isIconHighlighted('right', 'Details');
@@ -77,27 +103,34 @@ describe('Workbench Configuration Resolution', () => {
         workbench.isIconHighlighted('right', 'Related Elements');
         cy.getByTestId('site-right').should('not.exist');
       });
+
       it('Then, in the URL, the "workbenchConfiguration" search param is removed', () => {
         cy.url().should('not.include', 'workbenchConfiguration=');
+      });
+
+      it('Then, in the main area, no representation editor is opened', () => {
+        workbench.checkRepresentationEditorTabs([]);
       });
     });
 
     context('When opening the project with a workbench configuration where the side panels are expanded', () => {
       let workbench: Workbench;
       beforeEach(() => {
-        new Project().visit(projectId, {
+        new Project().visit(projectId, undefined, {
           qs: {
-            workbenchConfiguration: workbenchConfigurationWithExpandedPanels,
+            workbenchConfiguration: JSON.stringify(workbenchConfigurationWithExpandedPanels),
           },
         });
         workbench = new Workbench();
       });
+
       it('Then, the left panel is expanded and all views ("Explorer", "Validation") are highlighted and active', () => {
         workbench.checkPanelState('left', 'expanded');
         workbench.isIconHighlighted('left', 'Explorer');
         workbench.isIconHighlighted('left', 'Validation');
         workbench.checkPanelContent('left', ['Explorer', 'Validation']);
       });
+
       it('Then, the right panel is expanded and all views ("Details", "Query", "Representations", "Related Elements") are highlighted and active', () => {
         workbench.checkPanelState('right', 'expanded');
         workbench.isIconHighlighted('right', 'Details');
@@ -106,55 +139,73 @@ describe('Workbench Configuration Resolution', () => {
         workbench.isIconHighlighted('right', 'Related Elements');
         workbench.checkPanelContent('right', ['Details', 'Query', 'Representations', 'Related Elements']);
       });
+
       it('Then, in the URL, the "workbenchConfiguration" search param is removed', () => {
         cy.url().should('not.include', 'workbenchConfiguration=');
       });
+
+      it('Then, in the main area, no representation editor is opened', () => {
+        workbench.checkRepresentationEditorTabs([]);
+      });
     });
+
+    context(
+      'When opening the project with a workbench configuration where representation editors are specified',
+      () => {
+        let workbench: Workbench;
+        beforeEach(() => {
+          new Project().visit(projectId, topography2Id, {
+            qs: {
+              workbenchConfiguration: createWorkbenchConfigurationWithRepresentationEditors([
+                {
+                  representationId: topography1Id,
+                  isActive: false,
+                },
+                {
+                  representationId: topography2Id,
+                  isActive: true,
+                },
+              ]),
+            },
+          });
+          workbench = new Workbench();
+        });
+
+        it('Then, in the URL, the "workbenchConfiguration" search param is removed', () => {
+          cy.url().should('not.include', 'workbenchConfiguration=');
+        });
+
+        it('Then, in the main area, the specified representation editors are opened', () => {
+          cy.getByTestId('navbar-title').should('contain.text', projectName);
+          workbench.checkRepresentationEditorTabs([
+            {
+              representationLabel: 'Topography1',
+            },
+            {
+              representationLabel: 'Topography2',
+            },
+          ]);
+          const diagram: Diagram = new Diagram();
+          diagram.getDiagram('Topography2').should('not.exist');
+          diagram.getDiagram('Topography2').should('exist');
+        });
+      }
+    );
   });
 });
 
-const nullWorkbenchConfiguration: string = JSON.stringify(null);
-const workbenchConfigurationWithClosedPanels: string = JSON.stringify({
-  sidePanels: [
-    {
-      id: 'left',
-      isOpen: false,
-      views: [
-        { id: 'explorer', isActive: false },
-        { id: 'validation', isActive: false },
-      ],
+const createWorkbenchConfigurationWithRepresentationEditors: (
+  representationEditorConfigurations: RepresentationEditorConfiguration[]
+) => string = (representationEditorConfigurations) => {
+  return JSON.stringify({
+    mainPanel: {
+      id: 'main',
+      representationEditors: representationEditorConfigurations,
     },
-    {
-      id: 'right',
-      isOpen: false,
-      views: [
-        { id: 'details', isActive: true },
-        { id: 'query', isActive: true },
-        { id: 'representations', isActive: true },
-        { id: 'related-elements', isActive: true },
-      ],
-    },
-  ],
-});
-const workbenchConfigurationWithExpandedPanels: string = JSON.stringify({
-  sidePanels: [
-    {
-      id: 'left',
-      isOpen: true,
-      views: [
-        { id: 'explorer', isActive: true },
-        { id: 'validation', isActive: true },
-      ],
-    },
-    {
-      id: 'right',
-      isOpen: true,
-      views: [
-        { id: 'details', isActive: true },
-        { id: 'query', isActive: true },
-        { id: 'representations', isActive: true },
-        { id: 'related-elements', isActive: true },
-      ],
-    },
-  ],
-});
+  });
+};
+
+type RepresentationEditorConfiguration = {
+  representationId: string;
+  isActive: boolean;
+};

--- a/integration-tests-cypress/cypress/e2e/project/workbench/workbench-configuration.data.ts
+++ b/integration-tests-cypress/cypress/e2e/project/workbench/workbench-configuration.data.ts
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { WorkbenchConfiguration } from './workbench-configuration.data.types';
+
+export const workbenchConfigurationWithClosedPanels: WorkbenchConfiguration = {
+  mainPanel: null,
+  sidePanels: [
+    {
+      id: 'left',
+      isOpen: false,
+      views: [
+        { id: 'explorer', isActive: false },
+        { id: 'validation', isActive: false },
+      ],
+    },
+    {
+      id: 'right',
+      isOpen: false,
+      views: [
+        { id: 'details', isActive: true },
+        { id: 'query', isActive: true },
+        { id: 'representations', isActive: true },
+        { id: 'related-elements', isActive: true },
+      ],
+    },
+  ],
+};
+
+export const workbenchConfigurationWithExpandedPanels: WorkbenchConfiguration = {
+  mainPanel: null,
+  sidePanels: [
+    {
+      id: 'left',
+      isOpen: true,
+      views: [
+        { id: 'explorer', isActive: true },
+        { id: 'validation', isActive: true },
+      ],
+    },
+    {
+      id: 'right',
+      isOpen: true,
+      views: [
+        { id: 'details', isActive: true },
+        { id: 'query', isActive: true },
+        { id: 'representations', isActive: true },
+        { id: 'related-elements', isActive: true },
+      ],
+    },
+  ],
+};

--- a/integration-tests-cypress/cypress/e2e/project/workbench/workbench-configuration.data.types.ts
+++ b/integration-tests-cypress/cypress/e2e/project/workbench/workbench-configuration.data.types.ts
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+export interface WorkbenchConfiguration {
+  mainPanel: WorkbenchMainPanelConfiguration | null;
+  sidePanels: WorkbenchSidePanelConfiguration[];
+}
+
+export interface WorkbenchSidePanelConfiguration {
+  id: string;
+  isOpen: boolean;
+  views: WorkbenchViewConfiguration[];
+}
+
+export interface WorkbenchViewConfiguration {
+  id: string;
+  isActive: boolean;
+}
+
+export interface WorkbenchMainPanelConfiguration {
+  id: string;
+  representationEditors: WorkbenchRepresentationEditorConfiguration[];
+}
+
+export interface WorkbenchRepresentationEditorConfiguration {
+  representationId: string;
+  isActive: boolean;
+}

--- a/integration-tests-cypress/cypress/pages/Project.ts
+++ b/integration-tests-cypress/cypress/pages/Project.ts
@@ -14,8 +14,12 @@
 import { RenameProjectDialog } from './RenameProject';
 
 export class Project {
-  public visit(projectId: string, options?: Partial<Cypress.VisitOptions>): Cypress.Chainable<Cypress.AUTWindow> {
-    return cy.visit(`/projects/${projectId}/edit`, {
+  public visit(
+    projectId: string,
+    representationId?: string,
+    options?: Partial<Cypress.VisitOptions>
+  ): Cypress.Chainable<Cypress.AUTWindow> {
+    return cy.visit(`/projects/${projectId}/edit${representationId ? '/' + representationId : ''}`, {
       ...options,
       onBeforeLoad(win) {
         cy.spy(win.console, 'debug').as('consoleDebug');

--- a/integration-tests-cypress/cypress/workbench/Explorer.ts
+++ b/integration-tests-cypress/cypress/workbench/Explorer.ts
@@ -10,6 +10,9 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
+export interface CreatedRepresentationData {
+  representationId: string;
+}
 
 export class Explorer {
   public getExplorerView(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -89,7 +92,7 @@ export class Explorer {
     treeItemLabel: string,
     representationDescriptionName: string,
     representationLabel: string
-  ): void {
+  ): Cypress.Chainable<CreatedRepresentationData> {
     this.openTreeItemAction(treeItemLabel).getNewRepresentationButton().click();
 
     cy.get('[aria-labelledby="dialog-title"]').then((modal) => {
@@ -104,6 +107,18 @@ export class Explorer {
     // Wait for the modal to be closed and the representation actually opened
     cy.get('[aria-labelledby="dialog-title"]').should('not.exist');
     cy.getByTestId(`representation-tab-${representationLabel}`).should('be.visible');
+
+    return cy
+      .getByTestId(`representation-tab-${representationLabel}`)
+      .should('exist')
+      .invoke('attr', 'data-representationid')
+      .then((representationId) => {
+        if (representationId) {
+          return cy.wrap({ representationId });
+        } else {
+          throw new Error(`Cannot find opened representation tab with label "${representationLabel}"`);
+        }
+      });
   }
 
   public rename(treeItemLabel: string, newName: string): void {

--- a/integration-tests-cypress/cypress/workbench/Workbench.ts
+++ b/integration-tests-cypress/cypress/workbench/Workbench.ts
@@ -13,6 +13,9 @@
 
 type WorkbenchSide = 'left' | 'right';
 type PanelState = 'expanded' | 'collapsed';
+type RepresentationEditor = {
+  representationLabel: string;
+};
 
 export class Workbench {
   public openRepresentation(representationLabel: string): void {
@@ -74,6 +77,18 @@ export class Workbench {
       });
     } else {
       cy.get(`#${side}`).should('have.attr', 'data-panel-size', '0.0');
+    }
+  }
+
+  public checkRepresentationEditorTabs(expectedRepresentationEditors: RepresentationEditor[]) {
+    if (expectedRepresentationEditors.length == 0) {
+      cy.getByTestId(`onboard-area`).should('exist');
+    } else {
+      cy.getByTestId(`onboard-area`).should('not.exist');
+
+      expectedRepresentationEditors.forEach((expectedRepresentationEditor) => {
+        cy.getByTestId(`representation-tab-${expectedRepresentationEditor.representationLabel}`).should('exist');
+      });
     }
   }
 }

--- a/packages/core/frontend/sirius-components-core/src/representationmetadata/useRepresentationMetadata.types.ts
+++ b/packages/core/frontend/sirius-components-core/src/representationmetadata/useRepresentationMetadata.types.ts
@@ -13,6 +13,7 @@
 
 export interface UseRepresentationMetadataValue {
   data: GQLRepresentationMetadataQueryData | null;
+  getRepresentationMetadata: (editingContextId: string, representationIds: string[]) => void;
 }
 
 export interface GQLRepresentationMetadataQueryData {

--- a/packages/core/frontend/sirius-components-core/src/workbench/RepresentationNavigation.tsx
+++ b/packages/core/frontend/sirius-components-core/src/workbench/RepresentationNavigation.tsx
@@ -13,11 +13,11 @@
 import CloseIcon from '@mui/icons-material/Close';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
-
+import { ForwardedRef, forwardRef, useImperativeHandle } from 'react';
 import { makeStyles } from 'tss-react/mui';
 import { IconOverlay } from '../icon/IconOverlay';
 import { RepresentationNavigationProps } from './RepresentationNavigation.types';
-import { RepresentationMetadata } from './Workbench.types';
+import { RepresentationMetadata, RepresentationNavigationHandle } from './Workbench.types';
 
 const useRepresentationNavigationStyles = makeStyles()((theme) => ({
   tabsRoot: {
@@ -56,73 +56,94 @@ const a11yProps = (id: string) => {
   };
 };
 
-export const RepresentationNavigation = ({
-  representations,
-  displayedRepresentation,
-  onRepresentationClick,
-  onClose,
-}: RepresentationNavigationProps) => {
-  const { classes } = useRepresentationNavigationStyles();
+export const RepresentationNavigation = forwardRef<
+  RepresentationNavigationHandle | null,
+  RepresentationNavigationProps
+>(
+  (
+    { representations, displayedRepresentation, onRepresentationClick, onClose }: RepresentationNavigationProps,
+    refRepresentationNavigationHandle: ForwardedRef<RepresentationNavigationHandle | null>
+  ) => {
+    const { classes } = useRepresentationNavigationStyles();
 
-  const onChange = (_event: React.ChangeEvent<{}>, value: string) => {
-    const representationSelected = representations.find((representation) => representation.id === value);
-    if (representationSelected) {
-      const { id, label, kind, iconURLs, description } = representationSelected;
+    const onChange = (_event: React.ChangeEvent<{}>, value: string) => {
+      const representationSelected = representations.find((representation) => representation.id === value);
+      if (representationSelected) {
+        const { id, label, kind, iconURLs, description } = representationSelected;
 
-      const representation: RepresentationMetadata = {
-        id,
-        label,
-        kind,
-        iconURLs,
-        description,
-      };
-      onRepresentationClick(representation);
-    }
-  };
+        const representation: RepresentationMetadata = {
+          id,
+          label,
+          kind,
+          iconURLs,
+          description,
+        };
+        onRepresentationClick(representation);
+      }
+    };
 
-  const onRepresentationClose = (event: React.MouseEvent<SVGSVGElement>, representation: RepresentationMetadata) => {
-    event.stopPropagation();
-    onClose(representation);
-  };
+    const onRepresentationClose = (event: React.MouseEvent<SVGSVGElement>, representation: RepresentationMetadata) => {
+      event.stopPropagation();
+      onClose(representation);
+    };
 
-  return (
-    <Tabs
-      classes={{ root: classes.tabsRoot }}
-      value={displayedRepresentation.id}
-      onChange={onChange}
-      variant="scrollable"
-      scrollButtons
-      textColor="primary"
-      indicatorColor="primary">
-      {representations.map((representation) => {
-        return (
-          <Tab
-            {...a11yProps(representation.id)}
-            classes={{ root: classes.tabRoot }}
-            value={representation.id}
-            label={
-              <div className={classes.tabLabel}>
-                {representation.iconURLs && (
-                  <div className={classes.tabRepresentationIcon}>
-                    <IconOverlay iconURL={representation.iconURLs} alt="representation icon" />
-                  </div>
-                )}
-                <div className={classes.tabLabelText}>{representation.label}</div>
-                <CloseIcon
-                  className={classes.tabCloseIcon}
-                  fontSize="small"
-                  onClick={(event) => onRepresentationClose(event, representation)}
-                  data-testid={`close-representation-tab-${representation.label}`}
-                />
-              </div>
-            }
-            key={representation.id}
-            data-testid={`representation-tab-${representation.label}`}
-            data-testselected={representation.id === displayedRepresentation.id}
-            data-representationid={representation.id}
-          />
-        );
-      })}
-    </Tabs>
-  );
-};
+    useImperativeHandle(
+      refRepresentationNavigationHandle,
+      () => {
+        return {
+          getMainPanelConfiguration: () => {
+            return {
+              id: 'main',
+              representationEditors: representations.map((representation) => ({
+                representationId: representation.id,
+                isActive: representation.id === displayedRepresentation.id,
+              })),
+            };
+          },
+        };
+      },
+      [representations, displayedRepresentation]
+    );
+
+    return (
+      <Tabs
+        classes={{ root: classes.tabsRoot }}
+        value={displayedRepresentation.id}
+        onChange={onChange}
+        variant="scrollable"
+        scrollButtons
+        textColor="primary"
+        indicatorColor="primary">
+        {representations.map((representation) => {
+          return (
+            <Tab
+              {...a11yProps(representation.id)}
+              classes={{ root: classes.tabRoot }}
+              value={representation.id}
+              label={
+                <div className={classes.tabLabel}>
+                  {representation.iconURLs && (
+                    <div className={classes.tabRepresentationIcon}>
+                      <IconOverlay iconURL={representation.iconURLs} alt="representation icon" />
+                    </div>
+                  )}
+                  <div className={classes.tabLabelText}>{representation.label}</div>
+                  <CloseIcon
+                    className={classes.tabCloseIcon}
+                    fontSize="small"
+                    onClick={(event) => onRepresentationClose(event, representation)}
+                    data-testid={`close-representation-tab-${representation.label}`}
+                  />
+                </div>
+              }
+              key={representation.id}
+              data-testid={`representation-tab-${representation.label}`}
+              data-testselected={representation.id === displayedRepresentation.id}
+              data-representationid={representation.id}
+            />
+          );
+        })}
+      </Tabs>
+    );
+  }
+);

--- a/packages/core/frontend/sirius-components-core/src/workbench/Workbench.types.ts
+++ b/packages/core/frontend/sirius-components-core/src/workbench/Workbench.types.ts
@@ -78,8 +78,13 @@ export interface PanelsHandle {
   getSidePanelConfigurations: () => WorkbenchSidePanelConfiguration[];
 }
 
+export interface RepresentationNavigationHandle {
+  getMainPanelConfiguration: () => WorkbenchMainPanelConfiguration | null;
+}
+
 export interface WorkbenchConfiguration {
   sidePanels: WorkbenchSidePanelConfiguration[];
+  mainPanel: WorkbenchMainPanelConfiguration | null;
 }
 
 export interface WorkbenchSidePanelConfiguration {
@@ -90,5 +95,15 @@ export interface WorkbenchSidePanelConfiguration {
 
 export interface WorkbenchViewConfiguration {
   id: string;
+  isActive: boolean;
+}
+
+export interface WorkbenchMainPanelConfiguration {
+  id: string;
+  representationEditors: WorkbenchRepresentationEditorConfiguration[];
+}
+
+export interface WorkbenchRepresentationEditorConfiguration {
+  representationId: string;
   isActive: boolean;
 }

--- a/packages/core/frontend/sirius-components-core/src/workbench/useSynchronizeRepresentationWithSelection.tsx
+++ b/packages/core/frontend/sirius-components-core/src/workbench/useSynchronizeRepresentationWithSelection.tsx
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { useEffect } from 'react';
+import { useRepresentationMetadata } from '../representationmetadata/useRepresentationMetadata';
+import { GQLRepresentationMetadata } from '../representationmetadata/useRepresentationMetadata.types';
+import { useSelection } from '../selection/useSelection';
+import { UseSynchronizeRepresentationWithSelectionValue } from './useSynchronizeRepresentationWithSelection.types';
+
+export const useSynchronizeRepresentationWithSelection = (
+  editingContextId: string
+): UseSynchronizeRepresentationWithSelectionValue => {
+  const { selection } = useSelection();
+  const { getRepresentationMetadata, data } = useRepresentationMetadata();
+
+  useEffect(() => {
+    getRepresentationMetadata(
+      editingContextId,
+      selection.entries.map((entry) => entry.id)
+    );
+  }, [editingContextId, selection]);
+
+  const representationMetadata: GQLRepresentationMetadata[] | null =
+    data?.viewer.editingContext.representations.edges.map((edge) => edge.node) ?? null;
+
+  return { representationMetadata };
+};

--- a/packages/core/frontend/sirius-components-core/src/workbench/useSynchronizeRepresentationWithSelection.types.ts
+++ b/packages/core/frontend/sirius-components-core/src/workbench/useSynchronizeRepresentationWithSelection.types.ts
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { GQLRepresentationMetadata } from '../representationmetadata/useRepresentationMetadata.types';
+
+export interface UseSynchronizeRepresentationWithSelectionValue {
+  representationMetadata: GQLRepresentationMetadata[] | null;
+}

--- a/packages/core/frontend/sirius-components-core/src/workbench/useSynchronizeRepresentationWithWorkbenchConfiguration.tsx
+++ b/packages/core/frontend/sirius-components-core/src/workbench/useSynchronizeRepresentationWithWorkbenchConfiguration.tsx
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { useEffect, useState } from 'react';
+import { useRepresentationMetadata } from '../representationmetadata/useRepresentationMetadata';
+import { GQLRepresentationMetadata } from '../representationmetadata/useRepresentationMetadata.types';
+import { UseSynchronizeRepresentationWithWorkbenchConfigurationValue } from './useSynchronizeRepresentationWithWorkbenchConfiguration.types';
+import { WorkbenchConfiguration } from './Workbench.types';
+
+export const useSynchronizeRepresentationWithWorkbenchConfiguration = (
+  editingContextId: string,
+  initialWorkbenchConfiguration: WorkbenchConfiguration | null
+): UseSynchronizeRepresentationWithWorkbenchConfigurationValue => {
+  const [representationIds] = useState<string[] | null>(
+    initialWorkbenchConfiguration?.mainPanel?.representationEditors.map((editor) => editor.representationId) ?? null
+  );
+
+  const { getRepresentationMetadata, data } = useRepresentationMetadata();
+
+  useEffect(() => {
+    if (representationIds) {
+      getRepresentationMetadata(editingContextId, representationIds);
+    }
+  }, [representationIds]);
+
+  const representationMetadata: GQLRepresentationMetadata[] | null =
+    data?.viewer.editingContext.representations.edges.map((edge) => edge.node) ?? null;
+
+  return { representationMetadata };
+};

--- a/packages/core/frontend/sirius-components-core/src/workbench/useSynchronizeRepresentationWithWorkbenchConfiguration.types.ts
+++ b/packages/core/frontend/sirius-components-core/src/workbench/useSynchronizeRepresentationWithWorkbenchConfiguration.types.ts
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { GQLRepresentationMetadata } from '../representationmetadata/useRepresentationMetadata.types';
+
+export interface UseSynchronizeRepresentationWithWorkbenchConfigurationValue {
+  representationMetadata: GQLRepresentationMetadata[] | null;
+}

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectModal.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectModal.tsx
@@ -39,10 +39,20 @@ export const ShareProjectModal = ({ projectId, workbenchConfiguration, onClose }
     selection: selectionToSearchParamsValue(selection),
   });
 
-  const path =
-    generatePath(':origin/projects/:projectId/edit', { origin: window.location.origin, projectId: projectId }) +
-    '?' +
-    searchParams.toString();
+  const representationId: string | null =
+    workbenchConfiguration.mainPanel?.representationEditors.find((configuration) => configuration.isActive)
+      ?.representationId ?? null;
+
+  let path: string;
+  const origin = window.location.origin;
+  if (representationId) {
+    path =
+      generatePath(':origin/projects/:projectId/edit/:representationId', { origin, projectId, representationId }) +
+      '?' +
+      searchParams.toString();
+  } else {
+    path = generatePath(':origin/projects/:projectId/edit', { origin, projectId }) + '?' + searchParams.toString();
+  }
 
   let title = 'Shareable link';
   if (navigator.clipboard && document.hasFocus()) {


### PR DESCRIPTION
Follow-up to #5287 for (part of) #4886.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [X] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing

- [X] Variables have a proper type
- [X] Functions’ arguments have a proper type
- [X] Functions’ return type are specified
- Hooks are properly typed:
	- [X] `useState<STATE_TYPE>(…)`
- [X] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Review

### How to test this PR?

- Create a project with at least 2 representations, open it.
- Open both representations, noting which was the active one (visible in the main area).
- From the project contextual menu, create a shared URL.
- Load that URL => both representations are opened (main area has a tab for each, in the same order as the original) and the active representation is displayed.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?