### PR TITLE
[5222] Fix URL provided by 'Share Project' and 'Share Representation'

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -110,6 +110,8 @@ This occured for the tree filter menu in the Explorer when a table was opened, a
 - https://github.com/eclipse-sirius/sirius-web/issues/5540[#5540] [diagram] Preserve label positions when importing a diagram
 - https://github.com/eclipse-sirius/sirius-web/issues/5547[#5547] [diagram] Fix an issue where the internal handle of a node could be out of sync with the displayed handle after moving an edge segment.
 - https://github.com/eclipse-sirius/sirius-web/issues/5535[#5535] [diagram] Prevent node style to be faded after drag and drop
+- https://github.com/eclipse-sirius/sirius-web/issues/5222[#5222] [sirius-web] Fix the 'Share Project' and 'Share Representation' actions to always provide the right URL
+
 
 === New Features
 

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/EditProjectView.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/EditProjectView.tsx
@@ -121,7 +121,7 @@ export const EditProjectView = () => {
 
   const getRepresentationPath = (representationId: string) => {
     // Note that this should match the corresponding route configuration
-    return `/projects/${projectId}/edit/${representationId}`;
+    return `/projects/${rawProjectId}/edit/${representationId}`;
   };
 
   const isMissing = !loading && (!data || !data.viewer.project || !data.viewer.project.currentEditingContext);

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/EditProjectNavbarContextMenu.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/EditProjectNavbarContextMenu.tsx
@@ -60,7 +60,7 @@ export const EditProjectNavbarContextMenu = ({
         {project.capabilities.canRename ? (
           <RenameProjectMenuItem project={project} onCancel={onClose} onSuccess={onClose} />
         ) : null}
-        <ShareProjectMenuItem projectId={project.id} workbenchHandle={workbenchHandle} />
+        <ShareProjectMenuItem workbenchHandle={workbenchHandle} />
         {project.capabilities.canDuplicate ? (
           <DuplicateProjectMenuItem projectId={project.id} onClick={onClose} />
         ) : null}

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectMenuItem.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectMenuItem.tsx
@@ -19,7 +19,7 @@ import { useState } from 'react';
 import { ShareProjectMenuItemProps, ShareProjectMenuItemState } from './ShareProjectMenuItem.types';
 import { ShareProjectModal } from './ShareProjectModal';
 
-export const ShareProjectMenuItem = ({ projectId, workbenchHandle }: ShareProjectMenuItemProps) => {
+export const ShareProjectMenuItem = ({ workbenchHandle }: ShareProjectMenuItemProps) => {
   const [state, setState] = useState<ShareProjectMenuItemState>({
     isOpen: false,
   });
@@ -34,7 +34,6 @@ export const ShareProjectMenuItem = ({ projectId, workbenchHandle }: ShareProjec
       </MenuItem>
       {state.isOpen ? (
         <ShareProjectModal
-          projectId={projectId}
           workbenchConfiguration={workbenchHandle.getConfiguration()}
           onClose={() => setState((prevState) => ({ ...prevState, isOpen: false }))}
         />

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectMenuItem.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectMenuItem.types.ts
@@ -14,7 +14,6 @@
 import { WorkbenchHandle } from '@eclipse-sirius/sirius-components-core';
 
 export interface ShareProjectMenuItemProps {
-  projectId: string;
   workbenchHandle: WorkbenchHandle;
 }
 

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectModal.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectModal.tsx
@@ -16,11 +16,14 @@ import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import { generatePath } from 'react-router-dom';
+import { generatePath, useParams } from 'react-router-dom';
+import { EditProjectViewParams } from '../../EditProjectView.types';
 import { selectionToSearchParamsValue } from '../../SelectionSynchronizer';
 import { ShareProjectModalProps } from './ShareProjectModal.types';
 
-export const ShareProjectModal = ({ projectId, workbenchConfiguration, onClose }: ShareProjectModalProps) => {
+export const ShareProjectModal = ({ workbenchConfiguration, onClose }: ShareProjectModalProps) => {
+  const { projectId: rawProjectId } = useParams<EditProjectViewParams>();
+
   const refCallback = (node: HTMLElement) => {
     if (node !== null) {
       var range = document.createRange();
@@ -47,11 +50,18 @@ export const ShareProjectModal = ({ projectId, workbenchConfiguration, onClose }
   const origin = window.location.origin;
   if (representationId) {
     path =
-      generatePath(':origin/projects/:projectId/edit/:representationId', { origin, projectId, representationId }) +
+      generatePath(':origin/projects/:projectId/edit/:representationId', {
+        origin,
+        projectId: rawProjectId,
+        representationId,
+      }) +
       '?' +
       searchParams.toString();
   } else {
-    path = generatePath(':origin/projects/:projectId/edit', { origin, projectId }) + '?' + searchParams.toString();
+    path =
+      generatePath(':origin/projects/:projectId/edit', { origin, projectId: rawProjectId }) +
+      '?' +
+      searchParams.toString();
   }
 
   let title = 'Shareable link';

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectModal.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/ShareProjectModal.types.ts
@@ -14,7 +14,6 @@
 import { WorkbenchConfiguration } from '@eclipse-sirius/sirius-components-core';
 
 export interface ShareProjectModalProps {
-  projectId: string;
   workbenchConfiguration: WorkbenchConfiguration;
   onClose: () => void;
 }


### PR DESCRIPTION
Fixes #5222 by computing shared URL with the `rawProjectId` from the URL instead of the actual `projectId`.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [X] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Review

### How to test this PR?

* Run the Sirius Web Application and create a project with a diagram (e.g. Flow) and open it.
* The URL in the navigation bar should look like `/projects/:projectId/edit/:representationId`.
* Action 'Share Representation' from the diagram toolbar provides a URL of the form `/projects/:projectId/edit/:representationId?...`.
* Action 'Share' from the project contextual menu provides a URL of the form `/projects/:projectId/edit/:representationId?...`
* Now edit the URL in the navigation bar to add the SemanticData name 'main': `/projects/:projectId@main/edit/:representationId`.
* Action 'Share Representation' from the diagram toolbar provides a URL of the form `/projects/:projectId@main/edit/:representationId?...`.
* Action 'Share' from the project contextual menu provides a URL of the form `/projects/:projectId@main/edit/:representationId?...`

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?