### PR TITLE
[5535] Prevent node style from remaining faded after drag-and-drop

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -109,7 +109,7 @@ This occured for the tree filter menu in the Explorer when a table was opened, a
 - https://github.com/eclipse-sirius/sirius-web/issues/5519[#5519] [diagram] Fix an issue where ending a connection on a creation handle could make it impossible to start a new connection
 - https://github.com/eclipse-sirius/sirius-web/issues/5540[#5540] [diagram] Preserve label positions when importing a diagram
 - https://github.com/eclipse-sirius/sirius-web/issues/5547[#5547] [diagram] Fix an issue where the internal handle of a node could be out of sync with the displayed handle after moving an edge segment.
-
+- https://github.com/eclipse-sirius/sirius-web/issues/5535[#5535] [diagram] Prevent node style to be faded after drag and drop
 
 === New Features
 

--- a/integration-tests-playwright/playwright/e2e/dnd.spec.ts
+++ b/integration-tests-playwright/playwright/e2e/dnd.spec.ts
@@ -91,4 +91,38 @@ test.describe('diagram - drag and drop', () => {
     expect(reactFlowXYPositionAfter.x).not.toBe(reactFlowXYPositionBefore.x);
     expect(requestTriggered).toBe(false);
   });
+
+  test('when dragging a node, then not compatible node style changed', async ({ page }) => {
+    const entity1Locator = page.locator('[data-testid="FreeForm - Entity1"]');
+
+    const opacityBefore = await entity1Locator.evaluate((node) => {
+      return window.getComputedStyle(node).getPropertyValue('opacity');
+    });
+    expect(opacityBefore).toBe('1');
+
+    const entity2PlaywrightNode = new PlaywrightNode(page, 'Entity2-outside');
+    const xyPosition = await entity2PlaywrightNode.getDOMXYPosition();
+
+    await entity2PlaywrightNode.nodeLocator.hover({ position: { x: 10, y: 10 } });
+    await page.mouse.down();
+    await page.mouse.move(xyPosition.x + 25, xyPosition.y + 25, { steps: 10 });
+
+    await page.waitForFunction(
+      () => {
+        const node = document.querySelector(`[data-testid="FreeForm - Entity1"]`);
+        return node && window.getComputedStyle(node).getPropertyValue('opacity') === '0.4';
+      },
+      { timeout: 2000 }
+    );
+
+    await page.mouse.up();
+
+    await page.waitForFunction(
+      () => {
+        const node = document.querySelector(`[data-testid="FreeForm - Entity1"]`);
+        return node && window.getComputedStyle(node).getPropertyValue('opacity') === '1';
+      },
+      { timeout: 2000 }
+    );
+  });
 });

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/dropNode/useDropNode.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/dropNode/useDropNode.ts
@@ -315,8 +315,6 @@ export const useDropNode = (): UseDropNodeValue => {
           cancelDrop(draggedNode);
         }
 
-        resetDrop();
-
         setNodes((previousNodes) =>
           previousNodes.map((previousNode) => {
             if (previousNode.data.isDropNodeCandidate || previousNode.data.isDropNodeTarget) {
@@ -339,6 +337,7 @@ export const useDropNode = (): UseDropNodeValue => {
           })
         );
       }
+      resetDrop();
     },
     [droppableOnDiagram, initialPosition, getNodes]
   );


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/5535

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?