### PR TITLE
[6751] Introduce ICausalityChainVisitor to navigate causality chains

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -126,6 +126,8 @@ It has long been unused by Sirius Web itself (since the transition to MUI).
 - https://github.com/eclipse-sirius/sirius-web/issues/2928[#2928] [diagram] `ConnectionCreationHandles` now needs the node current position, width,  height and isDraggedNode props
 - https://github.com/eclipse-sirius/sirius-web/issues/6612[#6612] [core] `index.html` is not cached anymore.
 - https://github.com/eclipse-sirius/sirius-web/issues/6591[#6591] [diagram] added `representationKind` to `canHandle` methods of the `Palette` frontend extensions points, exported `DIAGRAM_REPRESENTATION_KIND` variable from the diagram package, `paletteQuickToolExtensionPoint` is now a `DataExtensionPoint` with a `canHandle` method
+- https://github.com/eclipse-sirius/sirius-web/issues/6751[#6751] [core] Existing code inspecting causes (via `cause.causedBy()`) should now rely on
+`ICausalityChainVisitor#findFirstCauseOfType`, which allows to navigate causality chains in a generic way.
 
 
 === Dependency update
@@ -193,6 +195,7 @@ The documentation can be built using `./doc/generate-local.bash`
 - https://github.com/eclipse-sirius/sirius-web/issues/6544[#6544] [tree] Leverage the Palette used by the diagram on the explorer.
 Use the configuration property `sirius.web.tree.new-palette.enabled` to temporary switch back to the old context menu.
 This configuration property will be removed soon once the migration to the palette will be completed.
+- https://github.com/eclipse-sirius/sirius-web/issues/6751[#6751] [core] Introduce `ICausalityChainVisitor` to navigate causality chains
 
 
 === Improvements

--- a/packages/core/backend/sirius-components-core/src/main/java/org/eclipse/sirius/components/core/api/ICausalityChainVisitor.java
+++ b/packages/core/backend/sirius-components-core/src/main/java/org/eclipse/sirius/components/core/api/ICausalityChainVisitor.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.core.api;
+
+import java.util.Optional;
+
+import org.eclipse.sirius.components.events.ICause;
+
+/**
+ * Provides helper methods to manipulate causality chains.
+ *
+ * @author gdaniel
+ */
+public interface ICausalityChainVisitor {
+
+    <T extends ICause> Optional<T> findFirstCauseOfType(ICause cause, Class<T> type);
+}

--- a/packages/core/backend/sirius-components-core/src/main/java/org/eclipse/sirius/components/core/services/CausalityChainVisitor.java
+++ b/packages/core/backend/sirius-components-core/src/main/java/org/eclipse/sirius/components/core/services/CausalityChainVisitor.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.core.services;
+
+import java.util.Optional;
+
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
+import org.eclipse.sirius.components.events.ICause;
+import org.springframework.stereotype.Service;
+
+/**
+ * Provides helper methods to manipulate causality chains.
+ *
+ * @author gdaniel
+ */
+@Service
+public class CausalityChainVisitor implements ICausalityChainVisitor {
+
+    @Override
+    public <T extends ICause> Optional<T> findFirstCauseOfType(ICause cause, Class<T> type) {
+        ICause current = cause;
+        while (current != null) {
+            if (type.isInstance(current)) {
+                return Optional.of(type.cast(current));
+            }
+            current = current.causedBy();
+        }
+        return Optional.empty();
+    }
+
+}

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/providers/GenericDiagramToolReferencePositionProvider.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/providers/GenericDiagramToolReferencePositionProvider.java
@@ -13,6 +13,8 @@
 package org.eclipse.sirius.components.collaborative.diagrams.providers;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.sirius.components.collaborative.diagrams.DiagramContext;
@@ -23,6 +25,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.dto.InvokeSingleClic
 import org.eclipse.sirius.components.collaborative.diagrams.dto.InvokeSingleClickOnTwoDiagramElementsToolInput;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.ReconnectEdgeInput;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.ReferencePosition;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.diagrams.layoutdata.Position;
 import org.eclipse.sirius.components.events.ICause;
@@ -45,25 +48,37 @@ public class GenericDiagramToolReferencePositionProvider implements IDiagramInpu
             ReconnectEdgeInput.class
     );
 
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public GenericDiagramToolReferencePositionProvider(ICausalityChainVisitor causalityChainVisitor) {
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
+    }
+
     @Override
     public boolean canHandle(ICause cause) {
-        return HANDLED_INPUT_TYPES.stream().anyMatch(type -> type.isInstance(cause));
+        return this.causalityChainVisitor.findFirstCauseOfType(cause, IInput.class)
+                .map(input -> HANDLED_INPUT_TYPES.stream().anyMatch(type -> type.isInstance(input)))
+                .orElse(false);
     }
 
     @Override
     public ReferencePosition getReferencePosition(ICause cause, DiagramContext diagramContext) {
         ReferencePosition referencePosition = null;
 
-        if (cause instanceof InvokeSingleClickOnDiagramElementToolInput input) {
-            referencePosition = this.handleInvokeSingleClickOnDiagramElement(input, diagramContext);
-        } else if (cause instanceof DropNodesInput input) {
-            referencePosition = this.handleDropNodes(input);
-        } else if (cause instanceof DropOnDiagramInput input) {
-            referencePosition = this.handleDropOnDiagram(input, diagramContext);
-        } else if (cause instanceof InvokeSingleClickOnTwoDiagramElementsToolInput input) {
-            referencePosition = this.handleInvokeSingleClickOnTwoDiagramElements(input);
-        } else if (cause instanceof ReconnectEdgeInput input) {
-            referencePosition = this.handleReconnectEdge(input);
+        Optional<IInput> optionalInput = this.causalityChainVisitor.findFirstCauseOfType(cause, IInput.class);
+        if (optionalInput.isPresent()) {
+            IInput diagramInput = optionalInput.get();
+            if (diagramInput instanceof InvokeSingleClickOnDiagramElementToolInput input) {
+                referencePosition = this.handleInvokeSingleClickOnDiagramElement(input, diagramContext);
+            } else if (diagramInput instanceof DropNodesInput input) {
+                referencePosition = this.handleDropNodes(input);
+            } else if (diagramInput instanceof DropOnDiagramInput input) {
+                referencePosition = this.handleDropOnDiagram(input, diagramContext);
+            } else if (diagramInput instanceof InvokeSingleClickOnTwoDiagramElementsToolInput input) {
+                referencePosition = this.handleInvokeSingleClickOnTwoDiagramElements(input);
+            } else if (diagramInput instanceof ReconnectEdgeInput input) {
+                referencePosition = this.handleReconnectEdge(input);
+            }
         }
 
         return referencePosition;

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/providers/GenericDiagramToolReferencePositionProviderTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/providers/GenericDiagramToolReferencePositionProviderTests.java
@@ -27,6 +27,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.dto.PinDiagramElemen
 import org.eclipse.sirius.components.collaborative.diagrams.dto.ReconnectEdgeInput;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.ReferencePosition;
 import org.eclipse.sirius.components.collaborative.diagrams.handlers.TestDiagramBuilder;
+import org.eclipse.sirius.components.core.services.CausalityChainVisitor;
 import org.eclipse.sirius.components.diagrams.events.ReconnectEdgeKind;
 import org.eclipse.sirius.components.diagrams.layoutdata.Position;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,7 @@ public class GenericDiagramToolReferencePositionProviderTests {
 
     @Test
     public void canHandle() {
-        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider();
+        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider(new CausalityChainVisitor());
 
         InvokeSingleClickOnDiagramElementToolInput inputInvokeSingleClick = new InvokeSingleClickOnDiagramElementToolInput(UUID.randomUUID(), "", "",
                 List.of(), "", 0, 0, List.of());
@@ -63,7 +64,7 @@ public class GenericDiagramToolReferencePositionProviderTests {
 
     @Test
     public void getReferencePositionInvokeSingleClickOnDiagramElementTool() {
-        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider();
+        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider(new CausalityChainVisitor());
         var diagramId = UUID.randomUUID().toString();
         DiagramContext diagramContext = new DiagramContext(new TestDiagramBuilder().getDiagram(diagramId));
         // Test click on diagram
@@ -80,7 +81,7 @@ public class GenericDiagramToolReferencePositionProviderTests {
 
     @Test
     public void getReferencePositionDropOnDiagramElementTool() {
-        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider();
+        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider(new CausalityChainVisitor());
         var diagramId = UUID.randomUUID().toString();
         DiagramContext diagramContext = new DiagramContext(new TestDiagramBuilder().getDiagram(diagramId));
         // Test drop on diagram
@@ -97,7 +98,7 @@ public class GenericDiagramToolReferencePositionProviderTests {
 
     @Test
     public void getReferencePositionDropOnNodeTool() {
-        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider();
+        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider(new CausalityChainVisitor());
         var diagramId = UUID.randomUUID().toString();
         DiagramContext diagramContext = new DiagramContext(new TestDiagramBuilder().getDiagram(diagramId));
         DropNodesInput dropNodeInput = new DropNodesInput(UUID.randomUUID(), "", "",
@@ -108,7 +109,7 @@ public class GenericDiagramToolReferencePositionProviderTests {
 
     @Test
     public void getReferencePositionInvokeSingleClickOnTwoDiagramElementsTool() {
-        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider();
+        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider(new CausalityChainVisitor());
         var diagramId = UUID.randomUUID().toString();
         DiagramContext diagramContext = new DiagramContext(new TestDiagramBuilder().getDiagram(diagramId));
         InvokeSingleClickOnTwoDiagramElementsToolInput invokeSingleClickOnTwoDiagramElementsToolInput = new InvokeSingleClickOnTwoDiagramElementsToolInput(UUID.randomUUID(), "", "",
@@ -120,7 +121,7 @@ public class GenericDiagramToolReferencePositionProviderTests {
 
     @Test
     public void getReferencePositionReconnectEdgeTool() {
-        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider();
+        var diagramToolReferencePositionProvider = new GenericDiagramToolReferencePositionProvider(new CausalityChainVisitor());
         var diagramId = UUID.randomUUID().toString();
         DiagramContext diagramContext = new DiagramContext(new TestDiagramBuilder().getDiagram(diagramId));
         ReconnectEdgeInput reconnectEdgeInput = new ReconnectEdgeInput(UUID.randomUUID(), "", "", "", CONTAINER_ID, ReconnectEdgeKind.SOURCE, 3, 2);

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DeleteFromDiagramChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DeleteFromDiagramChangeRecorder.java
@@ -24,6 +24,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventCon
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramQueryService;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.InvokeSingleClickOnDiagramElementToolInput;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Edge;
@@ -67,105 +68,121 @@ public class DeleteFromDiagramChangeRecorder implements IDiagramEventConsumer {
 
     private final List<ILabelAppearanceChangeUndoRecorder> labelAppearanceChangeUndoRecorders;
 
-    public DeleteFromDiagramChangeRecorder(IDiagramQueryService diagramQueryService, List<INodeAppearanceChangeUndoRecorder> nodeAppearanceChangeUndoRecorders, IEdgeAppearanceChangeUndoRecorder edgeAppearanceChangeUndoRecorder, List<ILabelAppearanceChangeUndoRecorder> labelAppearanceChangeUndoRecorders) {
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public DeleteFromDiagramChangeRecorder(IDiagramQueryService diagramQueryService, List<INodeAppearanceChangeUndoRecorder> nodeAppearanceChangeUndoRecorders,
+            IEdgeAppearanceChangeUndoRecorder edgeAppearanceChangeUndoRecorder, List<ILabelAppearanceChangeUndoRecorder> labelAppearanceChangeUndoRecorders,
+            ICausalityChainVisitor causalityChainVisitor) {
         this.diagramQueryService = Objects.requireNonNull(diagramQueryService);
         this.nodeAppearanceChangeUndoRecorders = Objects.requireNonNull(nodeAppearanceChangeUndoRecorders);
         this.edgeAppearanceChangeUndoRecorder = Objects.requireNonNull(edgeAppearanceChangeUndoRecorder);
         this.labelAppearanceChangeUndoRecorders = Objects.requireNonNull(labelAppearanceChangeUndoRecorders);
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
     }
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof InvokeSingleClickOnDiagramElementToolInput invokeSingleClickOnDiagramElementToolInput && (invokeSingleClickOnDiagramElementToolInput.toolId()
-                .equals(DeleteOneDiagramElementToolHandler.DELETE_ELEMENT_TOOL_ID) || invokeSingleClickOnDiagramElementToolInput.toolId()
-                .equals(DeleteMultipleDiagramElementToolHandler.DELETE_ELEMENT_TOOL_ID))) {
-            List<IAppearanceChange> undoAppearanceChanges = new ArrayList<>();
-            List<IRepresentationChange> representationChanges = new ArrayList<>();
-
-            invokeSingleClickOnDiagramElementToolInput.diagramElementIds().forEach(diagramElementId -> {
-                Optional<Edge> optionalPreviousEdge = this.diagramQueryService.findEdgeById(previousDiagram, diagramElementId);
-                if (optionalPreviousEdge.isPresent()) {
-                    var previousEdge = optionalPreviousEdge.get();
-                    undoAppearanceChanges.addAll(this.edgeAppearanceChangeUndoRecorder.computeEdgeAppearanceChanges(previousEdge, Optional.empty()));
-                } else {
-                    Optional<Node> optionalPreviousNode = this.diagramQueryService.findNodeById(previousDiagram, diagramElementId);
-                    if (optionalPreviousNode.isPresent()) {
-                        var previousNode = optionalPreviousNode.get();
-                        this.nodeAppearanceChangeUndoRecorders.stream()
-                                .filter(handler -> handler.canHandle(previousNode))
-                                .forEach(handler -> undoAppearanceChanges.addAll(handler.computeUndoNodeAppearanceChanges(previousNode, Optional.empty())));
-
-                        if (previousNode.isPinned()) {
-                            var diagramPinElementChange = new DiagramPinElementChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), Set.of(previousNode.getId()), true, false);
-                            representationChanges.add(diagramPinElementChange);
-                        }
-                        if (previousNode.getState().equals(ViewModifier.Faded)) {
-                            var diagramFadeElementChange = new DiagramFadeElementChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), Set.of(previousNode.getId()), true, false);
-                            representationChanges.add(diagramFadeElementChange);
-                        }
-                        if (previousNode.getState().equals(ViewModifier.Hidden)) {
-                            var diagramHideElementChange = new DiagramHideElementChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), Set.of(previousNode.getId()), true, false);
-                            representationChanges.add(diagramHideElementChange);
-                        }
-
-                        var previousNodeLayoutData = previousDiagram.getLayoutData().nodeLayoutData();
-                        if (previousNodeLayoutData.containsKey(previousNode.getId())) {
-                            var undoPositionEvent = new DiagramNodeLayoutEvent(previousNode.getId(), previousNodeLayoutData.get(previousNode.getId()));
-                            var nodeLayoutChange = new DiagramNodeLayoutChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), List.of(undoPositionEvent), List.of());
-                            representationChanges.add(nodeLayoutChange);
-                        }
-
-                        previousNode.getOutsideLabels().forEach(label -> {
-                            var previousLabelLayoutData = previousDiagram.getLayoutData().labelLayoutData();
-                            if (previousLabelLayoutData.containsKey(label.id())) {
-                                var diagramLabelLayoutChange = this.getDiagramNodeLabelChange(label.id(), previousLabelLayoutData.get(label.id()), invokeSingleClickOnDiagramElementToolInput.representationId());
-                                representationChanges.addAll(diagramLabelLayoutChange);
-                            }
-                            var undoLabelAppearanceChanges = new ArrayList<IAppearanceChange>();
-                            this.labelAppearanceChangeUndoRecorders.stream()
-                                    .filter(labelAppearanceChangeUndoRecorder -> labelAppearanceChangeUndoRecorder.canHandle(previousNode))
-                                    .findFirst()
-                                    .map(labelAppearanceChangeUndoRecorder -> labelAppearanceChangeUndoRecorder.computeUndoLabelAppearanceChanges(previousNode, label.id(), Optional.empty()))
-                                    .map(undoLabelAppearanceChanges::addAll);
-                            var diagramNodeLabelAppearanceChange = new DiagramLabelAppearanceChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), undoLabelAppearanceChanges, List.of());
-                            representationChanges.add(diagramNodeLabelAppearanceChange);
-                        });
-
-                        Optional.ofNullable(previousNode.getInsideLabel())
-                                .ifPresent(label -> {
-                                    var previousLabelLayoutData = previousDiagram.getLayoutData().labelLayoutData();
-                                    if (previousLabelLayoutData.containsKey(label.getId())) {
-                                        var diagramLabelLayoutChange = this.getDiagramNodeLabelChange(label.getId(), previousLabelLayoutData.get(label.getId()),
-                                                invokeSingleClickOnDiagramElementToolInput.representationId());
-                                        representationChanges.addAll(diagramLabelLayoutChange);
-                                    }
-                                    var undoLabelAppearanceChanges = new ArrayList<IAppearanceChange>();
-                                    this.labelAppearanceChangeUndoRecorders.stream()
-                                            .filter(labelAppearanceChangeUndoRecorder -> labelAppearanceChangeUndoRecorder.canHandle(previousNode))
-                                            .findFirst()
-                                            .map(labelAppearanceChangeUndoRecorder -> labelAppearanceChangeUndoRecorder.computeUndoLabelAppearanceChanges(previousNode, label.getId(), Optional.empty()))
-                                            .map(undoLabelAppearanceChanges::addAll);
-                                    var diagramNodeLabelAppearanceChange = new DiagramLabelAppearanceChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), undoLabelAppearanceChanges, List.of());
-                                    representationChanges.add(diagramNodeLabelAppearanceChange);
-                                });
-                    }
-                }
-            });
-
-            if (!undoAppearanceChanges.isEmpty()) {
-                var diagramNodeAppearanceChange = new DiagramNodeAppearanceChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), undoAppearanceChanges, List.of());
-                representationChanges.add(diagramNodeAppearanceChange);
-            }
-
-            if (!representationChanges.isEmpty()) {
-                if (!siriusEditingContext.getInputId2RepresentationChanges().containsKey(invokeSingleClickOnDiagramElementToolInput.id()) || siriusEditingContext.getInputId2RepresentationChanges()
-                        .get(invokeSingleClickOnDiagramElementToolInput.id()).isEmpty()) {
-                    siriusEditingContext.getInputId2RepresentationChanges().put(invokeSingleClickOnDiagramElementToolInput.id(), representationChanges);
-                } else {
-                    siriusEditingContext.getInputId2RepresentationChanges().get(invokeSingleClickOnDiagramElementToolInput.id()).addAll(representationChanges);
-                }
+        Optional<InvokeSingleClickOnDiagramElementToolInput> optionalInvokeSingleClickOnDiagramElementToolInput = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), InvokeSingleClickOnDiagramElementToolInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalInvokeSingleClickOnDiagramElementToolInput.isPresent()) {
+            InvokeSingleClickOnDiagramElementToolInput invokeSingleClickOnDiagramElementToolInput = optionalInvokeSingleClickOnDiagramElementToolInput.get();
+            if (this.isDeleteFromDiagramTool(invokeSingleClickOnDiagramElementToolInput.toolId())) {
+                this.recordChanges(siriusEditingContext, previousDiagram, invokeSingleClickOnDiagramElementToolInput);
             }
         }
+    }
+
+    private void recordChanges(EditingContext siriusEditingContext, Diagram previousDiagram, InvokeSingleClickOnDiagramElementToolInput invokeSingleClickOnDiagramElementToolInput) {
+        List<IAppearanceChange> undoAppearanceChanges = new ArrayList<>();
+        List<IRepresentationChange> representationChanges = new ArrayList<>();
+
+        invokeSingleClickOnDiagramElementToolInput.diagramElementIds().forEach(diagramElementId -> {
+            Optional<Edge> optionalPreviousEdge = this.diagramQueryService.findEdgeById(previousDiagram, diagramElementId);
+            if (optionalPreviousEdge.isPresent()) {
+                var previousEdge = optionalPreviousEdge.get();
+                undoAppearanceChanges.addAll(this.edgeAppearanceChangeUndoRecorder.computeEdgeAppearanceChanges(previousEdge, Optional.empty()));
+            } else {
+                Optional<Node> optionalPreviousNode = this.diagramQueryService.findNodeById(previousDiagram, diagramElementId);
+                if (optionalPreviousNode.isPresent()) {
+                    var previousNode = optionalPreviousNode.get();
+                    this.nodeAppearanceChangeUndoRecorders.stream()
+                            .filter(handler -> handler.canHandle(previousNode))
+                            .forEach(handler -> undoAppearanceChanges.addAll(handler.computeUndoNodeAppearanceChanges(previousNode, Optional.empty())));
+
+                    if (previousNode.isPinned()) {
+                        var diagramPinElementChange = new DiagramPinElementChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), Set.of(previousNode.getId()), true, false);
+                        representationChanges.add(diagramPinElementChange);
+                    }
+                    if (previousNode.getState().equals(ViewModifier.Faded)) {
+                        var diagramFadeElementChange = new DiagramFadeElementChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), Set.of(previousNode.getId()), true, false);
+                        representationChanges.add(diagramFadeElementChange);
+                    }
+                    if (previousNode.getState().equals(ViewModifier.Hidden)) {
+                        var diagramHideElementChange = new DiagramHideElementChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), Set.of(previousNode.getId()), true, false);
+                        representationChanges.add(diagramHideElementChange);
+                    }
+
+                    var previousNodeLayoutData = previousDiagram.getLayoutData().nodeLayoutData();
+                    if (previousNodeLayoutData.containsKey(previousNode.getId())) {
+                        var undoPositionEvent = new DiagramNodeLayoutEvent(previousNode.getId(), previousNodeLayoutData.get(previousNode.getId()));
+                        var nodeLayoutChange = new DiagramNodeLayoutChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), List.of(undoPositionEvent), List.of());
+                        representationChanges.add(nodeLayoutChange);
+                    }
+
+                    previousNode.getOutsideLabels().forEach(label -> {
+                        var previousLabelLayoutData = previousDiagram.getLayoutData().labelLayoutData();
+                        if (previousLabelLayoutData.containsKey(label.id())) {
+                            var diagramLabelLayoutChange = this.getDiagramNodeLabelChange(label.id(), previousLabelLayoutData.get(label.id()), invokeSingleClickOnDiagramElementToolInput.representationId());
+                            representationChanges.addAll(diagramLabelLayoutChange);
+                        }
+                        var undoLabelAppearanceChanges = new ArrayList<IAppearanceChange>();
+                        this.labelAppearanceChangeUndoRecorders.stream()
+                                .filter(labelAppearanceChangeUndoRecorder -> labelAppearanceChangeUndoRecorder.canHandle(previousNode))
+                                .findFirst()
+                                .map(labelAppearanceChangeUndoRecorder -> labelAppearanceChangeUndoRecorder.computeUndoLabelAppearanceChanges(previousNode, label.id(), Optional.empty()))
+                                .map(undoLabelAppearanceChanges::addAll);
+                        var diagramNodeLabelAppearanceChange = new DiagramLabelAppearanceChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), undoLabelAppearanceChanges, List.of());
+                        representationChanges.add(diagramNodeLabelAppearanceChange);
+                    });
+
+                    Optional.ofNullable(previousNode.getInsideLabel())
+                            .ifPresent(label -> {
+                                var previousLabelLayoutData = previousDiagram.getLayoutData().labelLayoutData();
+                                if (previousLabelLayoutData.containsKey(label.getId())) {
+                                    var diagramLabelLayoutChange = this.getDiagramNodeLabelChange(label.getId(), previousLabelLayoutData.get(label.getId()),
+                                            invokeSingleClickOnDiagramElementToolInput.representationId());
+                                    representationChanges.addAll(diagramLabelLayoutChange);
+                                }
+                                var undoLabelAppearanceChanges = new ArrayList<IAppearanceChange>();
+                                this.labelAppearanceChangeUndoRecorders.stream()
+                                        .filter(labelAppearanceChangeUndoRecorder -> labelAppearanceChangeUndoRecorder.canHandle(previousNode))
+                                        .findFirst()
+                                        .map(labelAppearanceChangeUndoRecorder -> labelAppearanceChangeUndoRecorder.computeUndoLabelAppearanceChanges(previousNode, label.getId(), Optional.empty()))
+                                        .map(undoLabelAppearanceChanges::addAll);
+                                var diagramNodeLabelAppearanceChange = new DiagramLabelAppearanceChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), undoLabelAppearanceChanges, List.of());
+                                representationChanges.add(diagramNodeLabelAppearanceChange);
+                            });
+                }
+            }
+        });
+
+        if (!undoAppearanceChanges.isEmpty()) {
+            var diagramNodeAppearanceChange = new DiagramNodeAppearanceChange(invokeSingleClickOnDiagramElementToolInput.id(), invokeSingleClickOnDiagramElementToolInput.representationId(), undoAppearanceChanges, List.of());
+            representationChanges.add(diagramNodeAppearanceChange);
+        }
+
+        if (!representationChanges.isEmpty()) {
+            if (!siriusEditingContext.getInputId2RepresentationChanges().containsKey(invokeSingleClickOnDiagramElementToolInput.id()) || siriusEditingContext.getInputId2RepresentationChanges()
+                    .get(invokeSingleClickOnDiagramElementToolInput.id()).isEmpty()) {
+                siriusEditingContext.getInputId2RepresentationChanges().put(invokeSingleClickOnDiagramElementToolInput.id(), representationChanges);
+            } else {
+                siriusEditingContext.getInputId2RepresentationChanges().get(invokeSingleClickOnDiagramElementToolInput.id()).addAll(representationChanges);
+            }
+        }
+    }
+
+    private boolean isDeleteFromDiagramTool(String toolId) {
+        return DeleteOneDiagramElementToolHandler.DELETE_ELEMENT_TOOL_ID.equals(toolId)
+                || DeleteMultipleDiagramElementToolHandler.DELETE_ELEMENT_TOOL_ID.equals(toolId);
     }
 
     private List<IRepresentationChange> getDiagramNodeLabelChange(String labelId, LabelLayoutData previousLabelLayoutData, String representationId) {

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramCollapseElementChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramCollapseElementChangeRecorder.java
@@ -14,11 +14,14 @@ package org.eclipse.sirius.web.application.undo.services.recorder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventConsumer;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.CollapsingState;
 import org.eclipse.sirius.components.diagrams.Diagram;
@@ -38,9 +41,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class DiagramCollapseElementChangeRecorder implements IDiagramEventConsumer {
 
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public DiagramCollapseElementChangeRecorder(ICausalityChainVisitor causalityChainVisitor) {
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
+    }
+
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
+        Optional<IDiagramInput> optionalDiagramInputCause = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), IDiagramInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalDiagramInputCause.isPresent()) {
+            IDiagramInput diagramInput = optionalDiagramInputCause.get();
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             diagramEvents.stream()
                     .filter(UpdateCollapsingStateEvent.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramFadeElementChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramFadeElementChangeRecorder.java
@@ -14,11 +14,14 @@ package org.eclipse.sirius.web.application.undo.services.recorder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventConsumer;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.ViewCreationRequest;
@@ -37,9 +40,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class DiagramFadeElementChangeRecorder implements IDiagramEventConsumer {
 
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public DiagramFadeElementChangeRecorder(ICausalityChainVisitor causalityChainVisitor) {
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
+    }
+
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
+        Optional<IDiagramInput> optionalDiagramInputCause = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), IDiagramInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalDiagramInputCause.isPresent()) {
+            IDiagramInput diagramInput = optionalDiagramInputCause.get();
             List<IRepresentationChange> representationChanges = new ArrayList<>();
 
             diagramEvents.stream()

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramHideElementChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramHideElementChangeRecorder.java
@@ -14,11 +14,14 @@ package org.eclipse.sirius.web.application.undo.services.recorder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventConsumer;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.ViewCreationRequest;
@@ -37,9 +40,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class DiagramHideElementChangeRecorder implements IDiagramEventConsumer {
 
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public DiagramHideElementChangeRecorder(ICausalityChainVisitor causalityChainVisitor) {
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
+    }
+
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
+        Optional<IDiagramInput> optionalDiagramInputCause = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), IDiagramInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalDiagramInputCause.isPresent()) {
+            IDiagramInput diagramInput = optionalDiagramInputCause.get();
             List<IRepresentationChange> representationChanges = new ArrayList<>();
 
             diagramEvents.stream()

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramLayoutChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramLayoutChangeRecorder.java
@@ -14,6 +14,8 @@ package org.eclipse.sirius.web.application.undo.services.recorder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventConsumer;
@@ -22,6 +24,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.dto.LabelLayoutDataI
 import org.eclipse.sirius.components.collaborative.diagrams.dto.LayoutDiagramInput;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.NodeLayoutDataInput;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.ViewCreationRequest;
@@ -50,9 +53,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class DiagramLayoutChangeRecorder implements IDiagramEventConsumer {
 
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public DiagramLayoutChangeRecorder(ICausalityChainVisitor causalityChainVisitor) {
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
+    }
+
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof LayoutDiagramInput layoutDiagramInput) {
+        Optional<LayoutDiagramInput> optionalLayoutDiagramInputCause = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), LayoutDiagramInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalLayoutDiagramInputCause.isPresent()) {
+            LayoutDiagramInput layoutDiagramInput = optionalLayoutDiagramInputCause.get();
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             List<DiagramNodeLayoutEvent> undoNodeLayoutEvents = new ArrayList<>();
             List<DiagramNodeLayoutEvent> redoNodeLayoutEvents = new ArrayList<>();

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramPinElementChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramPinElementChangeRecorder.java
@@ -14,11 +14,14 @@ package org.eclipse.sirius.web.application.undo.services.recorder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventConsumer;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.ViewCreationRequest;
@@ -37,9 +40,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class DiagramPinElementChangeRecorder implements IDiagramEventConsumer {
 
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public DiagramPinElementChangeRecorder(ICausalityChainVisitor causalityChainVisitor) {
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
+    }
+
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
+        Optional<IDiagramInput> optionalDiagramInputCause = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), IDiagramInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalDiagramInputCause.isPresent()) {
+            IDiagramInput diagramInput = optionalDiagramInputCause.get();
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             diagramEvents.stream()
                     .filter(PinDiagramElementEvent.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramViewModifiersChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/DiagramViewModifiersChangeRecorder.java
@@ -15,6 +15,7 @@ package org.eclipse.sirius.web.application.undo.services.recorder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
@@ -22,6 +23,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventCon
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramQueryService;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.ViewCreationRequest;
@@ -45,13 +47,18 @@ public class DiagramViewModifiersChangeRecorder implements IDiagramEventConsumer
 
     private final IDiagramQueryService diagramQueryService;
 
-    public DiagramViewModifiersChangeRecorder(IDiagramQueryService diagramQueryService) {
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public DiagramViewModifiersChangeRecorder(IDiagramQueryService diagramQueryService, ICausalityChainVisitor causalityChainVisitor) {
         this.diagramQueryService = Objects.requireNonNull(diagramQueryService);
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
     }
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
+        Optional<IDiagramInput> optionalDiagramInputCause = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), IDiagramInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalDiagramInputCause.isPresent()) {
+            IDiagramInput diagramInput = optionalDiagramInputCause.get();
             List<IRepresentationChange> representationChanges = new ArrayList<>();
 
             diagramEvents.stream()

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/EdgeAppearanceChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/EdgeAppearanceChangeRecorder.java
@@ -23,6 +23,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventCon
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramQueryService;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.ViewCreationRequest;
@@ -48,14 +49,19 @@ public class EdgeAppearanceChangeRecorder implements IDiagramEventConsumer {
 
     private final IEdgeAppearanceChangeUndoRecorder edgeAppearanceChangeUndoRecorder;
 
-    public EdgeAppearanceChangeRecorder(IDiagramQueryService diagramQueryService, IEdgeAppearanceChangeUndoRecorder edgeAppearanceChangeUndoRecorder) {
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public EdgeAppearanceChangeRecorder(IDiagramQueryService diagramQueryService, IEdgeAppearanceChangeUndoRecorder edgeAppearanceChangeUndoRecorder, ICausalityChainVisitor causalityChainVisitor) {
         this.diagramQueryService = Objects.requireNonNull(diagramQueryService);
         this.edgeAppearanceChangeUndoRecorder = Objects.requireNonNull(edgeAppearanceChangeUndoRecorder);
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
     }
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
+        Optional<IDiagramInput> optionalDiagramInputCause = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), IDiagramInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalDiagramInputCause.isPresent()) {
+            IDiagramInput diagramInput = optionalDiagramInputCause.get();
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             var editAppearanceChanges = diagramEvents.stream()
                     .filter(EditAppearanceEvent.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/LabelAppearanceChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/LabelAppearanceChangeRecorder.java
@@ -23,6 +23,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventCon
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramQueryService;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.ViewCreationRequest;
@@ -48,14 +49,20 @@ public class LabelAppearanceChangeRecorder implements IDiagramEventConsumer {
 
     private final List<ILabelAppearanceChangeUndoRecorder> labelAppearanceChangeUndoRecorders;
 
-    public LabelAppearanceChangeRecorder(IDiagramQueryService diagramQueryService, List<ILabelAppearanceChangeUndoRecorder> labelAppearanceChangeUndoRecorders) {
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public LabelAppearanceChangeRecorder(IDiagramQueryService diagramQueryService, List<ILabelAppearanceChangeUndoRecorder> labelAppearanceChangeUndoRecorders,
+            ICausalityChainVisitor causalityChainVisitor) {
         this.diagramQueryService = Objects.requireNonNull(diagramQueryService);
         this.labelAppearanceChangeUndoRecorders = Objects.requireNonNull(labelAppearanceChangeUndoRecorders);
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
     }
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
+        Optional<IDiagramInput> optionalDiagramInputCause = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), IDiagramInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalDiagramInputCause.isPresent()) {
+            IDiagramInput diagramInput = optionalDiagramInputCause.get();
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             var editAppearanceChanges = diagramEvents.stream()
                     .filter(EditAppearanceEvent.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/NodeAppearanceChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/NodeAppearanceChangeRecorder.java
@@ -23,6 +23,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventCon
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramQueryService;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Node;
@@ -49,14 +50,20 @@ public class NodeAppearanceChangeRecorder implements IDiagramEventConsumer {
 
     private final List<INodeAppearanceChangeUndoRecorder> nodeAppearanceChangeUndoRecorders;
 
-    public NodeAppearanceChangeRecorder(IDiagramQueryService diagramQueryService, List<INodeAppearanceChangeUndoRecorder> nodeAppearanceChangeUndoRecorders) {
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public NodeAppearanceChangeRecorder(IDiagramQueryService diagramQueryService, List<INodeAppearanceChangeUndoRecorder> nodeAppearanceChangeUndoRecorders,
+            ICausalityChainVisitor causalityChainVisitor) {
         this.diagramQueryService = Objects.requireNonNull(diagramQueryService);
         this.nodeAppearanceChangeUndoRecorders = Objects.requireNonNull(nodeAppearanceChangeUndoRecorders);
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
     }
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
+        Optional<IDiagramInput> optionalDiagramInputCause = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), IDiagramInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalDiagramInputCause.isPresent()) {
+            IDiagramInput diagramInput = optionalDiagramInputCause.get();
             List<IRepresentationChange> representationChanges = new ArrayList<>();
             var editAppearanceChanges = diagramEvents.stream()
                     .filter(EditAppearanceEvent.class::isInstance)

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/ViewRequestChangeRecorder.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/undo/services/recorder/ViewRequestChangeRecorder.java
@@ -25,6 +25,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventCon
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramQueryService;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
+import org.eclipse.sirius.components.core.api.ICausalityChainVisitor;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Node;
@@ -61,14 +62,21 @@ public class ViewRequestChangeRecorder implements IDiagramEventConsumer {
 
     private final List<INodeAppearanceChangeUndoRecorder> nodeAppearanceChangeUndoRecorders;
 
-    public ViewRequestChangeRecorder(IDiagramQueryService diagramQueryService, List<INodeAppearanceChangeUndoRecorder> nodeAppearanceChangeUndoRecorders) {
+    private final ICausalityChainVisitor causalityChainVisitor;
+
+    public ViewRequestChangeRecorder(IDiagramQueryService diagramQueryService, List<INodeAppearanceChangeUndoRecorder> nodeAppearanceChangeUndoRecorders,
+            ICausalityChainVisitor causalityChainVisitor) {
         this.diagramQueryService = Objects.requireNonNull(diagramQueryService);
         this.nodeAppearanceChangeUndoRecorders = Objects.requireNonNull(nodeAppearanceChangeUndoRecorders);
+        this.causalityChainVisitor = Objects.requireNonNull(causalityChainVisitor);
+
     }
 
     @Override
     public void accept(IEditingContext editingContext, Diagram previousDiagram, List<IDiagramEvent> diagramEvents, List<ViewDeletionRequest> viewDeletionRequests, List<ViewCreationRequest> viewCreationRequests, ChangeDescription changeDescription) {
-        if (editingContext instanceof EditingContext siriusEditingContext && changeDescription.getCause() instanceof IDiagramInput diagramInput) {
+        Optional<IDiagramInput> optionalDiagramInputCause = this.causalityChainVisitor.findFirstCauseOfType(changeDescription.getCause(), IDiagramInput.class);
+        if (editingContext instanceof EditingContext siriusEditingContext && optionalDiagramInputCause.isPresent()) {
+            IDiagramInput diagramInput = optionalDiagramInputCause.get();
             List<ViewCreationRequest> undoViewCreationRequests = new ArrayList<>();
             List<ViewDeletionRequest> undoViewDeletionRequests = new ArrayList<>();
             List<ViewCreationRequest> redoViewCreationRequests = new ArrayList<>(viewCreationRequests);


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/6751

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?