### PR TITLE
[6215] Automatically expand newly opened selection dialog to give more context

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -55,6 +55,7 @@ The font weights used in the default MUI theme can be found here[https://mui.com
 - https://github.com/eclipse-sirius/sirius-web/issues/6055[#6055] [test] Update an `ArchUnit` test to consider an empty list of fields.
 In Java 17, the Java compiler was always generating a private synthetic field for inner classes.
 In Java 18+ this synthetic field is not automatically generated anymore if it is not necessary, as a result some `ArchUnit` tests on fields could encounter an empty list of fields now which would trigger a test failure.
+- https://github.com/eclipse-sirius/sirius-web/issues/6215[#6215] [diagram] When a tool opens a selection dialog to ask for input, the tree displayed in the dialog is now expanded to reveal the element on which the tool was invoked to provide better context.
 
 
 
@@ -212,6 +213,7 @@ For example entering either `att def` or `NAD` will now find a tool named `New A
 - https://github.com/eclipse-sirius/sirius-web/issues/6416[#6416] [sirius-web] Perform the validation of the dependencies when a project is uploaded
 - https://github.com/eclipse-sirius/sirius-web/issues/6475[#6475] [diagram] Hide handles when moving an edge segment
 - https://github.com/eclipse-sirius/sirius-web/issues/6497[#6497] [diagram] Display an ellipsis decorator if multiple decorators should be displayed at the same position.
+
 
 
 == 2026.3.0

--- a/packages/selection/frontend/sirius-components-selection/src/SelectionDialogTreeView.tsx
+++ b/packages/selection/frontend/sirius-components-selection/src/SelectionDialogTreeView.tsx
@@ -18,6 +18,7 @@ import {
   TreeItemActionProps,
   TreeView,
   useExpandAllTreePath,
+  useTreePath,
 } from '@eclipse-sirius/sirius-components-trees';
 import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import Box from '@mui/material/Box';
@@ -29,12 +30,6 @@ import { useSelectionDialogTreeSubscription } from './useSelectionDialogTreeSubs
 
 export const SELECTION_DIALOG_TYPE: string = 'selectionDialogDescription';
 
-const initialState: SelectionDialogTreeViewState = {
-  filterBarText: '',
-  expanded: [],
-  maxDepth: 1,
-};
-
 export const SelectionDialogTreeView = ({
   editingContextId,
   treeDescriptionId,
@@ -43,7 +38,13 @@ export const SelectionDialogTreeView = ({
   selectedTreeItemIds,
   disabled,
 }: SelectionDialogTreeViewProps) => {
-  const [state, setState] = useState<SelectionDialogTreeViewState>(initialState);
+  const [state, setState] = useState<SelectionDialogTreeViewState>({
+    filterBarText: '',
+    expanded: [],
+    maxDepth: 1,
+    pristine: true,
+  });
+  const { getTreePath, data: treePathData } = useTreePath();
 
   const treeId = `selection://?treeDescriptionId=${encodeURIComponent(treeDescriptionId)}${encodeVariables(variables)}`;
   const { tree } = useSelectionDialogTreeSubscription(editingContextId, treeId, state.expanded, state.maxDepth);
@@ -53,8 +54,29 @@ export const SelectionDialogTreeView = ({
       ...prevState,
       expanded: newExpandedIds,
       maxDepth: Math.max(newMaxDepth, prevState.maxDepth),
+      pristine: false,
     }));
   };
+
+  useEffect(() => {
+    if (tree && state.pristine) {
+      var targetObjectId = variables.find((variable) => variable.name === 'targetObjectId')?.value as string;
+      getTreePath({
+        variables: {
+          editingContextId,
+          treeId: tree.id,
+          selectionEntryIds: [targetObjectId],
+        },
+      });
+    }
+  }, [tree, state.pristine, variables]);
+
+  useEffect(() => {
+    if (treePathData && treePathData.viewer?.editingContext?.treePath) {
+      const { treeItemIdsToExpand, maxDepth } = treePathData.viewer.editingContext.treePath;
+      onExpandedElementChange(treeItemIdsToExpand ?? [], maxDepth ?? 1);
+    }
+  }, [treePathData]);
 
   return (
     <Box

--- a/packages/selection/frontend/sirius-components-selection/src/SelectionDialogTreeView.types.ts
+++ b/packages/selection/frontend/sirius-components-selection/src/SelectionDialogTreeView.types.ts
@@ -26,4 +26,5 @@ export interface SelectionDialogTreeViewState {
   filterBarText: string;
   expanded: string[];
   maxDepth: number;
+  pristine: boolean;
 }


### PR DESCRIPTION
* On the left, invoking Papaya's "Import existing types" on master from a diagram: the user has to know/remember the document and path "where he was" to locate most probable elements.
* On the right, the targetObjectId of the diagram on which the tool has been invoked is revealed (but not selected), making it easier for the common cases where the element the user wants is "close to" the element on which the tool was invoked (of course, without preventing him to look elsewhere).

<img width="3836" height="1619" alt="image" src="https://github.com/user-attachments/assets/06afc5e4-bef1-460a-abfa-b5800fa286c7" />


# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?