### PR TITLE
[6503] Key bindings on diagram tools can conflict with browser actions

### DIFF
--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/api/IKeyBindingsProvider.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/api/IKeyBindingsProvider.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.api;
+
+import java.util.List;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
+
+/**
+ *  Interface for services providing the key bindings available on a diagram.
+ *
+ * @author pcdavid
+ */
+public interface IKeyBindingsProvider {
+
+    boolean canHandle(IEditingContext editingContext, DiagramDescription diagramDescription);
+
+    List<String> getKeyBindings(IEditingContext editingContext, DiagramDescription diagramDescription);
+}

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/dto/GetKeyBindingsInput.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/dto/GetKeyBindingsInput.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.dto;
+
+import java.util.UUID;
+
+import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
+
+/**
+ * The input for the key bindings event handler.
+ *
+ * @author pcdavid
+ */
+public record GetKeyBindingsInput(UUID id, String editingContextId, String representationId) implements IDiagramInput {
+
+}

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/dto/GetKeyBindingsSuccessPayload.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/dto/GetKeyBindingsSuccessPayload.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.dto;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.core.api.IPayload;
+
+/**
+ * The payload of the "Get Key Bindings" query returned on success.
+ *
+ * @author pcdavid
+ */
+public record GetKeyBindingsSuccessPayload(UUID id, List<String> bindings) implements IPayload {
+    public GetKeyBindingsSuccessPayload {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(bindings);
+    }
+
+}

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/GetKeyBindingsEventHandler.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/GetKeyBindingsEventHandler.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
+import org.eclipse.sirius.components.collaborative.api.ChangeKind;
+import org.eclipse.sirius.components.collaborative.api.Monitoring;
+import org.eclipse.sirius.components.collaborative.diagrams.DiagramContext;
+import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventHandler;
+import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
+import org.eclipse.sirius.components.collaborative.diagrams.api.IKeyBindingsProvider;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.GetDropNodeCompatibilityInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.GetKeyBindingsInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.GetKeyBindingsSuccessPayload;
+import org.eclipse.sirius.components.collaborative.messages.ICollaborativeMessageService;
+import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
+import org.springframework.stereotype.Service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import reactor.core.publisher.Sinks.Many;
+import reactor.core.publisher.Sinks.One;
+
+/**
+ * Event handler for the "get key bindings" query.
+ *
+ * @author pcdavid
+ */
+@Service
+public class GetKeyBindingsEventHandler implements IDiagramEventHandler {
+
+    private final IRepresentationDescriptionSearchService representationDescriptionSearchService;
+
+    private final List<IKeyBindingsProvider> keyBindingsProviders;
+
+    private final ICollaborativeMessageService messageService;
+
+    private final Counter counter;
+
+    public GetKeyBindingsEventHandler(IRepresentationDescriptionSearchService representationDescriptionSearchService, List<IKeyBindingsProvider> keyBindingsProviders,
+            ICollaborativeMessageService messageService, MeterRegistry meterRegistry) {
+        this.representationDescriptionSearchService = Objects.requireNonNull(representationDescriptionSearchService);
+        this.keyBindingsProviders = Objects.requireNonNull(keyBindingsProviders);
+        this.messageService = Objects.requireNonNull(messageService);
+
+        this.counter = Counter.builder(Monitoring.EVENT_HANDLER)
+                .tag(Monitoring.NAME, this.getClass().getSimpleName())
+                .register(meterRegistry);
+    }
+
+    @Override
+    public boolean canHandle(IEditingContext editingContext, IDiagramInput diagramInput) {
+        return diagramInput instanceof GetKeyBindingsInput;
+    }
+
+    @Override
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, DiagramContext diagramContext, IDiagramInput diagramInput) {
+        this.counter.increment();
+
+        ChangeDescription changeDescription = new ChangeDescription(ChangeKind.NOTHING, editingContext.getId(), diagramInput);
+        IPayload payload = null;
+
+        if (diagramInput instanceof GetKeyBindingsInput) {
+            Diagram diagram = diagramContext.diagram();
+            var diagramDescription = this.representationDescriptionSearchService.findById(editingContext, diagram.getDescriptionId())
+                    .filter(DiagramDescription.class::isInstance)
+                    .map(DiagramDescription.class::cast);
+
+            if (diagramDescription.isPresent()) {
+                List<String> result = new ArrayList<>();
+                this.keyBindingsProviders.stream()
+                        .filter(provider -> provider.canHandle(editingContext, diagramDescription.get()))
+                        .forEach(provider -> result.addAll(provider.getKeyBindings(editingContext, diagramDescription.get())));
+
+                payload = new GetKeyBindingsSuccessPayload(diagramInput.id(), result);
+            }
+        } else {
+            String message = this.messageService.invalidInput(diagramInput.getClass().getSimpleName(), GetDropNodeCompatibilityInput.class.getSimpleName());
+            payload = new ErrorPayload(diagramInput.id(), message);
+        }
+
+        payloadSink.tryEmitValue(payload);
+        changeDescriptionSink.tryEmitNext(changeDescription);
+    }
+}

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/resources/schema/diagram.graphqls
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/resources/schema/diagram.graphqls
@@ -456,6 +456,7 @@ type DiagramDescription implements RepresentationDescription {
   manageVisibilityActions(diagramElementId: ID!): [ManageVisibilityAction!]!
   connectorTools(sourceDiagramElementId: ID!, targetDiagramElementId: ID!): [Tool!]!
   dropNodeCompatibility: [DropNodeCompatibilityEntry!]!
+  keyBindings: [String!]!
   initialDirectEditElementLabel(labelId: ID!): String!
   diagramImpactAnalysisReport(toolId: ID!, diagramElementId: ID!, variables: [ToolVariable!]!): ImpactAnalysisReport!
   debug: Boolean

--- a/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/DiagramDescriptionKeyBindingsDataFetcher.java
+++ b/packages/diagrams/backend/sirius-components-diagrams-graphql/src/main/java/org/eclipse/sirius/components/diagrams/graphql/datafetchers/diagram/DiagramDescriptionKeyBindingsDataFetcher.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.graphql.datafetchers.diagram;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.GetKeyBindingsInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.GetKeyBindingsSuccessPayload;
+import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.components.graphql.api.IEditingContextDispatcher;
+import org.eclipse.sirius.components.graphql.api.LocalContextConstants;
+
+import graphql.schema.DataFetchingEnvironment;
+import reactor.core.publisher.Mono;
+
+/**
+ * The data fetcher for the {@code DiagramDescription { keyBindings }} query.
+ *
+ * @author pcdavid
+ */
+@QueryDataFetcher(type = "DiagramDescription", field = "keyBindings")
+public class DiagramDescriptionKeyBindingsDataFetcher implements IDataFetcherWithFieldCoordinates<CompletableFuture<List<String>>> {
+
+    private final IEditingContextDispatcher editingContextDispatcher;
+
+    public DiagramDescriptionKeyBindingsDataFetcher(IEditingContextDispatcher editingContextDispatcher) {
+        this.editingContextDispatcher = Objects.requireNonNull(editingContextDispatcher);
+    }
+
+    @Override
+    public CompletableFuture<List<String>> get(DataFetchingEnvironment environment) throws Exception {
+        Map<String, Object> localContext = environment.getLocalContext();
+        String editingContextId = Optional.ofNullable(localContext.get(LocalContextConstants.EDITING_CONTEXT_ID)).map(Object::toString).orElse(null);
+        String representationId = Optional.ofNullable(localContext.get(LocalContextConstants.REPRESENTATION_ID)).map(Object::toString).orElse(null);
+        if (editingContextId != null && representationId != null) {
+            GetKeyBindingsInput input = new GetKeyBindingsInput(UUID.randomUUID(), editingContextId, representationId);
+
+            return this.editingContextDispatcher.dispatchQuery(input.editingContextId(), input)
+                    .filter(GetKeyBindingsSuccessPayload.class::isInstance)
+                    .map(GetKeyBindingsSuccessPayload.class::cast)
+                    .map(GetKeyBindingsSuccessPayload::bindings)
+                    .toFuture();
+        }
+        return Mono.<List<String>>empty().toFuture();
+    }
+
+}

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/contexts/DiagramDescriptionContext.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/contexts/DiagramDescriptionContext.ts
@@ -19,6 +19,7 @@ const defaultValue: DiagramDescriptionContextValue = {
     id: '',
     nodeDescriptions: [],
     dropNodeCompatibility: [],
+    keyBindings: [],
     debug: false,
     arrangeLayoutDirection: 'RIGHT',
     layoutOption: 'NONE',

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/key-binding/useDiagramKeyBinding.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/key-binding/useDiagramKeyBinding.ts
@@ -15,6 +15,7 @@ import { Edge, Node, useReactFlow, useStoreApi, useViewport, Viewport, XYPositio
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { DiagramContext } from '../../contexts/DiagramContext';
 import { DiagramContextValue } from '../../contexts/DiagramContext.types';
+import { useDiagramDescription } from '../../contexts/useDiagramDescription';
 import { EdgeData, NodeData } from '../DiagramRenderer.types';
 import { isSingleClickOnDiagramElementTool, isToolSection } from '../palette/Palette';
 import { GQLPalette, GQLSingleClickOnDiagramElementTool } from '../palette/Palette.types';
@@ -61,6 +62,7 @@ const toolHasKeyBinding = (tool: GQLSingleClickOnDiagramElementTool, event: Reac
 
 export const useDiagramKeyBinding = (diagramTargetObjectId: string): UseDiagramKeyBindingValue => {
   const { editingContextId, diagramId } = useContext<DiagramContextValue>(DiagramContext);
+  const { diagramDescription } = useDiagramDescription();
   const { getNodes, getNode, getEdges, getEdge } = useReactFlow<Node<NodeData>, Edge<EdgeData>>();
   const [state, setState] = useState<UseDiagramKeyBindingState>({
     currentEvent: null,
@@ -138,6 +140,22 @@ export const useDiagramKeyBinding = (diagramTargetObjectId: string): UseDiagramK
       ) {
         return;
       }
+
+      diagramDescription.keyBindings.forEach((keyBinding) => {
+        let eventString = event.key;
+        if (event.metaKey) {
+          eventString = 'Meta+' + eventString;
+        }
+        if (event.altKey) {
+          eventString = 'Alt+' + eventString;
+        }
+        if (event.ctrlKey) {
+          eventString = 'Ctrl+' + eventString;
+        }
+        if (eventString === keyBinding) {
+          event.preventDefault();
+        }
+      });
 
       setState((prevState) => ({
         ...prevState,

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.tsx
@@ -64,6 +64,7 @@ export const getDiagramDescription = gql`
                 droppableOnDiagram
                 droppableOnNodeTypes
               }
+              keyBindings
               debug
               arrangeLayoutDirection
               layoutOption

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.types.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.types.ts
@@ -61,6 +61,7 @@ export interface GQLDiagramDescription {
   nodeDescriptions: GQLNodeDescription[];
   toolbar?: GQLDiagramToolbar;
   dropNodeCompatibility: GQLDropNodeCompatibility[];
+  keyBindings: string[];
   debug: boolean;
   arrangeLayoutDirection: GQLArrangeLayoutDirection;
   layoutOption: GQLDiagramLayoutOption;

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewDiagramDescriptionSearchService.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewDiagramDescriptionSearchService.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IIdentityService;
-import org.eclipse.sirius.components.core.api.IObjectSearchService;
 import org.eclipse.sirius.components.core.api.IURLParser;
 import org.eclipse.sirius.components.view.diagram.DiagramDescription;
 import org.eclipse.sirius.components.view.diagram.EdgeDescription;
@@ -42,15 +41,12 @@ public class ViewDiagramDescriptionSearchService implements IViewDiagramDescript
 
     private final IIdentityService identityService;
 
-    private final IObjectSearchService objectSearchService;
-
     private final IURLParser urlParser;
 
     private final IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService;
 
-    public ViewDiagramDescriptionSearchService(IIdentityService identityService, IObjectSearchService objectSearchService, IURLParser urlParser, IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService) {
+    public ViewDiagramDescriptionSearchService(IIdentityService identityService, IURLParser urlParser, IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService) {
         this.identityService = Objects.requireNonNull(identityService);
-        this.objectSearchService = Objects.requireNonNull(objectSearchService);
         this.urlParser = Objects.requireNonNull(urlParser);
         this.viewRepresentationDescriptionSearchService = Objects.requireNonNull(viewRepresentationDescriptionSearchService);
     }

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewKeyBindingsProvider.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/ViewKeyBindingsProvider.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.sirius.components.view.emf.diagram;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.collaborative.diagrams.api.IKeyBindingsProvider;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.components.view.KeyBinding;
+import org.eclipse.sirius.components.view.emf.ViewRepresentationDescriptionPredicate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service providing the diagram keyBindings value for DiagramDescription based on the View DSL.
+ *
+ * @author pcdavid
+ */
+@Service
+public class ViewKeyBindingsProvider implements IKeyBindingsProvider {
+
+    private final ViewDiagramDescriptionSearchService viewDiagramDescriptionSearchService;
+
+    private final ViewRepresentationDescriptionPredicate viewRepresentationDescriptionPredicate;
+
+    public ViewKeyBindingsProvider(ViewDiagramDescriptionSearchService viewDiagramDescriptionSearchService,
+            ViewRepresentationDescriptionPredicate viewRepresentationDescriptionPredicate) {
+        this.viewDiagramDescriptionSearchService = Objects.requireNonNull(viewDiagramDescriptionSearchService);
+        this.viewRepresentationDescriptionPredicate = Objects.requireNonNull(viewRepresentationDescriptionPredicate);
+    }
+
+    @Override
+    public boolean canHandle(IEditingContext editingContext, DiagramDescription diagramDescription) {
+        return this.viewRepresentationDescriptionPredicate.test(diagramDescription);
+    }
+
+    @Override
+    public List<String> getKeyBindings(IEditingContext editingContext, DiagramDescription diagramDescription) {
+        var optionalDiagramDescription = this.viewDiagramDescriptionSearchService.findById(editingContext, diagramDescription.getId());
+        if (optionalDiagramDescription.isPresent()) {
+            org.eclipse.sirius.components.view.diagram.DiagramDescription viewDiagramDescription = optionalDiagramDescription.get();
+            return this.findAllKeyBindings(viewDiagramDescription);
+        }
+        return List.of();
+    }
+
+    private List<String> findAllKeyBindings(org.eclipse.sirius.components.view.diagram.DiagramDescription viewDiagramDescription) {
+        List<String> result = new ArrayList<>();
+        viewDiagramDescription.eAllContents().forEachRemaining(o -> {
+            if (o instanceof KeyBinding binding) {
+                var key = binding.getKey();
+                if (binding.isMeta()) {
+                    key = "Meta+" + key;
+                }
+                if (binding.isAlt()) {
+                    key = "Alt+" + key;
+                }
+                if (binding.isCtrl()) {
+                    key = "Ctrl+" + key;
+                }
+                result.add(key);
+            }
+        });
+        return result;
+    }
+}


### PR DESCRIPTION
First attempt, which fetches *all* the key bindings defined anywhere on a diagram description at diagram load time, so that we have the information ready to use when inside the event listener to `preventDefault()` a key press which conflicts with any of them.

This is not precise enough: for example if a tool bound to _Ctrl-d_ is defined on nodes of type T, we will always block _Ctrl-d_ when invoked on the diagram, even if no node of type T is actually selected (and thus we would not actually invoke the diagram tool either).

To go further, we'd need to gather more precise information than just the global list of bindings, but also which type of node they apply to (somewhat similar to what we do with node drop compatibility data). It's not trivial though, as [the set of currently selected nodes](https://github.com/eclipse-sirius/sirius-web/blob/master/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/key-binding/useDiagramKeyBinding.ts#L84) is dynamic and computed outside of `onKeyBinding`. Maybe a `useRef` could be used here.

Finally, note that even having this additional data will not prevent some "edge cases". If a node type T defines a tool on _Ctrl-d_, a node of type T *is* actually selected and the user hits _Ctrl-d_, we would prevent the default browser behavior _even if the tool's pre-condition indicates that it does not actually apply to the selected node_.
