### PR TITLE
[fix] Make views explorer views order deterministic

### DIFF
--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/viewsexplorer/services/DefaultViewsExplorerContentService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/viewsexplorer/services/DefaultViewsExplorerContentService.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.sirius.web.application.views.viewsexplorer.services;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -41,7 +42,8 @@ public class DefaultViewsExplorerContentService implements IDefaultViewsExplorer
     }
 
     @Override
-    public List<RepresentationKind> getContents(IEditingContext editingContext, List<RepresentationMetadata> representationMetadata, Map<String, IRepresentationDescription> representationDescriptions) {
+    public List<RepresentationKind> getContents(IEditingContext editingContext, List<RepresentationMetadata> representationMetadata,
+            Map<String, IRepresentationDescription> representationDescriptions) {
         var descriptionTypes = this.groupByDescriptionType(representationMetadata, representationDescriptions);
         return this.groupByKind(descriptionTypes);
     }
@@ -49,22 +51,35 @@ public class DefaultViewsExplorerContentService implements IDefaultViewsExplorer
     private List<RepresentationDescriptionType> groupByDescriptionType(List<RepresentationMetadata> allMetadata, Map<String, IRepresentationDescription> allDescriptions) {
         return allMetadata.stream()
                 .collect(Collectors.groupingBy(RepresentationMetadata::getDescriptionId))
-                .entrySet().stream()
-                .map(entry -> Optional.ofNullable(allDescriptions.get(entry.getKey()))
-                        .map(representationDescription -> new RepresentationDescriptionType(entry.getKey(), representationDescription, entry.getValue())))
+                .entrySet()
+                .stream()
+                .map(entry -> this.toRepresentationDescriptionType(allDescriptions, entry))
                 .flatMap(Optional::stream)
+                .sorted(Comparator.comparing(descType -> descType.description().getLabel()))
                 .toList();
+    }
+
+    private Optional<RepresentationDescriptionType> toRepresentationDescriptionType(Map<String, IRepresentationDescription> allDescriptions, Map.Entry<String, List<RepresentationMetadata>> entry) {
+        return Optional.ofNullable(allDescriptions.get(entry.getKey()))
+                .map(representationDescription -> {
+                    var allRepresentationMetadata = entry.getValue().stream()
+                            .sorted(Comparator.comparing(RepresentationMetadata::getLabel))
+                            .toList();
+                    return new RepresentationDescriptionType(entry.getKey(), representationDescription, allRepresentationMetadata);
+                });
     }
 
     private List<RepresentationKind> groupByKind(List<RepresentationDescriptionType> descriptionTypes) {
         return descriptionTypes.stream()
                 .collect(Collectors.groupingBy(descType -> descType.representationsMetadata().get(0).getKind()))
-                .entrySet().stream()
+                .entrySet()
+                .stream()
                 .map(entry -> {
                     var kindId = entry.getKey();
                     var kindName = this.urlParser.getParameterValues(kindId).get("type").get(0);
                     return new RepresentationKind(kindId, kindName, entry.getValue());
                 })
+                .sorted(Comparator.comparing(RepresentationKind::name))
                 .toList();
     }
 }

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/viewsexplorer/ViewsExplorerViewControllerIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/viewsexplorer/ViewsExplorerViewControllerIntegrationTests.java
@@ -207,15 +207,16 @@ public class ViewsExplorerViewControllerIntegrationTests extends AbstractIntegra
             assertThat(tree.getChildren()).hasSize(1);
             assertThat(tree.getChildren().get(0).getChildren()).hasSize(1);
             assertThat(tree.getChildren().get(0).getChildren().get(0).getChildren()).hasSize(2);
-            assertThat(tree.getChildren().get(0).getChildren().get(0).getChildren().get(1).getLabel().toString()).isEqualTo("Foo");
+            assertThat(tree.getChildren().get(0).getChildren().get(0).getChildren())
+                    .anySatisfy(item -> assertThat(item.getLabel().toString()).isEqualTo("Foo"));
         });
 
         StepVerifier.create(defaultFlux)
-            .consumeNextWith(initialDefaultViewsContentConsumer)
-            .then(renameTreeItem)
-            .consumeNextWith(afterRenameViewsContentConsumer)
-            .thenCancel()
-            .verify(Duration.ofSeconds(10));
+                .consumeNextWith(initialDefaultViewsContentConsumer)
+                .then(renameTreeItem)
+                .consumeNextWith(afterRenameViewsContentConsumer)
+                .thenCancel()
+                .verify(Duration.ofSeconds(10));
     }
 
     @Test
@@ -288,7 +289,7 @@ public class ViewsExplorerViewControllerIntegrationTests extends AbstractIntegra
 
     private ViewsExplorerEventInput buildViewInput() {
         var representationId = new RepresentationIdBuilder().buildViewsExplorerViewRepresentationId(
-            List.of(Portal.KIND, TestIdentifiers.PORTAL_DESCRIPTION_ID.toString()));
+                List.of(Portal.KIND, TestIdentifiers.PORTAL_DESCRIPTION_ID.toString()));
         return new ViewsExplorerEventInput(UUID.randomUUID(), TestIdentifiers.ECORE_SAMPLE_EDITING_CONTEXT_ID, representationId);
     }
 }


### PR DESCRIPTION
# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?