### PR TITLE
[6240] Ability to call arrangeAll on diagrams from outside the component

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -136,6 +136,7 @@ See ADR-230 for the details.
 - https://github.com/eclipse-sirius/sirius-web/issues/6319[#6319] [tree] Wait for 500ms before asking for the tooltip of a tree item
 - https://github.com/eclipse-sirius/sirius-web/issues/6354[#6354] [diagram] Allow the layout use make same size to be used on nodes that don't have the same depth
 - https://github.com/eclipse-sirius/sirius-web/issues/6414[#6414] [diagram] Add e2e test for node decorators.
+- https://github.com/eclipse-sirius/sirius-web/issues/6240[#6240] [diagram] Ability to call arrangeAll on diagrams through workbench representation handle
 
 
 

--- a/integration-tests-playwright/playwright/e2e/diagrams/auto-layout.spec.ts
+++ b/integration-tests-playwright/playwright/e2e/diagrams/auto-layout.spec.ts
@@ -10,11 +10,11 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { test, expect } from '@playwright/test';
-import { PlaywrightProject } from '../../helpers/PlaywrightProject';
-import { PlaywrightWorkbench } from '../../helpers/PlaywrightWorkbench';
+import { expect, test } from '@playwright/test';
 import { PlaywrightExplorer } from '../../helpers/PlaywrightExplorer';
 import { PlaywrightNode } from '../../helpers/PlaywrightNode';
+import { PlaywrightProject } from '../../helpers/PlaywrightProject';
+import { PlaywrightWorkbench } from '../../helpers/PlaywrightWorkbench';
 
 test.describe('diagram - auto-layout', () => {
   let projectId;
@@ -40,9 +40,11 @@ test.describe('diagram - auto-layout', () => {
     await expect(page.getByTestId('FreeForm - Wifi')).toBeInViewport();
 
     const captureSubsystemNode = new PlaywrightNode(page, 'Capture_Subsystem');
-    const captureSubsystemPosition = await captureSubsystemNode.getReactFlowXYPosition();
-    expect(captureSubsystemPosition.x).toBe(12);
-    expect(captureSubsystemPosition.y).toBe(12);
+    await expect(async () => {
+      const captureSubsystemPosition = await captureSubsystemNode.getReactFlowXYPosition();
+      expect(captureSubsystemPosition.x).toBe(12);
+      expect(captureSubsystemPosition.y).toBe(12);
+    }).toPass({ timeout: 2000 });
 
     const dspNode = new PlaywrightNode(page, 'DSP');
     const dspPosition = await dspNode.getReactFlowXYPosition();
@@ -55,6 +57,13 @@ test.describe('diagram - auto-layout', () => {
   test('when moving a node on an auto-layout diagram, then move is reset to its default position', async ({ page }) => {
     await expect(page.getByTestId('rf__wrapper')).toBeAttached();
     await expect(page.getByTestId('FreeForm - Wifi')).toBeInViewport();
+
+    const captureSubsystemNode = new PlaywrightNode(page, 'Capture_Subsystem');
+    await expect(async () => {
+      const captureSubsystemPosition = await captureSubsystemNode.getReactFlowXYPosition();
+      expect(captureSubsystemPosition.x).toBe(12);
+    }).toPass({ timeout: 2000 });
+    await page.keyboard.press('Escape');
 
     const wifiNode = new PlaywrightNode(page, 'Wifi');
     const wifiPositionBefore = await wifiNode.getDOMXYPosition();

--- a/integration-tests-playwright/playwright/e2e/diagrams/edge-on-edge.spec.ts
+++ b/integration-tests-playwright/playwright/e2e/diagrams/edge-on-edge.spec.ts
@@ -110,7 +110,7 @@ test.describe('edge on edge', () => {
     page,
   }) => {
     const edges = page.locator('[data-testid^="rf__edge-"]');
-    await expect(edges).toHaveCount(2);
+    await expect(edges).toHaveCount(2, { timeout: 2000 });
 
     await expect(page.locator('.source_handle_right')).toHaveCount(1);
     await expect(page.locator('.source_handle_bottom')).toHaveCount(1);

--- a/integration-tests-playwright/playwright/e2e/diagrams/edge.spec.ts
+++ b/integration-tests-playwright/playwright/e2e/diagrams/edge.spec.ts
@@ -98,8 +98,10 @@ test.describe('edge', () => {
 
     const playwrightEdge = new PlaywrightEdge(page);
 
-    await playwrightEdge.click();
-    await playwrightEdge.isSelected();
+    await expect(async () => {
+      await playwrightEdge.click();
+      await playwrightEdge.isSelected();
+    }).toPass({ timeout: 2000 });
 
     const lastBendingPoint = page.locator(`[data-testid="bend-point-1"]`).first();
     const box = (await lastBendingPoint.boundingBox())!;
@@ -479,24 +481,26 @@ test.describe('edge', () => {
     await expect(playwrightEdge2.edgeLocator).toBeAttached();
     await expect(playwrightEdge3.edgeLocator).toBeAttached();
 
-    const edge1Path = await playwrightEdge1.getEdgePath();
-    const edge2Path = await playwrightEdge2.getEdgePath();
-    const edge3Path = await playwrightEdge3.getEdgePath();
+    await expect(async () => {
+      const edge1Path = await playwrightEdge1.getEdgePath();
+      const edge2Path = await playwrightEdge2.getEdgePath();
+      const edge3Path = await playwrightEdge3.getEdgePath();
 
-    const node1 = new PlaywrightNode(page, 'A');
-    await node1.move({ x: 100, y: 100 });
+      const node1 = new PlaywrightNode(page, 'A');
+      await node1.move({ x: 100, y: 100 });
 
-    const edge1PathAfter = await playwrightEdge1.getEdgePath();
-    const edge2PathAfter = await playwrightEdge2.getEdgePath();
-    const edge3PathAfter = await playwrightEdge3.getEdgePath();
+      const edge1PathAfter = await playwrightEdge1.getEdgePath();
+      const edge2PathAfter = await playwrightEdge2.getEdgePath();
+      const edge3PathAfter = await playwrightEdge3.getEdgePath();
 
-    expect(edge1Path).not.toBe(edge1PathAfter);
-    expect(edge2Path).not.toBe(edge2PathAfter);
-    expect(edge3Path).not.toBe(edge3PathAfter);
+      expect(edge1Path).not.toBe(edge1PathAfter);
+      expect(edge2Path).not.toBe(edge2PathAfter);
+      expect(edge3Path).not.toBe(edge3PathAfter);
 
-    await edgeExpect(edge1Path).toHaveSamePath(edge1PathAfter);
-    await edgeExpect(edge2Path).toHaveSamePath(edge2PathAfter);
-    await edgeExpect(edge3Path).toHaveSamePath(edge3PathAfter);
+      await edgeExpect(edge1Path).toHaveSamePath(edge1PathAfter);
+      await edgeExpect(edge2Path).toHaveSamePath(edge2PathAfter);
+      await edgeExpect(edge3Path).toHaveSamePath(edge3PathAfter);
+    }).toPass({ timeout: 2000 });
   });
 });
 

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/index.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/index.ts
@@ -99,4 +99,7 @@ export type { IElementSVGExportHandler } from './renderer/toolbar/experimental-s
 export { svgExportIElementSVGExportHandlerExtensionPoint } from './renderer/toolbar/experimental-svg-export/SVGExportHandlerExtensionPoints';
 export type { GQLToolVariable, GQLToolVariableType } from './renderer/tools/useInvokePaletteTool.types';
 export { DiagramRepresentation } from './representation/DiagramRepresentation';
-export type { GQLDiagramDescription } from './representation/DiagramRepresentation.types';
+export type {
+  GQLDiagramDescription,
+  WorkbenchDiagramRepresentationHandle,
+} from './representation/DiagramRepresentation.types';

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.tsx
@@ -12,13 +12,9 @@
  *******************************************************************************/
 
 import { gql, useQuery } from '@apollo/client';
-import {
-  RepresentationComponentProps,
-  Selection,
-  useMultiToast,
-  WorkbenchMainRepresentationHandle,
-} from '@eclipse-sirius/sirius-components-core';
+import { RepresentationComponentProps, Selection, useMultiToast } from '@eclipse-sirius/sirius-components-core';
 import { ReactFlowProvider } from '@xyflow/react';
+import { LayoutOptions } from 'elkjs';
 import { ForwardedRef, forwardRef, memo, useEffect, useImperativeHandle, useState } from 'react';
 import { DiagramContext } from '../contexts/DiagramContext';
 import { DiagramDescriptionContext } from '../contexts/DiagramDescriptionContext';
@@ -29,14 +25,17 @@ import { DiagramDirectEditContextProvider } from '../renderer/direct-edit/Diagra
 import { DropNodeContextProvider } from '../renderer/dropNode/DropNodeContext';
 import { MarkerDefinitions } from '../renderer/edge/MarkerDefinitions';
 import { FullscreenContextProvider } from '../renderer/fullscreen/FullscreenContext';
+import { useArrangeAll } from '../renderer/layout/arrange-all/useArrangeAll';
 import { NodeContextProvider } from '../renderer/node/NodeContext';
 import { DiagramPaletteContextProvider } from '../renderer/palette/contexts/DiagramPaletteContext';
 import { useApplySelection } from '../renderer/selection/useApplySelection';
+import { useExportToImage } from '../renderer/toolbar/useExportToImage';
 import {
   DiagramRepresentationState,
   GQLDiagramDescription,
   GQLDiagramDescriptionData,
   GQLDiagramDescriptionVariables,
+  WorkbenchDiagramRepresentationHandle,
 } from './DiagramRepresentation.types';
 import { DiagramSubscriptionProvider } from './DiagramSubscriptionProvider';
 
@@ -77,15 +76,17 @@ export const getDiagramDescription = gql`
 
 /**
  * This is needed because the DiagramRepresentation component, which receives the `ref`, can not use it itself:
- * the `applySelection` it needs to publish with `useImperativeHandle` can only be implemented from inside
+ * the `applySelection` and `applyLayout` it needs to publish with `useImperativeHandle` can only be implemented from inside
  * the React Flow context (where `useApplySelection()` can be invoked).
  */
-const ApplySelectionWrapper = forwardRef(
+const ApplyWrapper = forwardRef(
   (
     props: { representationId: string; children: React.ReactNode },
-    ref: ForwardedRef<WorkbenchMainRepresentationHandle>
+    ref: ForwardedRef<WorkbenchDiagramRepresentationHandle>
   ) => {
     const { applySelection: applyAndRevealSelection } = useApplySelection();
+    const { arrangeAll } = useArrangeAll();
+    const { exportToSVG } = useExportToImage();
     useImperativeHandle(
       ref,
       () => {
@@ -93,6 +94,12 @@ const ApplySelectionWrapper = forwardRef(
           id: props.representationId,
           applySelection: (selection: Selection) => {
             applyAndRevealSelection(selection, true);
+          },
+          applyLayout: async (layoutOptions: LayoutOptions) => {
+            await arrangeAll(layoutOptions);
+          },
+          exportSVG: (callback: (dataUrl: string) => void) => {
+            exportToSVG(callback);
           },
         };
       },
@@ -103,10 +110,10 @@ const ApplySelectionWrapper = forwardRef(
 );
 
 export const DiagramRepresentation = memo(
-  forwardRef<WorkbenchMainRepresentationHandle, RepresentationComponentProps>(
+  forwardRef<WorkbenchDiagramRepresentationHandle, RepresentationComponentProps>(
     (
       { editingContextId, representationId, readOnly }: RepresentationComponentProps,
-      ref: ForwardedRef<WorkbenchMainRepresentationHandle>
+      ref: ForwardedRef<WorkbenchDiagramRepresentationHandle>
     ) => {
       const [state, setState] = useState<DiagramRepresentationState>({
         id: crypto.randomUUID(),
@@ -190,7 +197,7 @@ export const DiagramRepresentation = memo(
                             consumePostToolSelection,
                             toolSelections: state.toolSelections,
                           }}>
-                          <ApplySelectionWrapper representationId={representationId} ref={ref}>
+                          <ApplyWrapper representationId={representationId} ref={ref}>
                             <ManageVisibilityContextProvider>
                               <DialogContextProvider>
                                 <DiagramSubscriptionProvider
@@ -200,7 +207,7 @@ export const DiagramRepresentation = memo(
                                 />
                               </DialogContextProvider>
                             </ManageVisibilityContextProvider>
-                          </ApplySelectionWrapper>
+                          </ApplyWrapper>
                         </DiagramContext.Provider>
                       </DiagramDescriptionContext.Provider>
                     </FullscreenContextProvider>

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.types.ts
@@ -11,7 +11,7 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { Selection } from '@eclipse-sirius/sirius-components-core';
+import { Selection, WorkbenchMainRepresentationHandle } from '@eclipse-sirius/sirius-components-core';
 import { GQLNodeDescription } from '../graphql/query/nodeDescriptionFragment.types';
 import { GQLDiagramEventPayload } from '../graphql/subscription/diagramEventSubscription.types';
 
@@ -76,4 +76,9 @@ export interface GQLDropNodeCompatibility {
   droppedNodeDescriptionId: string;
   droppableOnDiagram: boolean;
   droppableOnNodeTypes: string[];
+}
+
+export interface WorkbenchDiagramRepresentationHandle extends WorkbenchMainRepresentationHandle {
+  applyLayout: ((layoutOptions: Record<string, string>) => Promise<void>) | null;
+  exportSVG: ((callback: (dataUrl: string) => void) => void) | null;
 }


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/6240

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [x] Variables have a proper type
- [x] Functions’ arguments have a proper type
- [x] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?

It can be tested by calling the new applyLayout method on a diagram workbench handle. For example by obtaining the handle from another view with workbench.getDisplayedRepresentationHandle() and calling the applyLayout method.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?