### PR TITLE
[6678] Add search feature to palette contributed tools

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -58,6 +58,9 @@ If no `IOmniboxCommandOrdererDelegate` is implemented, a default implementation 
 Add `searchedValue` prop to `PaletteToolOverriddenContributionComponentProps`
 Export fuzzyMatch function to filter a tool with the searchedValue.
 Use exported `ToolListItemText component` from the palette package to highlight the searched text in rendered contributions.
+- https://github.com/eclipse-sirius/sirius-web/issues/6678[#6678] [palette] Fix the search feature of the palette with tool contribution
+Add `searchedValue` prop to `PaletteToolContributionComponentProps`.
+Contributions have to return null in their component if they are not candidate of the search, you can do that using `searchedValue` and `fuzzyMatch function`
 
 === New Features
 
@@ -176,7 +179,6 @@ This is to make it easier to type when the area overlaps another elements.
 Added `asLastToolUsed` to `PaletteToolOverriddenContributionComponentProps` & `PaletteToolContributionComponentProps`
 Added `isToolInPalette` to `PaletteToolOverriddenContributionComponentProps`, this can be use to know if a tool rendered as the last tool used should be disabled because the precondition of the tool is false (and thus it's not in the palette of that element)
 - https://github.com/eclipse-sirius/sirius-web/issues/6655[#6655] [trees] Fix an issue where the Tree palette was rendered outside the workbench.
-
 
 === New Features
 

--- a/packages/palette/frontend/sirius-components-palette/src/extensions/PaletteToolContribution.types.ts
+++ b/packages/palette/frontend/sirius-components-palette/src/extensions/PaletteToolContribution.types.ts
@@ -28,4 +28,8 @@ export interface PaletteToolContributionComponentProps {
    * True if the tool is rendered as the last tool used, false otherwise.
    */
   asLastToolUsed: boolean;
+  /**
+   * Current text in the search field of the toolbar or null if nothing is being searched.
+   */
+  searchedValue: string | null;
 }

--- a/packages/palette/frontend/sirius-components-palette/src/index.ts
+++ b/packages/palette/frontend/sirius-components-palette/src/index.ts
@@ -46,6 +46,7 @@ export type {
 export { PaletteQuickAccessToolBar } from './quick-access-tool/PaletteQuickAccessToolBar';
 export { Tool } from './quick-access-tool/Tool';
 export { fuzzyMatch } from './search/fuzzyMatch';
+export { HighlightedLabel } from './search/HighlightedLabel';
 export { PaletteSearchField } from './search/PaletteSearchField';
 export { PaletteSearchResult } from './search/PaletteSearchResult';
 export { ToolListItem } from './tool-list-item/ToolListItem';

--- a/packages/palette/frontend/sirius-components-palette/src/search/PaletteSearchResult.tsx
+++ b/packages/palette/frontend/sirius-components-palette/src/search/PaletteSearchResult.tsx
@@ -17,11 +17,14 @@ import List from '@mui/material/List';
 import Typography from '@mui/material/Typography';
 import { useEffect, useMemo, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
+import { PaletteToolContributionProps } from '../extensions/PaletteToolContribution.types';
+import { paletteToolExtensionPoint } from '../extensions/PaletteToolExtensionPoints';
 import { PaletteToolOverriddenContributionProps } from '../extensions/PaletteToolOverrideContribution.types';
 import { paletteToolOverrideExtensionPoint } from '../extensions/PaletteToolOverrideExtensionPoints';
 import { isTool, isToolSection } from '../Palette';
 import { GQLPaletteEntry, GQLTool } from '../Palette.types';
 import { useTool } from '../tool-section/useTool';
+import { usePalette } from '../usePalette';
 import { fuzzyMatch } from './fuzzyMatch';
 import { PaletteSearchResultProps } from './PaletteSearchResult.types';
 
@@ -69,11 +72,11 @@ export const PaletteSearchResult = ({
 }: PaletteSearchResultProps) => {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const { getRenderedTool } = useTool();
+  const { setLastToolInvokedId } = usePalette();
   const { classes } = useStyle();
   const paletteToolOverriddenData: DataExtension<PaletteToolOverriddenContributionProps[]> = useData(
     paletteToolOverrideExtensionPoint
   );
-
   const toolList: GQLTool[] = useMemo(() => flatToolsFromPaletteEntries(palette.paletteEntries), [palette]);
   const filteredToolList: GQLTool[] = toolList.filter((tool) => {
     const overriddenTool = paletteToolOverriddenData.data.find((contributedTool) =>
@@ -86,6 +89,22 @@ export const PaletteSearchResult = ({
       return fuzzyMatch(tool.label, searchedValue).matches;
     }
   });
+
+  // Tools contributions
+  const paletteToolData: DataExtension<PaletteToolContributionProps[]> = useData(paletteToolExtensionPoint);
+  const filteredContributions: JSX.Element[] = paletteToolData.data
+    .filter((contributedTool) => contributedTool.canHandle(representationKind))
+    .map((contributedTool, index) => {
+      const ContributedComponent = contributedTool.component;
+      return (
+        <ContributedComponent
+          representationElementIds={representationElementIds}
+          key={`contribution_${index}`}
+          onInvoked={() => setLastToolInvokedId(palette.id, contributedTool.id)}
+          asLastToolUsed={false}
+          searchedValue={searchedValue}></ContributedComponent>
+      );
+    });
 
   useEffect(() => {
     const handleKeyDown = (event) => {
@@ -131,6 +150,7 @@ export const PaletteSearchResult = ({
         {filteredToolList.length > 0 ? (
           <List className={classes.toolList} component="nav">
             {filteredToolList.map(convertToListItem)}
+            {filteredContributions}
           </List>
         ) : (
           <Typography variant="body2" align="center">

--- a/packages/palette/frontend/sirius-components-palette/src/tool-section/PaletteToolSection.tsx
+++ b/packages/palette/frontend/sirius-components-palette/src/tool-section/PaletteToolSection.tsx
@@ -148,7 +148,8 @@ export const PaletteToolSection = ({
         <ContributedComponent
           representationElementIds={representationElementIds}
           onInvoked={() => setLastToolInvokedId(palette.id, contributedTool.id)}
-          asLastToolUsed={false}></ContributedComponent>
+          asLastToolUsed={false}
+          searchedValue={null}></ContributedComponent>
       );
     });
 

--- a/packages/palette/frontend/sirius-components-palette/src/tool-section/useTool.tsx
+++ b/packages/palette/frontend/sirius-components-palette/src/tool-section/useTool.tsx
@@ -123,7 +123,8 @@ export const useTool = (): useToolValue => {
         <ContributedComponent
           representationElementIds={representationElementIds}
           onInvoked={() => setLastToolInvokedId(palette.id, contributedTool.id)}
-          asLastToolUsed={asLastToolUsed}></ContributedComponent>
+          asLastToolUsed={asLastToolUsed}
+          searchedValue={searchedValue}></ContributedComponent>
       );
     }
     return null;

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/context-menu-contributions/delete/DeleteToolContribution.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/context-menu-contributions/delete/DeleteToolContribution.tsx
@@ -10,7 +10,11 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { PaletteToolContributionComponentProps } from '@eclipse-sirius/sirius-components-palette';
+import {
+  fuzzyMatch,
+  HighlightedLabel,
+  PaletteToolContributionComponentProps,
+} from '@eclipse-sirius/sirius-components-palette';
 import { TreePaletteContext, TreePaletteContextValue } from '@eclipse-sirius/sirius-components-trees';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -20,7 +24,7 @@ import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDelete } from './useDelete';
 
-export const DeleteToolContribution = ({ onInvoked }: PaletteToolContributionComponentProps) => {
+export const DeleteToolContribution = ({ onInvoked, searchedValue }: PaletteToolContributionComponentProps) => {
   const { handleDelete } = useDelete();
   const { editingContextId, item, treeId, readOnly } = useContext<TreePaletteContextValue>(TreePaletteContext);
 
@@ -37,12 +41,21 @@ export const DeleteToolContribution = ({ onInvoked }: PaletteToolContributionCom
     deleteTreeItem();
   };
 
+  const matchResult = searchedValue ? fuzzyMatch(t('delete'), searchedValue) : null;
+  if (!!searchedValue && !matchResult?.matches) {
+    return null;
+  }
+
   return (
     <MenuItem key="delete-tree-item" onClick={handleClick} data-testid="delete" disabled={readOnly}>
       <ListItemIcon>
         <DeleteIcon fontSize="small" />
       </ListItemIcon>
-      <ListItemText primary={t('delete')} />
+      {matchResult ? (
+        <HighlightedLabel label={t('delete')} textIndicesToHighlight={matchResult.matchingIndices} />
+      ) : (
+        <ListItemText primary={t('delete')} />
+      )}
     </MenuItem>
   );
 };

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/context-menu-contributions/edit/DirectEditToolContribution.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/context-menu-contributions/edit/DirectEditToolContribution.tsx
@@ -10,7 +10,11 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { PaletteToolContributionComponentProps } from '@eclipse-sirius/sirius-components-palette';
+import {
+  fuzzyMatch,
+  HighlightedLabel,
+  PaletteToolContributionComponentProps,
+} from '@eclipse-sirius/sirius-components-palette';
 import { TreePaletteContext, TreePaletteContextValue } from '@eclipse-sirius/sirius-components-trees';
 import EditIcon from '@mui/icons-material/Edit';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -19,7 +23,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export const DirectEditToolContribution = ({ onInvoked }: PaletteToolContributionComponentProps) => {
+export const DirectEditToolContribution = ({ onInvoked, searchedValue }: PaletteToolContributionComponentProps) => {
   const { t } = useTranslation('sirius-components-trees', { keyPrefix: 'renameMenuItem' });
   const { item, readOnly, onDirectEditClick } = useContext<TreePaletteContextValue>(TreePaletteContext);
 
@@ -32,12 +36,21 @@ export const DirectEditToolContribution = ({ onInvoked }: PaletteToolContributio
     onDirectEditClick();
   };
 
+  const matchResult = searchedValue ? fuzzyMatch(t('rename'), searchedValue) : null;
+  if (!!searchedValue && !matchResult?.matches) {
+    return null;
+  }
+
   return (
     <MenuItem key="rename" onClick={handleClick} data-testid="rename-tree-item" disabled={readOnly}>
       <ListItemIcon>
         <EditIcon fontSize="small" />
       </ListItemIcon>
-      <ListItemText primary={t('rename')} />
+      {matchResult ? (
+        <HighlightedLabel label={t('rename')} textIndicesToHighlight={matchResult.matchingIndices} />
+      ) : (
+        <ListItemText primary={t('rename')} />
+      )}
     </MenuItem>
   );
 };

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/palette-contributions/delete/DeleteToolContribution.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/palette-contributions/delete/DeleteToolContribution.tsx
@@ -10,7 +10,11 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { PaletteToolContributionComponentProps } from '@eclipse-sirius/sirius-components-palette';
+import {
+  fuzzyMatch,
+  HighlightedLabel,
+  PaletteToolContributionComponentProps,
+} from '@eclipse-sirius/sirius-components-palette';
 import { TreePaletteContext, TreePaletteContextValue } from '@eclipse-sirius/sirius-components-trees';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -40,7 +44,7 @@ const useStyle = makeStyles()((theme) => ({
   },
 }));
 
-export const DeleteToolContribution = ({ onInvoked }: PaletteToolContributionComponentProps) => {
+export const DeleteToolContribution = ({ onInvoked, searchedValue }: PaletteToolContributionComponentProps) => {
   const { handleDelete } = useDelete();
   const { editingContextId, item, treeId, readOnly } = useContext<TreePaletteContextValue>(TreePaletteContext);
 
@@ -58,6 +62,11 @@ export const DeleteToolContribution = ({ onInvoked }: PaletteToolContributionCom
     deleteTreeItem();
   };
 
+  const matchResult = searchedValue ? fuzzyMatch(t('delete'), searchedValue) : null;
+  if (!!searchedValue && !matchResult?.matches) {
+    return null;
+  }
+
   return (
     <Tooltip title={t('delete')} placement="right">
       <ListItemButton
@@ -68,7 +77,11 @@ export const DeleteToolContribution = ({ onInvoked }: PaletteToolContributionCom
         <ListItemIcon className={classes.listItemIcon}>
           <DeleteIcon />
         </ListItemIcon>
-        <ListItemText primary={t('delete')} className={classes.listItemText} />
+        {matchResult ? (
+          <HighlightedLabel label={t('delete')} textIndicesToHighlight={matchResult.matchingIndices} />
+        ) : (
+          <ListItemText primary={t('delete')} className={classes.listItemText} />
+        )}
       </ListItemButton>
     </Tooltip>
   );

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/palette-contributions/edit/DirectEditToolContribution.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/palette-contributions/edit/DirectEditToolContribution.tsx
@@ -10,7 +10,11 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { PaletteToolContributionComponentProps } from '@eclipse-sirius/sirius-components-palette';
+import {
+  fuzzyMatch,
+  HighlightedLabel,
+  PaletteToolContributionComponentProps,
+} from '@eclipse-sirius/sirius-components-palette';
 import { TreePaletteContext, TreePaletteContextValue } from '@eclipse-sirius/sirius-components-trees';
 import EditIcon from '@mui/icons-material/Edit';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -39,7 +43,7 @@ const useStyle = makeStyles()((theme) => ({
   },
 }));
 
-export const DirectEditToolContribution = ({ onInvoked }: PaletteToolContributionComponentProps) => {
+export const DirectEditToolContribution = ({ onInvoked, searchedValue }: PaletteToolContributionComponentProps) => {
   const { t } = useTranslation('sirius-components-trees', { keyPrefix: 'renameMenuItem' });
   const { item, readOnly, onDirectEditClick } = useContext<TreePaletteContextValue>(TreePaletteContext);
   const { classes } = useStyle();
@@ -53,6 +57,11 @@ export const DirectEditToolContribution = ({ onInvoked }: PaletteToolContributio
     onDirectEditClick();
   };
 
+  const matchResult = searchedValue ? fuzzyMatch(t('rename'), searchedValue) : null;
+  if (!!searchedValue && !matchResult?.matches) {
+    return null;
+  }
+
   return (
     <Tooltip title={t('rename')} placement="right">
       <ListItemButton
@@ -63,7 +72,11 @@ export const DirectEditToolContribution = ({ onInvoked }: PaletteToolContributio
         <ListItemIcon className={classes.listItemIcon}>
           <EditIcon />
         </ListItemIcon>
-        <ListItemText primary={t('rename')} className={classes.listItemText} />
+        {matchResult ? (
+          <HighlightedLabel label={t('rename')} textIndicesToHighlight={matchResult.matchingIndices} />
+        ) : (
+          <ListItemText primary={t('rename')} className={classes.listItemText} />
+        )}
       </ListItemButton>
     </Tooltip>
   );

--- a/packages/sirius-web/frontend/sirius-web-view-fork/src/contributions/ForkToolContribution.tsx
+++ b/packages/sirius-web/frontend/sirius-web-view-fork/src/contributions/ForkToolContribution.tsx
@@ -12,7 +12,11 @@
  *******************************************************************************/
 import { gql, useMutation } from '@apollo/client';
 import { useMultiToast } from '@eclipse-sirius/sirius-components-core';
-import { PaletteToolContributionComponentProps } from '@eclipse-sirius/sirius-components-palette';
+import {
+  fuzzyMatch,
+  HighlightedLabel,
+  PaletteToolContributionComponentProps,
+} from '@eclipse-sirius/sirius-components-palette';
 import { TreePaletteContext, TreePaletteContextValue } from '@eclipse-sirius/sirius-components-trees';
 import EditNoteIcon from '@mui/icons-material/EditNote';
 import Button from '@mui/material/Button';
@@ -52,6 +56,8 @@ const forkViewMutation = gql`
   }
 `;
 
+const toolLabel = 'Fork View Model';
+
 const isErrorPayload = (payload: CreateForkedStudioPayload): payload is GQLErrorPayload =>
   payload.__typename === 'ErrorPayload';
 
@@ -59,7 +65,7 @@ const isSuccessPayload = (payload: CreateForkedStudioPayload): payload is Create
   payload.__typename === 'CreateProjectSuccessPayload';
 
 export const ForkToolContribution = forwardRef(
-  ({ onInvoked }: PaletteToolContributionComponentProps, ref: React.ForwardedRef<HTMLLIElement>) => {
+  ({ onInvoked, searchedValue }: PaletteToolContributionComponentProps, ref: React.ForwardedRef<HTMLLIElement>) => {
     const { editingContextId, item, readOnly } = useContext<TreePaletteContextValue>(TreePaletteContext);
 
     const [createProject, { data, error }] = useMutation<GQLCreateForkedStudioMutationData>(forkViewMutation);
@@ -101,6 +107,11 @@ export const ForkToolContribution = forwardRef(
       }
     }
 
+    const matchResult = searchedValue ? fuzzyMatch(toolLabel, searchedValue) : null;
+    if (!!searchedValue && !matchResult?.matches) {
+      return null;
+    }
+
     const forkViewMutationHandler = () => {
       const input: GQLCreateForkedStudioInput = {
         id: crypto.randomUUID(),
@@ -122,7 +133,11 @@ export const ForkToolContribution = forwardRef(
           <ListItemIcon>
             <EditNoteIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>Fork View Model</ListItemText>
+          {matchResult ? (
+            <HighlightedLabel label={toolLabel} textIndicesToHighlight={matchResult.matchingIndices} />
+          ) : (
+            <ListItemText primary={toolLabel} />
+          )}
         </MenuItem>
         {state.isOpen ? (
           <Dialog


### PR DESCRIPTION
This is a re-publication of https://github.com/eclipse-sirius/sirius-web/pull/6679 after I messed up.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/6678
Signed-off-by: Michaël Charfadi <michael.charfadi@obeosoft.com>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?