### PR TITLE
[6736] Make ChangeDescription rely on ICause instead of IInput

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -34,6 +34,7 @@ The package `@lexical/code` is not used anymore.
 - https://github.com/eclipse-sirius/sirius-web/issues/6461[#6461] [core] If you have an implementation of `IOmniboxCommandOrderer`, it should now implements
 `IOmniboxCommandOrdererDelegate` instead.
 If no `IOmniboxCommandOrdererDelegate` is implemented, a default implementation of `IDefaultOmniboxCommandOrderer` that is part of sirius-components will be used.
+- https://github.com/eclipse-sirius/sirius-web/issues/6736[#6736] [core] `ChangeDescription#getInput(): IInput` has been modified to `ChangeDescription#getCause(): ICause`.
 
 
 === Dependency update
@@ -76,6 +77,8 @@ This package can thus be easily reused by those who want to integrate Markdown r
 Downstream applications can implement `IOmniboxCommandOrdererDelegate` to define their own ordering strategy.
 - https://github.com/eclipse-sirius/sirius-web/issues/6726[#6726] [releng] Start extracting the manual code annotated with '@generated NOT' from generated code into a spec package.
 - https://github.com/eclipse-sirius/sirius-web/issues/6538[#6538] [diagram] Align the lifecycle of the connector tool popup and the palette
+- https://github.com/eclipse-sirius/sirius-web/issues/6736[#6736] [core] Update `ChangeDescription` to accept an `ICause` as parameter instead of just `IInput`.
+This will allow us to reuse the change description to propagate more information.
 
 
 

--- a/packages/charts/backend/sirius-components-collaborative-charts/src/main/java/org/eclipse/sirius/components/collaborative/charts/HierarchyEventFlux.java
+++ b/packages/charts/backend/sirius-components-collaborative-charts/src/main/java/org/eclipse/sirius/components/collaborative/charts/HierarchyEventFlux.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import org.eclipse.sirius.components.charts.hierarchy.Hierarchy;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.events.ICause;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,10 +44,10 @@ public class HierarchyEventFlux {
         this.currentHierarchy = Objects.requireNonNull(currentHierarchy);
     }
 
-    public void hierarchyRefreshed(IInput input, Hierarchy newHierarchy) {
+    public void hierarchyRefreshed(ICause cause, Hierarchy newHierarchy) {
         this.currentHierarchy = newHierarchy;
         if (this.sink.currentSubscriberCount() > 0) {
-            EmitResult emitResult = this.sink.tryEmitNext(new HierarchyRefreshedEventPayload(input.id(), this.currentHierarchy));
+            EmitResult emitResult = this.sink.tryEmitNext(new HierarchyRefreshedEventPayload(cause.id(), this.currentHierarchy));
             if (emitResult.isFailure()) {
                 this.logger.atWarn()
                         .setMessage("An error has occurred while emitting a HierarchyRefreshedEventPayload: {}")

--- a/packages/charts/backend/sirius-components-collaborative-charts/src/main/java/org/eclipse/sirius/components/collaborative/charts/HierarchyEventProcessor.java
+++ b/packages/charts/backend/sirius-components-collaborative-charts/src/main/java/org/eclipse/sirius/components/collaborative/charts/HierarchyEventProcessor.java
@@ -20,6 +20,7 @@ import org.eclipse.sirius.components.collaborative.api.ISubscriptionManager;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.core.api.IRepresentationInput;
+import org.eclipse.sirius.components.events.ICause;
 import org.eclipse.sirius.components.representations.IRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,9 +56,9 @@ public class HierarchyEventProcessor implements IHierarchyEventProcessor {
     }
 
     @Override
-    public void update(IInput input, Hierarchy hierarchy) {
+    public void update(ICause cause, Hierarchy hierarchy) {
         this.hierarchyContext = new HierarchyContext(hierarchy);
-        this.hierarchyEventFlux.hierarchyRefreshed(input, hierarchy);
+        this.hierarchyEventFlux.hierarchyRefreshed(cause, hierarchy);
     }
 
     @Override

--- a/packages/charts/backend/sirius-components-collaborative-charts/src/main/java/org/eclipse/sirius/components/collaborative/charts/HierarchyRefresher.java
+++ b/packages/charts/backend/sirius-components-collaborative-charts/src/main/java/org/eclipse/sirius/components/collaborative/charts/HierarchyRefresher.java
@@ -84,12 +84,12 @@ public class HierarchyRefresher implements IRepresentationRefresher {
                     var object = optionalObject.get();
 
                     var refreshedHierarchy = this.hierarchyCreationService.create(editingContext, hierarchyDescription, object, new HierarchyContext(existingHierarchy));
-                    this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getInput(), editingContext, refreshedHierarchy);
-                    hierarchyEventProcessor.update(changeDescription.getInput(), refreshedHierarchy);
+                    this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getCause(), editingContext, refreshedHierarchy);
+                    hierarchyEventProcessor.update(changeDescription.getCause(), refreshedHierarchy);
                 }
             } else if (this.isReloadRefresh(changeDescription, existingHierarchy)) {
                 this.representationSearchService.findById(editingContext, existingHierarchy.getId(), Hierarchy.class)
-                        .ifPresent(hierarchy -> hierarchyEventProcessor.update(changeDescription.getInput(), hierarchy));
+                        .ifPresent(hierarchy -> hierarchyEventProcessor.update(changeDescription.getCause(), hierarchy));
             }
         }
     }

--- a/packages/charts/backend/sirius-components-collaborative-charts/src/main/java/org/eclipse/sirius/components/collaborative/charts/IHierarchyEventProcessor.java
+++ b/packages/charts/backend/sirius-components-collaborative-charts/src/main/java/org/eclipse/sirius/components/collaborative/charts/IHierarchyEventProcessor.java
@@ -14,7 +14,7 @@ package org.eclipse.sirius.components.collaborative.charts;
 
 import org.eclipse.sirius.components.charts.hierarchy.Hierarchy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessor;
-import org.eclipse.sirius.components.core.api.IInput;
+import org.eclipse.sirius.components.events.ICause;
 
 /**
  * Interface implemented by the hierarchy event processor.
@@ -26,11 +26,11 @@ public interface IHierarchyEventProcessor extends IRepresentationEventProcessor 
     /**
      * Used to update the state of the representation event processor.
      *
-     * @param input The input which has caused the update
+     * @param cause The cause of the update
      * @param hierarchy The new version of the representation
      *
      * @technical-debt This API should not be considered stable for the moment, it is still being evaluated against the
      * various use cases of our event processors
      */
-    void update(IInput input, Hierarchy hierarchy);
+    void update(ICause cause, Hierarchy hierarchy);
 }

--- a/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/api/ChangeDescription.java
+++ b/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/api/ChangeDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Obeo.
+ * Copyright (c) 2021, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import org.eclipse.sirius.components.core.api.IInput;
+import org.eclipse.sirius.components.events.ICause;
 
 /**
  * The change description is used to express the changes that have been performed in response to an input in the
@@ -32,18 +32,18 @@ public class ChangeDescription {
 
     private final String sourceId;
 
-    private final IInput input;
+    private final ICause cause;
 
     private final Map<String, Object> parameters;
 
-    public ChangeDescription(String kind, String sourceId, IInput input) {
-        this(kind, sourceId, input, new HashMap<>());
+    public ChangeDescription(String kind, String sourceId, ICause cause) {
+        this(kind, sourceId, cause, new HashMap<>());
     }
 
-    public ChangeDescription(String kind, String sourceId, IInput input, Map<String, Object> parameters) {
+    public ChangeDescription(String kind, String sourceId, ICause cause, Map<String, Object> parameters) {
         this.kind = Objects.requireNonNull(kind);
         this.sourceId = Objects.requireNonNull(sourceId);
-        this.input = Objects.requireNonNull(input);
+        this.cause = Objects.requireNonNull(cause);
         this.parameters = Objects.requireNonNull(parameters);
     }
 
@@ -55,8 +55,8 @@ public class ChangeDescription {
         return this.sourceId;
     }
 
-    public IInput getInput() {
-        return this.input;
+    public ICause getCause() {
+        return this.cause;
     }
 
     public Map<String, Object> getParameters() {

--- a/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/ChangeDescriptionPublisher.java
+++ b/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/ChangeDescriptionPublisher.java
@@ -22,8 +22,8 @@ import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.collaborative.dto.RepresentationRenamedEventPayload;
 import org.eclipse.sirius.components.collaborative.editingcontext.api.IChangeDescriptionConsumer;
 import org.eclipse.sirius.components.core.api.IEditingContext;
-import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.events.ICause;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -44,8 +44,8 @@ public class ChangeDescriptionPublisher implements IChangeDescriptionConsumer {
     @Override
     public void preAccept(Sinks.Many<IPayload> payloadSink, Sinks.Many<Boolean> canBeDisposedSink, IEditingContext editingContext, ChangeDescription changeDescription) {
         if (payloadSink.currentSubscriberCount() > 0) {
-            IInput input = changeDescription.getInput();
-            UUID correlationId = input.id();
+            ICause cause = changeDescription.getCause();
+            UUID correlationId = cause.id();
 
             if (ChangeKind.REPRESENTATION_RENAMING.equals(changeDescription.getKind()) && !changeDescription.getParameters().isEmpty()) {
                 Map<String, Object> parameters = changeDescription.getParameters();

--- a/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessorCleaner.java
+++ b/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessorCleaner.java
@@ -61,7 +61,7 @@ public class EditingContextEventProcessorCleaner implements IChangeDescriptionCo
         this.disposeDeletedRepresentations(canBeDisposedSink, editingContext, changeDescription);
         this.disposeDanglingRepresentations(canBeDisposedSink, editingContext);
 
-        this.danglingRepresentationDeletionService.deleteDanglingRepresentations(changeDescription.getInput(), editingContext);
+        this.danglingRepresentationDeletionService.deleteDanglingRepresentations(changeDescription.getCause(), editingContext);
     }
 
     private void disposeDeletedRepresentations(Sinks.Many<Boolean> canBeDisposedSink, IEditingContext editingContext, ChangeDescription changeDescription) {

--- a/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextSaver.java
+++ b/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextSaver.java
@@ -42,7 +42,7 @@ public class EditingContextSaver implements IChangeDescriptionConsumer {
     @Override
     public void postAccept(Sinks.Many<IPayload> payloadSink, Sinks.Many<Boolean> canBeDisposedSink, IEditingContext editingContext, ChangeDescription changeDescription) {
         if (ChangeKind.SEMANTIC_CHANGE.equals(changeDescription.getKind())) {
-            this.editingContextPersistenceService.persist(changeDescription.getInput(), editingContext);
+            this.editingContextPersistenceService.persist(changeDescription.getCause(), editingContext);
         }
     }
 }

--- a/packages/deck/backend/sirius-components-collaborative-deck/src/main/java/org/eclipse/sirius/components/collaborative/deck/DeckEventFlux.java
+++ b/packages/deck/backend/sirius-components-collaborative-deck/src/main/java/org/eclipse/sirius/components/collaborative/deck/DeckEventFlux.java
@@ -18,6 +18,7 @@ import org.eclipse.sirius.components.collaborative.deck.dto.DeckRefreshedEventPa
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.deck.Deck;
+import org.eclipse.sirius.components.events.ICause;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,10 +45,10 @@ public class DeckEventFlux {
         this.currentDeck = Objects.requireNonNull(currentDeck);
     }
 
-    public void deckRefreshed(IInput input, Deck newDeck) {
+    public void deckRefreshed(ICause cause, Deck newDeck) {
         this.currentDeck = newDeck;
         if (this.sink.currentSubscriberCount() > 0) {
-            EmitResult emitResult = this.sink.tryEmitNext(new DeckRefreshedEventPayload(input.id(), this.currentDeck));
+            EmitResult emitResult = this.sink.tryEmitNext(new DeckRefreshedEventPayload(cause.id(), this.currentDeck));
             if (emitResult.isFailure()) {
                 this.logger.atWarn()
                         .setMessage("An error has occurred while emitting a DeckRefreshedEventPayload: {}")

--- a/packages/deck/backend/sirius-components-collaborative-deck/src/main/java/org/eclipse/sirius/components/collaborative/deck/DeckEventProcessor.java
+++ b/packages/deck/backend/sirius-components-collaborative-deck/src/main/java/org/eclipse/sirius/components/collaborative/deck/DeckEventProcessor.java
@@ -126,18 +126,18 @@ public class DeckEventProcessor implements IDeckEventProcessor {
             Deck refreshedDeckRepresentation = this.deckCreationService.refresh(this.editingContext, this.deckContext).orElse(null);
             this.deckContext = new DeckContext(refreshedDeckRepresentation, new ArrayList<>());
             if (refreshedDeckRepresentation != null) {
-                this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getInput(), this.editingContext, refreshedDeckRepresentation);
+                this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getCause(), this.editingContext, refreshedDeckRepresentation);
                 this.logger.atTrace()
                         .setMessage("Deck refreshed: {}")
                         .addArgument(refreshedDeckRepresentation.getId())
                         .log();
             }
-            this.deckEventFlux.deckRefreshed(changeDescription.getInput(), this.deckContext.deck());
+            this.deckEventFlux.deckRefreshed(changeDescription.getCause(), this.deckContext.deck());
         } else if (changeDescription.getKind().equals(ChangeKind.RELOAD_REPRESENTATION) && changeDescription.getSourceId().equals(this.deckContext.deck().getId())) {
             Optional<Deck> optionalReloadedDeck = this.representationSearchService.findById(this.editingContext, this.deckContext.deck().getId(), Deck.class);
             if (optionalReloadedDeck.isPresent()) {
                 this.deckContext = new DeckContext(optionalReloadedDeck.get(), new ArrayList<>());
-                this.deckEventFlux.deckRefreshed(changeDescription.getInput(), this.deckContext.deck());
+                this.deckEventFlux.deckRefreshed(changeDescription.getCause(), this.deckContext.deck());
             }
         }
     }

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramEventProcessor.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramEventProcessor.java
@@ -40,6 +40,7 @@ import org.eclipse.sirius.components.core.api.IRepresentationInput;
 import org.eclipse.sirius.components.core.api.SuccessPayload;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.components.events.ICause;
 import org.eclipse.sirius.components.representations.IRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,7 +173,7 @@ public class DiagramEventProcessor implements IDiagramEventProcessor {
         if (this.shouldRefresh(changeDescription)) {
             this.diagramEventConsumers.forEach(consumer -> consumer.accept(this.editingContext, this.diagramContext.diagram(), this.diagramContext.diagramEvents(), this.diagramContext.viewDeletionRequests(), this.diagramContext.viewCreationRequests(), changeDescription));
             Diagram refreshedDiagram = this.diagramCreationService.refresh(this.editingContext, this.diagramContext).orElse(null);
-            this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getInput(), this.editingContext, refreshedDiagram);
+            this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getCause(), this.editingContext, refreshedDiagram);
 
             if (refreshedDiagram != null) {
                 this.logger.atTrace()
@@ -182,29 +183,29 @@ public class DiagramEventProcessor implements IDiagramEventProcessor {
             }
 
             this.diagramContext = new DiagramContext(refreshedDiagram);
-            this.currentRevisionId = changeDescription.getInput().id();
+            this.currentRevisionId = changeDescription.getCause().id();
             this.currentRevisionCause = DiagramRefreshedEventPayload.CAUSE_REFRESH;
 
-            ReferencePosition referencePosition = this.getReferencePosition(changeDescription.getInput());
-            this.diagramEventFlux.diagramRefreshed(changeDescription.getInput().id(), refreshedDiagram, DiagramRefreshedEventPayload.CAUSE_REFRESH, referencePosition);
+            ReferencePosition referencePosition = this.getReferencePosition(changeDescription.getCause());
+            this.diagramEventFlux.diagramRefreshed(changeDescription.getCause().id(), refreshedDiagram, DiagramRefreshedEventPayload.CAUSE_REFRESH, referencePosition);
         } else if (changeDescription.getKind().equals(ChangeKind.RELOAD_REPRESENTATION) && changeDescription.getSourceId().equals(this.diagramContext.diagram().getId())) {
             Optional<Diagram> optionalReloadedDiagram = this.representationSearchService.findById(this.editingContext, this.diagramContext.diagram().getId(), Diagram.class);
             if (optionalReloadedDiagram.isPresent()) {
                 var reloadedDiagram = optionalReloadedDiagram.get();
                 this.diagramContext = new DiagramContext(reloadedDiagram);
-                this.currentRevisionId = changeDescription.getInput().id();
+                this.currentRevisionId = changeDescription.getCause().id();
                 this.currentRevisionCause = DiagramRefreshedEventPayload.CAUSE_LAYOUT;
-                ReferencePosition referencePosition = this.getReferencePosition(changeDescription.getInput());
-                this.diagramEventFlux.diagramRefreshed(changeDescription.getInput().id(), reloadedDiagram, DiagramRefreshedEventPayload.CAUSE_LAYOUT, referencePosition);
+                ReferencePosition referencePosition = this.getReferencePosition(changeDescription.getCause());
+                this.diagramEventFlux.diagramRefreshed(changeDescription.getCause().id(), reloadedDiagram, DiagramRefreshedEventPayload.CAUSE_LAYOUT, referencePosition);
             }
         }
     }
 
-    private ReferencePosition getReferencePosition(IInput diagramInput) {
+    private ReferencePosition getReferencePosition(ICause cause) {
         return this.diagramInputReferencePositionProviders.stream()
-                .filter(handler -> handler.canHandle(diagramInput))
+                .filter(handler -> handler.canHandle(cause))
                 .findFirst()
-                .map(provider -> provider.getReferencePosition(diagramInput, this.diagramContext))
+                .map(provider -> provider.getReferencePosition(cause, this.diagramContext))
                 .orElse(null);
     }
 

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/api/IDiagramInputReferencePositionProvider.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/api/IDiagramInputReferencePositionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Obeo.
+ * Copyright (c) 2023, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ package org.eclipse.sirius.components.collaborative.diagrams.api;
 
 import org.eclipse.sirius.components.collaborative.diagrams.DiagramContext;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.ReferencePosition;
-import org.eclipse.sirius.components.core.api.IInput;
+import org.eclipse.sirius.components.events.ICause;
 
 /**
  * Provides diagram input reference position for a diagram.
@@ -23,7 +23,7 @@ import org.eclipse.sirius.components.core.api.IInput;
  */
 public interface IDiagramInputReferencePositionProvider {
 
-    boolean canHandle(IInput diagramInput);
+    boolean canHandle(ICause cause);
 
-    ReferencePosition getReferencePosition(IInput diagramInput, DiagramContext diagramContext);
+    ReferencePosition getReferencePosition(ICause cause, DiagramContext diagramContext);
 }

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/InvokeSingleClickOnDiagramElementToolEventHandler.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/InvokeSingleClickOnDiagramElementToolEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 Obeo.
+ * Copyright (c) 2019, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/providers/GenericDiagramToolReferencePositionProvider.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/providers/GenericDiagramToolReferencePositionProvider.java
@@ -25,6 +25,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.dto.ReconnectEdgeInp
 import org.eclipse.sirius.components.collaborative.diagrams.dto.ReferencePosition;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.diagrams.layoutdata.Position;
+import org.eclipse.sirius.components.events.ICause;
 import org.springframework.stereotype.Service;
 
 /**
@@ -45,24 +46,23 @@ public class GenericDiagramToolReferencePositionProvider implements IDiagramInpu
     );
 
     @Override
-    public boolean canHandle(IInput input) {
-        return HANDLED_INPUT_TYPES.stream().anyMatch(type -> type.isInstance(input));
-
+    public boolean canHandle(ICause cause) {
+        return HANDLED_INPUT_TYPES.stream().anyMatch(type -> type.isInstance(cause));
     }
 
     @Override
-    public ReferencePosition getReferencePosition(IInput diagramInput, DiagramContext diagramContext) {
+    public ReferencePosition getReferencePosition(ICause cause, DiagramContext diagramContext) {
         ReferencePosition referencePosition = null;
 
-        if (diagramInput instanceof InvokeSingleClickOnDiagramElementToolInput input) {
+        if (cause instanceof InvokeSingleClickOnDiagramElementToolInput input) {
             referencePosition = this.handleInvokeSingleClickOnDiagramElement(input, diagramContext);
-        } else if (diagramInput instanceof DropNodesInput input) {
+        } else if (cause instanceof DropNodesInput input) {
             referencePosition = this.handleDropNodes(input);
-        } else if (diagramInput instanceof DropOnDiagramInput input) {
+        } else if (cause instanceof DropOnDiagramInput input) {
             referencePosition = this.handleDropOnDiagram(input, diagramContext);
-        } else if (diagramInput instanceof InvokeSingleClickOnTwoDiagramElementsToolInput input) {
+        } else if (cause instanceof InvokeSingleClickOnTwoDiagramElementsToolInput input) {
             referencePosition = this.handleInvokeSingleClickOnTwoDiagramElements(input);
-        } else if (diagramInput instanceof ReconnectEdgeInput input) {
+        } else if (cause instanceof ReconnectEdgeInput input) {
             referencePosition = this.handleReconnectEdge(input);
         }
 

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/FormDescriptionEditorEventFlux.java
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/FormDescriptionEditorEventFlux.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import org.eclipse.sirius.components.collaborative.formdescriptioneditors.dto.FormDescriptionEditorRefreshedEventPayload;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.events.ICause;
 import org.eclipse.sirius.components.formdescriptioneditors.FormDescriptionEditor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,10 +45,10 @@ public class FormDescriptionEditorEventFlux {
         this.currentFormDescriptionEditor = Objects.requireNonNull(currentFormDescriptionEditor);
     }
 
-    public void formDescriptionEditorRefreshed(IInput input, FormDescriptionEditor newFormDescriptionEditor) {
+    public void formDescriptionEditorRefreshed(ICause cause, FormDescriptionEditor newFormDescriptionEditor) {
         this.currentFormDescriptionEditor = newFormDescriptionEditor;
         if (this.sink.currentSubscriberCount() > 0) {
-            EmitResult emitResult = this.sink.tryEmitNext(new FormDescriptionEditorRefreshedEventPayload(input.id(), this.currentFormDescriptionEditor));
+            EmitResult emitResult = this.sink.tryEmitNext(new FormDescriptionEditorRefreshedEventPayload(cause.id(), this.currentFormDescriptionEditor));
             if (emitResult.isFailure()) {
                 this.logger.atWarn()
                         .setMessage("An error has occurred while emitting a FormDescriptionEditorRefreshedEventPayload: {}")

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/FormDescriptionEditorEventProcessor.java
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/FormDescriptionEditorEventProcessor.java
@@ -140,7 +140,7 @@ public class FormDescriptionEditorEventProcessor implements IFormDescriptionEdit
                         .log();
 
                 this.formDescriptionEditorContext.update(refreshedFormDescriptionEditor);
-                this.formDescriptionEditorEventFlux.formDescriptionEditorRefreshed(changeDescription.getInput(), refreshedFormDescriptionEditor);
+                this.formDescriptionEditorEventFlux.formDescriptionEditorRefreshed(changeDescription.getCause(), refreshedFormDescriptionEditor);
             }
         }
     }

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/FormEventProcessor.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/FormEventProcessor.java
@@ -254,7 +254,7 @@ public class FormEventProcessor implements IFormEventProcessor {
 
     private void emitNewForm(ChangeDescription changeDescription) {
         if (this.sink.currentSubscriberCount() > 0) {
-            EmitResult emitResult = this.sink.tryEmitNext(new FormRefreshedEventPayload(changeDescription.getInput().id(), this.currentForm.get()));
+            EmitResult emitResult = this.sink.tryEmitNext(new FormRefreshedEventPayload(changeDescription.getCause().id(), this.currentForm.get()));
             if (emitResult.isFailure()) {
                 this.logger.atWarn()
                         .setMessage("An error has occurred while emitting a FormRefreshedEventPayload: {}")

--- a/packages/gantt/backend/sirius-components-collaborative-gantt/src/main/java/org/eclipse/sirius/components/collaborative/gantt/GanttEventFlux.java
+++ b/packages/gantt/backend/sirius-components-collaborative-gantt/src/main/java/org/eclipse/sirius/components/collaborative/gantt/GanttEventFlux.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import org.eclipse.sirius.components.collaborative.gantt.dto.GanttRefreshedEventPayload;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.events.ICause;
 import org.eclipse.sirius.components.gantt.Gantt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,10 +45,10 @@ public class GanttEventFlux {
         this.currentGantt = Objects.requireNonNull(currentGantt);
     }
 
-    public void ganttRefreshed(IInput input, Gantt newGantt) {
+    public void ganttRefreshed(ICause cause, Gantt newGantt) {
         this.currentGantt = newGantt;
         if (this.sink.currentSubscriberCount() > 0) {
-            EmitResult emitResult = this.sink.tryEmitNext(new GanttRefreshedEventPayload(input.id(), this.currentGantt));
+            EmitResult emitResult = this.sink.tryEmitNext(new GanttRefreshedEventPayload(cause.id(), this.currentGantt));
             if (emitResult.isFailure()) {
                 this.logger.atWarn()
                         .setMessage("An error has occurred while emitting a GanttRefreshedEventPayload: {}")

--- a/packages/gantt/backend/sirius-components-collaborative-gantt/src/main/java/org/eclipse/sirius/components/collaborative/gantt/GanttEventProcessor.java
+++ b/packages/gantt/backend/sirius-components-collaborative-gantt/src/main/java/org/eclipse/sirius/components/collaborative/gantt/GanttEventProcessor.java
@@ -128,7 +128,7 @@ public class GanttEventProcessor implements IGanttEventProcessor {
             this.ganttContext.update(refreshedGanttRepresentation);
 
             if (refreshedGanttRepresentation != null) {
-                this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getInput(), this.editingContext, refreshedGanttRepresentation);
+                this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getCause(), this.editingContext, refreshedGanttRepresentation);
                 this.logger.atTrace()
                         .setMessage("Gantt refreshed: {}")
                         .addArgument(ganttId)
@@ -140,12 +140,12 @@ public class GanttEventProcessor implements IGanttEventProcessor {
                         .log();
             }
 
-            this.ganttEventFlux.ganttRefreshed(changeDescription.getInput(), this.ganttContext.getGantt());
+            this.ganttEventFlux.ganttRefreshed(changeDescription.getCause(), this.ganttContext.getGantt());
         } else if (changeDescription.getKind().equals(ChangeKind.RELOAD_REPRESENTATION) && changeDescription.getSourceId().equals(this.ganttContext.getGantt().getId())) {
             Optional<Gantt> reloadedGantt = this.representationSearchService.findById(this.editingContext, this.ganttContext.getGantt().getId(), Gantt.class);
             if (reloadedGantt.isPresent()) {
                 this.ganttContext.update(reloadedGantt.get());
-                this.ganttEventFlux.ganttRefreshed(changeDescription.getInput(), this.ganttContext.getGantt());
+                this.ganttEventFlux.ganttRefreshed(changeDescription.getCause(), this.ganttContext.getGantt());
             }
         }
     }

--- a/packages/portals/backend/sirius-components-collaborative-portals/src/main/java/org/eclipse/sirius/components/collaborative/portals/PortalEventProcessor.java
+++ b/packages/portals/backend/sirius-components-collaborative-portals/src/main/java/org/eclipse/sirius/components/collaborative/portals/PortalEventProcessor.java
@@ -31,6 +31,7 @@ import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.core.api.IRepresentationInput;
+import org.eclipse.sirius.components.events.ICause;
 import org.eclipse.sirius.components.portals.Portal;
 import org.eclipse.sirius.components.representations.IRepresentation;
 import org.slf4j.Logger;
@@ -105,10 +106,10 @@ public class PortalEventProcessor implements IPortalEventProcessor {
         }
     }
 
-    private void updatePortal(IInput input, Portal newPortal) {
+    private void updatePortal(ICause cause, Portal newPortal) {
         this.currentPortal = newPortal;
-        this.representationPersistenceStrategy.applyPersistenceStrategy(input, this.editingContext, this.currentPortal);
-        this.emitNewPortal(input);
+        this.representationPersistenceStrategy.applyPersistenceStrategy(cause, this.editingContext, this.currentPortal);
+        this.emitNewPortal(cause);
     }
 
     @Override
@@ -121,7 +122,7 @@ public class PortalEventProcessor implements IPortalEventProcessor {
                     .orElse("");
             if (portalServices.referencesRepresentation(this.currentPortal, deletedRepresentationId)) {
                 var newPortal = portalServices.removeRepresentation(this.currentPortal, deletedRepresentationId);
-                this.updatePortal(changeDescription.getInput(), newPortal);
+                this.updatePortal(changeDescription.getCause(), newPortal);
             }
         } else if (changeDescription.getKind().equals(ChangeKind.REPRESENTATION_RENAMING)) {
             // Re-send the portal to all subscribers if one of the embedded representations has been renamed.
@@ -131,21 +132,21 @@ public class PortalEventProcessor implements IPortalEventProcessor {
                     .map(String.class::cast)
                     .orElse("");
             if (renamedRepresentationId.equals(this.currentPortal.getId()) || portalServices.referencesRepresentation(this.currentPortal, renamedRepresentationId)) {
-                this.emitNewPortal(changeDescription.getInput());
+                this.emitNewPortal(changeDescription.getCause());
             }
         } else if (changeDescription.getKind().equals(ChangeKind.RELOAD_REPRESENTATION) && changeDescription.getSourceId().equals(this.currentPortal.getId())) {
             Optional<Portal> reloadedPortal = this.representationSearchService.findById(this.editingContext, this.currentPortal.getId(), Portal.class);
             if (reloadedPortal.isPresent()) {
-                this.updatePortal(changeDescription.getInput(), reloadedPortal.get());
+                this.updatePortal(changeDescription.getCause(), reloadedPortal.get());
             }
         } else if (changeDescription.getSourceId().equals(this.currentPortal.getId()) && changeDescription.getParameters().get(IPortalEventHandler.NEXT_PORTAL_PARAMETER) instanceof Portal nextPortal) {
-            this.updatePortal(changeDescription.getInput(), nextPortal);
+            this.updatePortal(changeDescription.getCause(), nextPortal);
         }
     }
 
-    private void emitNewPortal(IInput input) {
+    private void emitNewPortal(ICause cause) {
         if (this.sink.currentSubscriberCount() > 0) {
-            EmitResult emitResult = this.sink.tryEmitNext(new PortalRefreshedEventPayload(input.id(), this.currentPortal));
+            EmitResult emitResult = this.sink.tryEmitNext(new PortalRefreshedEventPayload(cause.id(), this.currentPortal));
             if (emitResult.isFailure()) {
                 this.logger.atWarn()
                         .setMessage("An error has occurred while emitting a PortalRefreshedEventPayload: {}")

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DeleteFromDiagramChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DeleteFromDiagramChangeRecorder.java
@@ -76,7 +76,7 @@ public class DeleteFromDiagramChangeRecorder implements IDiagramEventConsumer {
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof InvokeSingleClickOnDiagramElementToolInput invokeSingleClickOnDiagramElementToolInput && (invokeSingleClickOnDiagramElementToolInput.toolId()
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof InvokeSingleClickOnDiagramElementToolInput invokeSingleClickOnDiagramElementToolInput && (invokeSingleClickOnDiagramElementToolInput.toolId()
                 .equals(DeleteOneDiagramElementToolHandler.DELETE_ELEMENT_TOOL_ID) || invokeSingleClickOnDiagramElementToolInput.toolId()
                 .equals(DeleteMultipleDiagramElementToolHandler.DELETE_ELEMENT_TOOL_ID))) {
             List<IAppearanceChange> undoAppearanceChanges = new ArrayList<>();

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramCollapseElementChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramCollapseElementChangeRecorder.java
@@ -40,7 +40,7 @@ public class DiagramCollapseElementChangeRecorder implements IDiagramEventConsum
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof IDiagramInput diagramInput) {
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             diagramEvents.stream()
                     .filter(UpdateCollapsingStateEvent.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramFadeElementChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramFadeElementChangeRecorder.java
@@ -39,7 +39,7 @@ public class DiagramFadeElementChangeRecorder implements IDiagramEventConsumer {
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof IDiagramInput diagramInput) {
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
             List<IRepresentationChange> representationChanges = new ArrayList<>();
 
             diagramEvents.stream()

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramHideElementChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramHideElementChangeRecorder.java
@@ -39,7 +39,7 @@ public class DiagramHideElementChangeRecorder implements IDiagramEventConsumer {
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof IDiagramInput diagramInput) {
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
             List<IRepresentationChange> representationChanges = new ArrayList<>();
 
             diagramEvents.stream()

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramLayoutChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramLayoutChangeRecorder.java
@@ -52,7 +52,7 @@ public class DiagramLayoutChangeRecorder implements IDiagramEventConsumer {
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof LayoutDiagramInput layoutDiagramInput) {
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof LayoutDiagramInput layoutDiagramInput) {
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             List<DiagramNodeLayoutEvent> undoNodeLayoutEvents = new ArrayList<>();
             List<DiagramNodeLayoutEvent> redoNodeLayoutEvents = new ArrayList<>();

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramPinElementChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramPinElementChangeRecorder.java
@@ -39,7 +39,7 @@ public class DiagramPinElementChangeRecorder implements IDiagramEventConsumer {
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof IDiagramInput diagramInput) {
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             diagramEvents.stream()
                     .filter(PinDiagramElementEvent.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramViewModifiersChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramViewModifiersChangeRecorder.java
@@ -51,7 +51,7 @@ public class DiagramViewModifiersChangeRecorder implements IDiagramEventConsumer
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof IDiagramInput diagramInput) {
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
             List<IRepresentationChange> representationChanges = new ArrayList<>();
 
             diagramEvents.stream()

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/EdgeAppearanceChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/EdgeAppearanceChangeRecorder.java
@@ -55,7 +55,7 @@ public class EdgeAppearanceChangeRecorder implements IDiagramEventConsumer {
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof IDiagramInput diagramInput) {
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             var editAppearanceChanges = diagramEvents.stream()
                     .filter(EditAppearanceEvent.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/LabelAppearanceChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/LabelAppearanceChangeRecorder.java
@@ -55,7 +55,7 @@ public class LabelAppearanceChangeRecorder implements IDiagramEventConsumer {
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof IDiagramInput diagramInput) {
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             var editAppearanceChanges = diagramEvents.stream()
                     .filter(EditAppearanceEvent.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/NodeAppearanceChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/NodeAppearanceChangeRecorder.java
@@ -56,7 +56,7 @@ public class NodeAppearanceChangeRecorder implements IDiagramEventConsumer {
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof IDiagramInput diagramInput) {
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             var editAppearanceChanges = diagramEvents.stream()
                     .filter(EditAppearanceEvent.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/ViewRequestChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/ViewRequestChangeRecorder.java
@@ -68,7 +68,7 @@ public class ViewRequestChangeRecorder implements IDiagramEventConsumer {
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getInput() instanceof IDiagramInput diagramInput) {
+        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
             List<ViewCreationRequest> undoViewCreationRequests = new ArrayList<>();
             List<ViewDeletionRequest> undoViewDeletionRequests = new ArrayList<>();
             List<ViewCreationRequest> redoViewCreationRequests = new ArrayList<>(viewCreationRequests);
@@ -118,7 +118,6 @@ public class ViewRequestChangeRecorder implements IDiagramEventConsumer {
                         var diagramHideElementChange = new DiagramHideElementChange(diagramInput.id(), diagramInput.representationId(), Set.of(previousNode.getId()), true, false);
                         representationChanges.add(diagramHideElementChange);
                     }
-
                     var previousNodeLayoutData = previousDiagram.getLayoutData().nodeLayoutData();
                     if (previousNodeLayoutData.containsKey(previousNode.getId())) {
                         var undoPositionEvent = new DiagramNodeLayoutEvent(previousNode.getId(), previousNodeLayoutData.get(previousNode.getId()));
@@ -142,7 +141,6 @@ public class ViewRequestChangeRecorder implements IDiagramEventConsumer {
                                     representationChanges.addAll(diagramLabelLayoutChange);
                                 }
                             });
-
                 }
                 var diagramNodeAppearanceChange = new DiagramNodeAppearanceChange(diagramInput.id(), diagramInput.representationId(), undoAppearanceChanges, List.of());
                 representationChanges.add(diagramNodeAppearanceChange);

--- a/packages/tables/backend/sirius-components-collaborative-tables/src/main/java/org/eclipse/sirius/components/collaborative/tables/TableEventProcessor.java
+++ b/packages/tables/backend/sirius-components-collaborative-tables/src/main/java/org/eclipse/sirius/components/collaborative/tables/TableEventProcessor.java
@@ -153,14 +153,14 @@ public class TableEventProcessor implements IRepresentationEventProcessor {
             this.tableContext.reset();
             this.tableContext.update(table);
             if (table != null) {
-                this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getInput(), this.tableCreationParameters.getEditingContext(), table);
+                this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getCause(), this.tableCreationParameters.getEditingContext(), table);
                 this.logger.atTrace()
                         .setMessage("Table refreshed: {}")
                         .addArgument(table.getId())
                         .log();
             }
             if (this.sink.currentSubscriberCount() > 0) {
-                EmitResult emitResult = this.sink.tryEmitNext(new TableRefreshedEventPayload(changeDescription.getInput().id(), table));
+                EmitResult emitResult = this.sink.tryEmitNext(new TableRefreshedEventPayload(changeDescription.getCause().id(), table));
                 if (emitResult.isFailure()) {
                     this.logger.atWarn()
                             .setMessage("An error has occurred while emitting a TableRefreshedEventPayload: {}")
@@ -177,7 +177,7 @@ public class TableEventProcessor implements IRepresentationEventProcessor {
                         .filter(String.class::isInstance)
                         .map(String.class::cast)
                         .ifPresent(newGlobalFilter -> {
-                            EmitResult emitResult = this.sink.tryEmitNext(new TableGlobalFilterValuePayload(changeDescription.getInput().id(), newGlobalFilter));
+                            EmitResult emitResult = this.sink.tryEmitNext(new TableGlobalFilterValuePayload(changeDescription.getCause().id(), newGlobalFilter));
                             if (emitResult.isFailure()) {
                                 this.logger.atWarn()
                                         .setMessage("An error has occurred while emitting a TableGlobalFilterValuePayload: {}")
@@ -192,7 +192,7 @@ public class TableEventProcessor implements IRepresentationEventProcessor {
                         .filter(List.class::isInstance)
                         .map(List.class::cast)
                         .ifPresent(newColumnFilters -> {
-                            EmitResult emitResult = this.sink.tryEmitNext(new TableColumnFilterPayload(changeDescription.getInput().id(), newColumnFilters));
+                            EmitResult emitResult = this.sink.tryEmitNext(new TableColumnFilterPayload(changeDescription.getCause().id(), newColumnFilters));
                             if (emitResult.isFailure()) {
                                 this.logger.atWarn()
                                         .setMessage("An error has occurred while emitting a TableColumnFilterPayload: {}")
@@ -207,7 +207,7 @@ public class TableEventProcessor implements IRepresentationEventProcessor {
                         .filter(List.class::isInstance)
                         .map(List.class::cast)
                         .ifPresent(newColumnSort -> {
-                            EmitResult emitResult = this.sink.tryEmitNext(new TableColumnSortPayload(changeDescription.getInput().id(), newColumnSort));
+                            EmitResult emitResult = this.sink.tryEmitNext(new TableColumnSortPayload(changeDescription.getCause().id(), newColumnSort));
                             if (emitResult.isFailure()) {
                                 this.logger.atWarn()
                                         .setMessage("An error has occurred while emitting a TableColumnSortPayload: {}")

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/TreeEventProcessor.java
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/main/java/org/eclipse/sirius/components/collaborative/trees/TreeEventProcessor.java
@@ -138,7 +138,7 @@ public class TreeEventProcessor implements ITreeEventProcessor {
 
             this.currentTree.set(tree);
             if (this.sink.currentSubscriberCount() > 0) {
-                EmitResult emitResult = this.sink.tryEmitNext(new TreeRefreshedEventPayload(changeDescription.getInput().id(), tree));
+                EmitResult emitResult = this.sink.tryEmitNext(new TreeRefreshedEventPayload(changeDescription.getCause().id(), tree));
                 if (emitResult.isFailure()) {
                     this.logger.atWarn()
                             .setMessage("An error has occurred while emitting a TreeRefreshedEventPayload: {}")

--- a/packages/validation/backend/sirius-components-collaborative-validation/src/main/java/org/eclipse/sirius/components/collaborative/validation/ValidationEventProcessor.java
+++ b/packages/validation/backend/sirius-components-collaborative-validation/src/main/java/org/eclipse/sirius/components/collaborative/validation/ValidationEventProcessor.java
@@ -130,7 +130,7 @@ public class ValidationEventProcessor implements IValidationEventProcessor {
 
             this.validationContext.update(validation);
             if (this.sink.currentSubscriberCount() > 0) {
-                EmitResult emitResult = this.sink.tryEmitNext(new ValidationRefreshedEventPayload(changeDescription.getInput().id(), validation));
+                EmitResult emitResult = this.sink.tryEmitNext(new ValidationRefreshedEventPayload(changeDescription.getCause().id(), validation));
                 if (emitResult.isFailure()) {
                     this.logger.atWarn()
                             .setMessage("An error has occurred while emitting a ValidationRefreshedEventPayload: {}")

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/messages/IViewEMFMessageService.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/messages/IViewEMFMessageService.java
@@ -109,6 +109,7 @@ public interface IViewEMFMessageService {
             return "";
         }
 
+        @Override
         public String defaultQuickToolAdjustSize() {
             return "";
         }

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/messages/ViewEMFMessageService.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/messages/ViewEMFMessageService.java
@@ -53,6 +53,7 @@ public class ViewEMFMessageService implements IViewEMFMessageService {
         return this.messageSourceAccessor.getMessage("CORE_PROPERTIES");
     }
 
+    @Override
     public String defaultQuickToolAdjustSize() {
         return this.messageSourceAccessor.getMessage("ADJUST_SIZE");
     }


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/6736
Signed-off-by: Gwendal Daniel <gwendal.daniel@obeosoft.com>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?