### PR TITLE
[4171] Make sure the close button is always visible in representation tabs

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -119,6 +119,7 @@ This occured for the tree filter menu in the Explorer when a table was opened, a
 - https://github.com/eclipse-sirius/sirius-web/issues/5581[#5581] [diagram] Prevent node header to overlap its children
 - https://github.com/eclipse-sirius/sirius-web/issues/5590[#5590] [diagram] Fix filter modal menu not rendering correctly
 - https://github.com/eclipse-sirius/sirius-web/issues/5593[#5593] [diagram] Restore position dependant rotation for `imageNodeStyle`
+- https://github.com/eclipse-sirius/sirius-web/issues/4171[#4171] [sirius-web] Fix the display of tabs for representations with very long names, which could hide the "close tab" button (and the icon)
 
 === New Features
 

--- a/packages/core/frontend/sirius-components-core/src/workbench/RepresentationNavigation.tsx
+++ b/packages/core/frontend/sirius-components-core/src/workbench/RepresentationNavigation.tsx
@@ -13,6 +13,7 @@
 import CloseIcon from '@mui/icons-material/Close';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
+import Tooltip from '@mui/material/Tooltip';
 import { ForwardedRef, forwardRef, useImperativeHandle } from 'react';
 import { makeStyles } from 'tss-react/mui';
 import { IconOverlay } from '../icon/IconOverlay';
@@ -31,8 +32,8 @@ const useRepresentationNavigationStyles = makeStyles()((theme) => ({
     textTransform: 'none',
   },
   tabLabel: {
-    display: 'flex',
-    flexDirection: 'row',
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr auto',
     alignItems: 'center',
     width: 'inherit',
   },
@@ -121,20 +122,22 @@ export const RepresentationNavigation = forwardRef<
               classes={{ root: classes.tabRoot }}
               value={representation.id}
               label={
-                <div className={classes.tabLabel}>
-                  {representation.iconURLs && (
-                    <div className={classes.tabRepresentationIcon}>
-                      <IconOverlay iconURL={representation.iconURLs} alt="representation icon" />
-                    </div>
-                  )}
-                  <div className={classes.tabLabelText}>{representation.label}</div>
-                  <CloseIcon
-                    className={classes.tabCloseIcon}
-                    fontSize="small"
-                    onClick={(event) => onRepresentationClose(event, representation)}
-                    data-testid={`close-representation-tab-${representation.label}`}
-                  />
-                </div>
+                <Tooltip title={representation.label}>
+                  <div className={classes.tabLabel}>
+                    {representation.iconURLs && (
+                      <div className={classes.tabRepresentationIcon}>
+                        <IconOverlay iconURL={representation.iconURLs} alt="representation icon" />
+                      </div>
+                    )}
+                    <div className={classes.tabLabelText}>{representation.label}</div>
+                    <CloseIcon
+                      className={classes.tabCloseIcon}
+                      fontSize="small"
+                      onClick={(event) => onRepresentationClose(event, representation)}
+                      data-testid={`close-representation-tab-${representation.label}`}
+                    />
+                  </div>
+                </Tooltip>
               }
               key={representation.id}
               data-testid={`representation-tab-${representation.label}`}


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/4171


Before:

<img width="627" height="178" alt="Capture d’écran du 2025-10-01 11-32-28" src="https://github.com/user-attachments/assets/52e0aaff-bb44-4302-b6dd-ba28ba060b0f" />


After:

<img width="627" height="178" alt="Capture d’écran du 2025-10-01 11-28-26" src="https://github.com/user-attachments/assets/2d1e38ee-4f93-4cec-82ca-d3c648d9a37f" />



# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?