### PR TITLE
[6756] Add a Service to create Forms

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -90,7 +90,7 @@ Downstream applications can implement `IOmniboxCommandOrdererDelegate` to define
 - https://github.com/eclipse-sirius/sirius-web/issues/6736[#6736] [core] Update `ChangeDescription` to accept an `ICause` as parameter instead of just `IInput`.
 This will allow us to reuse the change description to propagate more information.
 - https://github.com/eclipse-sirius/sirius-web/issues/6688[#6688] [diagram] Use outside label height for child node layout in freeform diagrams
-
+- https://github.com/eclipse-sirius/sirius-web/issues/6756[#6756] [form] Add a Service to create Forms.
 
 
 == 2026.7.0

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/FormCreationService.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/FormCreationService.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2026 CEA LIST.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     CEA LIST - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.forms;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.collaborative.forms.api.IFormCreationService;
+import org.eclipse.sirius.components.core.api.IIdentityService;
+import org.eclipse.sirius.components.forms.Form;
+import org.eclipse.sirius.components.forms.description.FormDescription;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service used to create forms.
+ *
+ * @author pdeville
+ */
+@Service
+public class FormCreationService implements IFormCreationService {
+
+    private final IIdentityService identityService;
+
+    public FormCreationService(IIdentityService identityService) {
+        this.identityService = Objects.requireNonNull(identityService);
+    }
+
+    @Override
+    public Form create(Object targetObject, FormDescription formDescription) {
+        return Form.newForm(UUID.randomUUID().toString())
+                .targetObjectId(this.identityService.getId(targetObject))
+                .descriptionId(formDescription.getId())
+                .pages(List.of())
+                .build();
+    }
+
+}

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/api/IFormCreationService.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/api/IFormCreationService.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2026 CEA LIST.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     CEA LIST - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.forms.api;
+
+import org.eclipse.sirius.components.forms.Form;
+import org.eclipse.sirius.components.forms.description.FormDescription;
+
+/**
+ * Service used to create forms from scratch.
+ *
+ * @author pdeville
+ */
+public interface IFormCreationService {
+
+    /**
+     * Creates a new form using the given parameters.
+     *
+     * @param targetObject
+     *            The object used as the target
+     * @param formDescription
+     *            The description of the form
+     * @return A new form
+     */
+    Form create(Object targetObject, FormDescription formDescription);
+
+}


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/6756

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
This service could be use in `org.eclipse.sirius.components.collaborative.forms.handlers.CreateFormEventHandler` but if I had a new service in the constructor I get the following checkstyle error: "La méthode ou le constructeur a plus de 7 paramètres (trouvé 8). [ParameterNumber]" so I unfortunately could not do it. I could add it as @autowired field but it seems not recommended neither, what do you prefer ?

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?