### PR TITLE
[5457] Fix a rendering issue where the tree filter menu could be partially obscured when a table is opened

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -104,6 +104,9 @@ The code in question now use `com.github.ben-manes.caffeine` instead, the altern
 - https://github.com/eclipse-sirius/sirius-web/issues/5160[#5160] [diagram] Revert the fix 5160 related to the lifecycle of the diagram because of instability issues
 - https://github.com/eclipse-sirius/sirius-web/issues/3029[#3029] [diagram] Fix drop position to match node feedback instead of cursor position
 - https://github.com/eclipse-sirius/sirius-web/issues/5516[#5516] [diagram] Fix an issue where a node style was not updated after canceling a connection
+- https://github.com/eclipse-sirius/sirius-web/issues/5457[#5457] [explorer, diagram] Fix a rendering issue where some menus could be partially obscured.
+This occured for the tree filter menu in the Explorer when a table was opened, and with the diagram filters menu which could be obscured by the right-side panel.
+
 
 === New Features
 

--- a/packages/sirius-web/frontend/sirius-web-application/src/diagrams/DiagramFilter.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/diagrams/DiagramFilter.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,10 +11,7 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import ClickAwayListener from '@mui/material/ClickAwayListener';
 import IconButton from '@mui/material/IconButton';
-import Paper from '@mui/material/Paper';
-import Popper from '@mui/material/Popper';
 import Tooltip from '@mui/material/Tooltip';
 
 import {
@@ -23,6 +20,7 @@ import {
   DiagramPanelActionProps,
 } from '@eclipse-sirius/sirius-components-diagrams';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import Menu from '@mui/material/Menu';
 import { useContext, useRef, useState } from 'react';
 import { DiagramFilterForm } from './DiagramFilterForm';
 
@@ -48,20 +46,9 @@ export const DiagramFilter = ({ editingContextId, diagramId }: DiagramPanelActio
           </IconButton>
         </span>
       </Tooltip>
-      <Popper
-        open={isOpen}
-        anchorEl={anchorRef.current}
-        placement="bottom-start"
-        disablePortal
-        style={{ zIndex: '9999' }}>
-        <Paper style={{ maxHeight: '50vh', overflow: 'auto' }}>
-          <ClickAwayListener onClickAway={() => setIsOpen(false)}>
-            <div>
-              <DiagramFilterForm editingContextId={editingContextId} diagramId={diagramId} readOnly={false} />
-            </div>
-          </ClickAwayListener>
-        </Paper>
-      </Popper>
+      <Menu anchorEl={anchorRef.current} open={isOpen} onClose={() => setIsOpen(false)}>
+        <DiagramFilterForm editingContextId={editingContextId} diagramId={diagramId} readOnly={false} />
+      </Menu>
     </>
   );
 };

--- a/packages/trees/frontend/sirius-components-trees/src/views/TreeFiltersMenu.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/views/TreeFiltersMenu.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,16 +13,13 @@
 
 import FilterListIcon from '@mui/icons-material/FilterList';
 import Checkbox from '@mui/material/Checkbox';
-import ClickAwayListener from '@mui/material/ClickAwayListener';
-import Fade from '@mui/material/Fade';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
 import IconButton from '@mui/material/IconButton';
-import Paper from '@mui/material/Paper';
-import Popper from '@mui/material/Popper';
+import Menu from '@mui/material/Menu';
 import { useEffect, useRef, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
-import { TreeFilterMenuProps, TreeFilter } from './TreeFiltersMenu.types';
+import { TreeFilter, TreeFilterMenuProps } from './TreeFiltersMenu.types';
 
 const useTreeFiltersMenuStyles = makeStyles()((_) => ({
   root: {
@@ -74,39 +71,25 @@ export const TreeFiltersMenu = ({ filters, onTreeFilterMenuItemClick }: TreeFilt
         onClick={handleToggle}>
         <FilterListIcon color={open ? 'disabled' : 'inherit'} />
       </IconButton>
-      <Popper
-        data-testid={`tree-filter-menu`}
-        open={open}
-        anchorEl={anchorRef.current}
-        role={undefined}
-        placement={'bottom-start'}
-        transition>
-        {({ TransitionProps }) => (
-          <Fade {...TransitionProps} timeout={350}>
-            <Paper>
-              <ClickAwayListener onClickAway={handleClose}>
-                <FormGroup>
-                  {filters.map((filter) => (
-                    <FormControlLabel
-                      key={filter.id}
-                      className={classes.treeFilter}
-                      control={
-                        <Checkbox
-                          data-testid={`tree-filter-menu-checkbox-${filter.label}`}
-                          checked={filter.state}
-                          onChange={(event) => updateTreeFilters(filter, event.target.checked)}
-                          name={filter.label}
-                        />
-                      }
-                      label={filter.label}
-                    />
-                  ))}
-                </FormGroup>
-              </ClickAwayListener>
-            </Paper>
-          </Fade>
-        )}
-      </Popper>
+      <Menu data-testid="tree-filter-menu" anchorEl={anchorRef.current} open={open} onClose={handleClose}>
+        <FormGroup>
+          {filters.map((filter) => (
+            <FormControlLabel
+              key={filter.id}
+              className={classes.treeFilter}
+              control={
+                <Checkbox
+                  data-testid={`tree-filter-menu-checkbox-${filter.label}`}
+                  checked={filter.state}
+                  onChange={(event) => updateTreeFilters(filter, event.target.checked)}
+                  name={filter.label}
+                />
+              }
+              label={filter.label}
+            />
+          ))}
+        </FormGroup>
+      </Menu>
     </div>
   );
 };


### PR DESCRIPTION

<img width="499" height="345" alt="image" src="https://github.com/user-attachments/assets/0408b6e3-0805-42fb-84bd-3eab56218830" />

Bug: https://github.com/eclipse-sirius/sirius-web/issues/5457
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?